### PR TITLE
Store known span tags densely in TagMap by tag-id (phase 2 - dense tag storage)

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -182,5 +182,12 @@ public final class TracerConfig {
   public static final String TRACE_ORG_GUARD_STRICT = "trace.org.guard.strict";
   public static final String TRACE_ORG_GUARD_TRUSTED_OPMS = "trace.org.guard.trusted.opms";
 
+  /**
+   * Routes known tags through the dense (id-keyed) tag store instead of per-tag entries.
+   * Experimental, OFF by default. The {@code KnownTagCodec} is registered regardless; this flag
+   * only selects whether tags take the dense storage path.
+   */
+  public static final String TRACE_DENSE_TAGS_ENABLED = "trace.experimental.dense.tags.enabled";
+
   private TracerConfig() {}
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -40,6 +40,7 @@ import datadog.trace.api.DynamicConfig;
 import datadog.trace.api.EndpointTracker;
 import datadog.trace.api.IdGenerationStrategy;
 import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.api.KnownTags;
 import datadog.trace.api.Pair;
 import datadog.trace.api.TagMap;
 import datadog.trace.api.TraceConfig;
@@ -655,6 +656,14 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
 
     // preload this enum to avoid triggering classloading on the hot path
     TraceCollector.PublishState.values();
+
+    // Dense known-tag store (experimental, OFF by default): registering the KnownTagCodec resolver
+    // flips the dense store live so known tags store without a per-tag Entry. Gated by a system
+    // property for A/B benchmarking; when off, keyOf stays a no-op and tag storage is byte-identical
+    // to today. Promote to a Config flag if this becomes a permanent rollout.
+    if (Boolean.getBoolean("dd.trace.dense.tags.enabled")) {
+      KnownTags.init();
+    }
 
     if (reportInTracerFlare) {
       TracerFlare.addReporter(this);

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -41,6 +41,7 @@ import datadog.trace.api.DynamicConfig;
 import datadog.trace.api.EndpointTracker;
 import datadog.trace.api.IdGenerationStrategy;
 import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.api.KnownTags;
 import datadog.trace.api.Pair;
 import datadog.trace.api.TagMap;
 import datadog.trace.api.TraceConfig;
@@ -662,6 +663,13 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
 
     // preload this enum to avoid triggering classloading on the hot path
     TraceCollector.PublishState.values();
+
+    // Register the KnownTagCodec resolver unconditionally so tag-id name resolution (keyOf/nameOf,
+    // OTel name mapping) is always live. Whether known tags actually take the dense store is a
+    // separate, const-folded decision (KnownTagCodec.DENSE_STORE, from
+    // trace.experimental.dense.tags.enabled); when that flag is off, tag storage is byte-identical
+    // to the bucket-only behavior.
+    KnownTags.init();
 
     if (reportInTracerFlare) {
       TracerFlare.addReporter(this);

--- a/internal-api/src/jmh/java/datadog/trace/api/DenseStoreAllocBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/api/DenseStoreAllocBenchmark.java
@@ -1,0 +1,148 @@
+package datadog.trace.api;
+
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Deterministic allocation A/B for the dense known-tag store, using the REAL {@link KnownTags}
+ * resolver (a {@code StringIndex} probe + a constant-returning {@code switch} — allocation-free,
+ * exactly like production). An earlier synthetic prefix resolver allocated in {@code keyOf}
+ * (substring) and {@code nameOf} (concat), contaminating the dense arm; this measures the store,
+ * not the resolver.
+ *
+ * <p>Models how a real span's tags route: {@code today} = all custom (what ships now — every tag
+ * buckets, since nothing is registered as known), {@code dense} = the same tag count with a
+ * realistic fraction routed to the dense store (real known tag names) and the rest custom. Run with
+ * {@code -prof gc}; the {@code gc.alloc.rate.norm} (B/op) delta at the same {@code tagCount} is
+ * what enabling the dense store does to a real span's per-build allocation.
+ *
+ * <p><b>Results — buildMap, JDK 17 (Zulu 17.0.7, Apple Silicon), {@code -prof gc -f 1 -wi 2 -i 3},
+ * 2026-07-08.</b> Allocation is deterministic (±0.001 B/op); throughput on this run is NOT
+ * trustworthy (single fork, short) — read B/op only.
+ *
+ * <pre>{@code
+ * scenario    tagCount=7   tagCount=12
+ * today          408 B/op     704 B/op
+ * dense          376 B/op     416 B/op
+ * allKnown       176 B/op     400 B/op
+ * }</pre>
+ *
+ * <p>Gate met: {@code dense < today} at both counts (the over-provision artifact is gone). The
+ * Entry-less win scales with the known-tag fraction — ~8% at 7 tags (~70% known), ~41% at 12;
+ * {@code allKnown} (the codegen endgame / read-through parent shape) reaches ~57% at 7.
+ *
+ * <p><b>Serialize paths (same run, B/op).</b> {@code buildAndSerialize} (alloc-free {@code forEach}
+ * flyweight) adds a flat +16 B/op over {@code buildMap} in every scenario (7: 392, 12: 432 dense).
+ * {@code buildAndSerializeViaIterator} — the {@code EntryReader} enhanced-for modeling the count
+ * pre-pass at {@code TraceMapperV0_4:95} — adds a CONSTANT per-call cost (+56 custom / +80 dense,
+ * identical at 7 and 12 tags): that flat-vs-tagCount signature is the {@code EntryReaderIterator}
+ * OBJECT, NOT per-tag Entry — the iterator reuses a dense flyweight (TagMap:2182/2652). So the
+ * dense win SURVIVES serialization; the only nit is {@code iterator()} allocating one Iterator per
+ * call, which {@code forEach} avoids and which can be recycled away.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 2)
+@Measurement(iterations = 3, time = 2)
+@Fork(1)
+@Threads(1)
+public class DenseStoreAllocBenchmark {
+
+  // Real stored (dense-routed) tag names — a realistic web/db span's known set.
+  static final String[] KNOWN =
+      new String[] {
+        DDTags.BASE_SERVICE,
+        Tags.VERSION,
+        Tags.COMPONENT,
+        Tags.SPAN_KIND,
+        Tags.HTTP_METHOD,
+        Tags.HTTP_ROUTE,
+        Tags.DB_TYPE,
+        Tags.DB_INSTANCE,
+        Tags.PEER_HOSTNAME,
+        Tags.DB_USER,
+        DDTags.LANGUAGE_TAG_KEY,
+        Tags.PEER_PORT,
+      };
+
+  // today = all custom (all bucket, what ships now); dense = ~70% known + custom (a real span);
+  // allKnown = 100% known (the trace-tier read-through parent's shape — exercises lazy buckets).
+  @Param({"today", "dense", "allKnown"})
+  String scenario;
+
+  @Param({"7", "12"})
+  int tagCount;
+
+  private String[] keys;
+  private String[] values;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    KnownTags.init(); // registers the real (allocation-free) resolver
+    int knownCount;
+    if ("allKnown".equals(scenario)) {
+      knownCount = tagCount; // 100% known (<= KNOWN.length)
+    } else if ("dense".equals(scenario)) {
+      knownCount = (tagCount * 7) / 10; // ~70% known + custom
+    } else {
+      knownCount = 0; // today: all custom (all bucket)
+    }
+    this.keys = new String[tagCount];
+    this.values = new String[tagCount];
+    for (int i = 0; i < tagCount; i++) {
+      this.keys[i] = i < knownCount ? KNOWN[i] : "custom.tag." + i;
+      this.values[i] = "value-" + i;
+    }
+  }
+
+  @Benchmark
+  public TagMap buildMap() {
+    TagMap m = TagMap.create(16);
+    for (int i = 0; i < tagCount; i++) {
+      m.set(keys[i], values[i]);
+    }
+    return m;
+  }
+
+  @Benchmark
+  public void buildAndSerialize(Blackhole bh) {
+    TagMap m = TagMap.create(16);
+    for (int i = 0; i < tagCount; i++) {
+      m.set(keys[i], values[i]);
+    }
+    // forEach: the alloc-free flyweight emit for dense
+    m.forEach(reader -> bh.consume(reader.objectValue()));
+    bh.consume(m);
+  }
+
+  @Benchmark
+  public void buildAndSerializeViaIterator(Blackhole bh) {
+    TagMap m = TagMap.create(16);
+    for (int i = 0; i < tagCount; i++) {
+      m.set(keys[i], values[i]);
+    }
+    // models the REAL serializer's count pre-pass (TraceMapperV0_4:95). The EntryReader iterator
+    // uses a reused dense flyweight (NO per-tag Entry alloc — TagMap:2182/2652), so the dense win
+    // SURVIVES; the only extra cost vs forEach is the EntryReaderIterator object itself (a fixed
+    // per-call cost, constant across tagCount — not per-tag). forEach avoids even that.
+    for (TagMap.EntryReader reader : m) {
+      bh.consume(reader.objectValue());
+    }
+    bh.consume(m);
+  }
+}

--- a/internal-api/src/jmh/java/datadog/trace/api/DenseStoreAllocBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/api/DenseStoreAllocBenchmark.java
@@ -1,0 +1,150 @@
+package datadog.trace.api;
+
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Deterministic allocation A/B for the dense known-tag store, using the REAL {@link KnownTags}
+ * resolver (a {@code StringIndex} probe + a constant-returning {@code switch} — allocation-free,
+ * exactly like production). An earlier synthetic prefix resolver allocated in {@code keyOf}
+ * (substring) and {@code nameOf} (concat), contaminating the dense arm; this measures the store,
+ * not the resolver.
+ *
+ * <p>Models how a real span's tags route: {@code today} = all custom (what ships now — every tag
+ * buckets, since nothing is registered as known), {@code dense} = the same tag count with a
+ * realistic fraction routed to the dense store (real known tag names) and the rest custom. Run with
+ * {@code -prof gc}; the {@code gc.alloc.rate.norm} (B/op) delta at the same {@code tagCount} is
+ * what enabling the dense store does to a real span's per-build allocation.
+ *
+ * <p><b>Results — buildMap, JDK 17 (Zulu 17.0.7, Apple Silicon), {@code -prof gc -f 1 -wi 2 -i 3},
+ * 2026-07-08.</b> Allocation is deterministic (±0.001 B/op); throughput on this run is NOT
+ * trustworthy (single fork, short) — read B/op only.
+ *
+ * <pre>{@code
+ * scenario    tagCount=7   tagCount=12
+ * today          408 B/op     704 B/op
+ * dense          376 B/op     416 B/op
+ * allKnown       176 B/op     400 B/op
+ * }</pre>
+ *
+ * <p>Gate met: {@code dense < today} at both counts (the over-provision artifact is gone). The
+ * Entry-less win scales with the known-tag fraction — ~8% at 7 tags (~70% known), ~41% at 12;
+ * {@code allKnown} (the codegen endgame / read-through parent shape) reaches ~57% at 7.
+ *
+ * <p><b>Serialize paths (same run, B/op).</b> {@code buildAndSerialize} (alloc-free {@code forEach}
+ * flyweight) adds a flat +16 B/op over {@code buildMap} in every scenario (7: 392, 12: 432 dense).
+ * {@code buildAndSerializeViaIterator} — the {@code EntryReader} enhanced-for modeling the count
+ * pre-pass at {@code TraceMapperV0_4:95} — adds a CONSTANT per-call cost (+56 custom / +80 dense,
+ * identical at 7 and 12 tags): that flat-vs-tagCount signature is the {@code EntryReaderIterator}
+ * OBJECT, NOT per-tag Entry — the iterator reuses a dense flyweight (TagMap:2182/2652). So the
+ * dense win SURVIVES serialization; the only nit is {@code iterator()} allocating one Iterator per
+ * call, which {@code forEach} avoids and which can be recycled away.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 2, time = 2)
+@Measurement(iterations = 3, time = 2)
+@Fork(
+    value = 1,
+    jvmArgsAppend = {"-Ddd.trace.experimental.dense.tags.enabled=true"})
+@Threads(1)
+public class DenseStoreAllocBenchmark {
+
+  // Real stored (dense-routed) tag names — a realistic web/db span's known set.
+  static final String[] KNOWN =
+      new String[] {
+        DDTags.BASE_SERVICE,
+        Tags.VERSION,
+        Tags.COMPONENT,
+        Tags.SPAN_KIND,
+        Tags.HTTP_METHOD,
+        Tags.HTTP_ROUTE,
+        Tags.DB_TYPE,
+        Tags.DB_INSTANCE,
+        Tags.PEER_HOSTNAME,
+        Tags.DB_USER,
+        DDTags.LANGUAGE_TAG_KEY,
+        Tags.PEER_PORT,
+      };
+
+  // today = all custom (all bucket, what ships now); dense = ~70% known + custom (a real span);
+  // allKnown = 100% known (the trace-tier read-through parent's shape — exercises lazy buckets).
+  @Param({"today", "dense", "allKnown"})
+  String scenario;
+
+  @Param({"7", "12"})
+  int tagCount;
+
+  private String[] keys;
+  private String[] values;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    KnownTags.init(); // registers the real (allocation-free) resolver
+    int knownCount;
+    if ("allKnown".equals(scenario)) {
+      knownCount = tagCount; // 100% known (<= KNOWN.length)
+    } else if ("dense".equals(scenario)) {
+      knownCount = (tagCount * 7) / 10; // ~70% known + custom
+    } else {
+      knownCount = 0; // today: all custom (all bucket)
+    }
+    this.keys = new String[tagCount];
+    this.values = new String[tagCount];
+    for (int i = 0; i < tagCount; i++) {
+      this.keys[i] = i < knownCount ? KNOWN[i] : "custom.tag." + i;
+      this.values[i] = "value-" + i;
+    }
+  }
+
+  @Benchmark
+  public TagMap buildMap() {
+    TagMap m = TagMap.create(16);
+    for (int i = 0; i < tagCount; i++) {
+      m.set(keys[i], values[i]);
+    }
+    return m;
+  }
+
+  @Benchmark
+  public void buildAndSerialize(Blackhole bh) {
+    TagMap m = TagMap.create(16);
+    for (int i = 0; i < tagCount; i++) {
+      m.set(keys[i], values[i]);
+    }
+    // forEach: the alloc-free flyweight emit for dense
+    m.forEach(reader -> bh.consume(reader.objectValue()));
+    bh.consume(m);
+  }
+
+  @Benchmark
+  public void buildAndSerializeViaIterator(Blackhole bh) {
+    TagMap m = TagMap.create(16);
+    for (int i = 0; i < tagCount; i++) {
+      m.set(keys[i], values[i]);
+    }
+    // models the REAL serializer's count pre-pass (TraceMapperV0_4:95). The EntryReader iterator
+    // uses a reused dense flyweight (NO per-tag Entry alloc — TagMap:2182/2652), so the dense win
+    // SURVIVES; the only extra cost vs forEach is the EntryReaderIterator object itself (a fixed
+    // per-call cost, constant across tagCount — not per-tag). forEach avoids even that.
+    for (TagMap.EntryReader reader : m) {
+      bh.consume(reader.objectValue());
+    }
+    bh.consume(m);
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -1447,6 +1447,7 @@ public class Config {
   private final boolean jdkSocketEnabled;
 
   private final boolean spanBuilderReuseEnabled;
+  private final boolean traceDenseTagsEnabled;
   private final int tagNameUtf8CacheSize;
   private final int tagValueUtf8CacheSize;
   private final int stackTraceLengthLimit;
@@ -3414,6 +3415,8 @@ public class Config {
 
     this.spanBuilderReuseEnabled =
         configProvider.getBoolean(GeneralConfig.SPAN_BUILDER_REUSE_ENABLED, true);
+    this.traceDenseTagsEnabled =
+        configProvider.getBoolean(TracerConfig.TRACE_DENSE_TAGS_ENABLED, false);
     this.tagNameUtf8CacheSize =
         Math.max(configProvider.getInteger(GeneralConfig.TAG_NAME_UTF8_CACHE_SIZE, 128), 0);
     this.tagValueUtf8CacheSize =
@@ -5336,6 +5339,10 @@ public class Config {
 
   public boolean isSpanBuilderReuseEnabled() {
     return spanBuilderReuseEnabled;
+  }
+
+  public boolean isTraceDenseTagsEnabled() {
+    return traceDenseTagsEnabled;
   }
 
   public int getTagNameUtf8CacheSize() {

--- a/internal-api/src/main/java/datadog/trace/api/KnownTagCodec.java
+++ b/internal-api/src/main/java/datadog/trace/api/KnownTagCodec.java
@@ -1,0 +1,177 @@
+package datadog.trace.api;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * Registry for generated tag ID ↔ name resolution. The code generator populates this at tracer init
+ * via {@link #register(Resolver)}. Once registered, HotSpot CHA devirtualizes and inlines the
+ * resolver's switch, making {@link #nameOf}/{@link #keyOf} effectively zero-overhead.
+ */
+public final class KnownTagCodec {
+  // Plain (non-volatile) fast-path flag: false until a resolver is ever registered. A plain read is
+  // free and hoistable, unlike a volatile read of `resolver` (costly on weak memory models such as
+  // ARM). A stale `false` is benign — callers treat the tag as unknown and use the hash buckets,
+  // which is correct, just unoptimized; the next read after publication takes the slot path.
+  private static boolean active;
+
+  private static volatile Resolver resolver;
+
+  /** Fast-path gate: true once a resolver has been registered. */
+  public static boolean isActive() {
+    return active;
+  }
+
+  /*
+   * tagId bit layout: [63 intercepted] [62-48 globalSerial (15 bits)] [47-32 fieldPos]
+   * [31-0 nameHash]. Bit 63 (the sign bit) marks a tag the tag interceptor must see, so the check
+   * is a single {@code tagId < 0}. globalSerial is globally unique per known tag; fieldPos is its
+   * slot in the global positional layout (TagMap.knownEntries index); nameHash is
+   * TagMap.Entry#_hash(name) and is layout-independent. Unknown (string-only) tags have the upper
+   * 32 bits zero. NOTE: TagMap.Entry decodes nameHash inline as (int) tagId on its hot path, so the
+   * low-32 encoding here must stay in sync with that.
+   */
+  public static int globalSerial(long tagId) {
+    return (int) ((tagId >>> 48) & 0x7FFF);
+  }
+
+  /**
+   * Flag bit (the sign bit) marking a tag the tag interceptor must process — reserved/"virtual"
+   * tags AND intercepted-but-stored tags (e.g. http.method, which the interceptor side-effects and
+   * also stores). Encoded in the id so {@code DDSpanContext.setTag(long)} can route with a single
+   * sign test ({@link #isIntercepted}) instead of resolving the name. Non-intercepted tags (peer.*,
+   * base.service, …) leave it clear and take the fast store path. Must agree with the interceptor's
+   * name-based {@code needsIntercept} for every assigned id.
+   */
+  public static final long INTERCEPTED = Long.MIN_VALUE; // 1L << 63
+
+  /** True if the tagId is flagged for tag-interceptor processing. */
+  public static boolean isIntercepted(long tagId) {
+    return tagId < 0L;
+  }
+
+  /** Returns the tagId with the {@link #INTERCEPTED} flag set. */
+  public static long intercepted(long tagId) {
+    return tagId | INTERCEPTED;
+  }
+
+  public static int fieldPos(long tagId) {
+    return (int) ((tagId >>> 32) & 0xFFFF);
+  }
+
+  public static int nameHash(long tagId) {
+    return (int) tagId;
+  }
+
+  /**
+   * globalSerial partition. {@code [1, FIRST_STORED_SERIAL)} is reserved for "virtual" tags that
+   * are specially handled (redirected to span fields or processed by the tag interceptor) and are
+   * NOT stored in the TagMap — these are hand-assigned in tracer core. {@code [FIRST_STORED_SERIAL,
+   * ..]} is for generated convention tags that ARE stored (slotted/bucketed). {@code globalSerial
+   * == 0} means unknown / string-only. Both core and the code generator must agree on this
+   * boundary.
+   */
+  public static final int FIRST_STORED_SERIAL = 256;
+
+  /** True if the tagId names a reserved "virtual"/specially-handled tag (not stored in the map). */
+  public static boolean isReserved(long tagId) {
+    int globalSerial = globalSerial(tagId);
+    return globalSerial > 0 && globalSerial < FIRST_STORED_SERIAL;
+  }
+
+  /** True if the tagId names a generated, map-stored (slotted/bucketed) tag. */
+  public static boolean isStored(long tagId) {
+    return globalSerial(tagId) >= FIRST_STORED_SERIAL;
+  }
+
+  /**
+   * Sentinel {@code fieldPos} meaning "no positional slot". It is the maximum value the 16-bit
+   * fieldPos field can hold, so it always compares {@code >= slotCount()} and routes to the hash
+   * buckets rather than the fast positional array. Two kinds of tagId use it:
+   *
+   * <ul>
+   *   <li>Reserved/virtual tags ({@code globalSerial < FIRST_STORED_SERIAL}) — not stored at all;
+   *       the sentinel just guarantees an incidental store never lands in a slot.
+   *   <li>Unslotted stored tags ({@code globalSerial >= FIRST_STORED_SERIAL}) — "low-priority" tags
+   *       that get a stable id (and so {@code keyOf}/{@code nameOf} unification with their string
+   *       form) but are deliberately not given a slot, so they live in the buckets and don't widen
+   *       {@code knownEntries[]} for every span. {@code getEntry(long)} for these resolves the name
+   *       and rehashes — the cost of not owning a slot.
+   * </ul>
+   */
+  public static final int NO_SLOT = 0xFFFF;
+
+  /**
+   * True if the tagId names a stored tag that deliberately has no positional slot (bucket-only).
+   */
+  public static boolean isUnslotted(long tagId) {
+    return isStored(tagId) && fieldPos(tagId) == NO_SLOT;
+  }
+
+  /**
+   * Builds a tagId from its parts: {@code globalSerial} (globally unique per known tag), {@code
+   * fieldPos} (the tag's slot within its span type's positional table), and the tag {@code name}
+   * (whose hash is computed via the same function the runtime uses, so the low 32 bits match {@link
+   * TagMap.Entry#hash()}). Inverse of {@link #globalSerial}/{@link #fieldPos}/{@link #nameHash}.
+   * Intended for the code generator and tests.
+   */
+  public static long tagId(int globalSerial, int fieldPos, String name) {
+    long nameHash = TagMap.Entry._hash(name) & 0xFFFFFFFFL;
+    return ((long) globalSerial << 48) | ((long) (fieldPos & 0xFFFF) << 32) | nameHash;
+  }
+
+  /**
+   * Builds a tagId with no positional slot ({@code fieldPos == }{@link #NO_SLOT}). Use for reserved
+   * "virtual" tags and for "low-priority" stored tags that get a stable id but are intentionally
+   * kept out of the fast slot array (they route to the hash buckets). See {@link #NO_SLOT}.
+   */
+  public static long tagId(int globalSerial, String name) {
+    return tagId(globalSerial, NO_SLOT, name);
+  }
+
+  // Number of positional slots in the global layout = (max stored fieldPos) + 1, declared by the
+  // registered provider. Captured once at registration and read as a dynamic constant; TagMap sizes
+  // its knownEntries array to exactly this rather than a hardcoded max. 0 when no resolver.
+  private static int slotCount;
+
+  /** Slot count of the registered provider (max stored fieldPos + 1); 0 if none. */
+  public static int slotCount() {
+    return slotCount;
+  }
+
+  public interface Resolver {
+    String nameOf(long tagId);
+
+    long keyOf(String name);
+
+    /** Number of positional slots this provider uses: (max stored fieldPos) + 1. */
+    int slotCount();
+  }
+
+  @SuppressFBWarnings(
+      value = "AT_STALE_THREAD_WRITE_OF_PRIMITIVE",
+      justification =
+          "active/slotCount are plain by design: written once at tracer-init registration (before"
+              + " any span processing) and read plain on the hot path. A stale read is benign — the"
+              + " tag is treated as unknown and takes the hash-bucket path — so plain reads are"
+              + " deliberately preferred over a costly volatile read on weak memory models.")
+  public static void register(Resolver resolver) {
+    KnownTagCodec.resolver = resolver; // volatile write publishes the resolver
+    KnownTagCodec.slotCount = (resolver != null) ? resolver.slotCount() : 0;
+    KnownTagCodec.active =
+        (resolver != null); // plain write; readers re-read resolver volatile anyway
+  }
+
+  public static String nameOf(long tagId) {
+    if (!active) return null;
+    Resolver r = resolver;
+    return r != null ? r.nameOf(tagId) : null;
+  }
+
+  public static long keyOf(String name) {
+    if (!active) return 0L;
+    Resolver r = resolver;
+    return r != null ? r.keyOf(name) : 0L;
+  }
+
+  private KnownTagCodec() {}
+}

--- a/internal-api/src/main/java/datadog/trace/api/KnownTagCodec.java
+++ b/internal-api/src/main/java/datadog/trace/api/KnownTagCodec.java
@@ -1,0 +1,253 @@
+package datadog.trace.api;
+
+/**
+ * Registry for generated tag ID ↔ name resolution. The code generator populates this at tracer init
+ * via {@link #register(Resolver)}. Once registered, HotSpot CHA devirtualizes and inlines the
+ * resolver's switch, making {@link #nameOf}/{@link #keyOf} effectively zero-overhead.
+ */
+public final class KnownTagCodec {
+  // Plain (non-volatile) fast-path flag: false until a mapping-bearing resolver is registered (it
+  // stays false when the codec freezes as the empty NoKnownTagCodec). A plain read is free and
+  // hoistable, unlike a volatile read of `resolver` (costly on weak memory models such as ARM). A
+  // stale `false` is benign — callers treat the tag as unknown and use the hash buckets, which is
+  // correct, just unoptimized; the next read after publication takes the slot path.
+  private static boolean active;
+
+  // The installed codec. There is always conceptually a codec: either a real resolver (via
+  // register, at tracer init) or the empty NoKnownTagCodec, lazily installed on first use if
+  // nothing
+  // was registered. Resolved exactly once, then LOCKED — so a map can never be built half-bucketed
+  // then half-dense by a late registration.
+  private static volatile Resolver resolver;
+
+  // True once `resolver` is resolved (real via register, or lazy NoKnownTagCodec). Cold-path only.
+  private static volatile boolean locked;
+
+  /** Fast-path gate: true once a mapping-bearing resolver has been registered. */
+  public static boolean isActive() {
+    return active;
+  }
+
+  /*
+   * tagId bit layout: [63 intercepted] [62-48 globalSerial (15 bits)] [47-32 fieldPos]
+   * [31-0 nameHash]. Bit 63 (the sign bit) marks a tag the tag interceptor must see, so the check
+   * is a single {@code tagId < 0}. globalSerial is globally unique per known tag; fieldPos is its
+   * slot in the global positional layout (TagMap.knownEntries index); nameHash is
+   * TagMap.Entry#_hash(name) and is layout-independent. Unknown (string-only) tags have the upper
+   * 32 bits zero. NOTE: TagMap.Entry decodes nameHash inline as (int) tagId on its hot path, so the
+   * low-32 encoding here must stay in sync with that.
+   */
+  public static int globalSerial(long tagId) {
+    return (int) ((tagId >>> 48) & 0x7FFF);
+  }
+
+  /**
+   * Flag bit (the sign bit) marking a tag the tag interceptor must process — reserved/"virtual"
+   * tags AND intercepted-but-stored tags (e.g. http.method, which the interceptor side-effects and
+   * also stores). Encoded in the id so {@code DDSpanContext.setTag(long)} can route with a single
+   * sign test ({@link #isIntercepted}) instead of resolving the name. Non-intercepted tags (peer.*,
+   * base.service, …) leave it clear and take the fast store path. Must agree with the interceptor's
+   * name-based {@code needsIntercept} for every assigned id.
+   */
+  public static final long INTERCEPTED = Long.MIN_VALUE; // 1L << 63
+
+  /** True if the tagId is flagged for tag-interceptor processing. */
+  public static boolean isIntercepted(long tagId) {
+    return tagId < 0L;
+  }
+
+  /** Returns the tagId with the {@link #INTERCEPTED} flag set. */
+  public static long intercepted(long tagId) {
+    return tagId | INTERCEPTED;
+  }
+
+  public static int fieldPos(long tagId) {
+    return (int) ((tagId >>> 32) & 0xFFFF);
+  }
+
+  public static int nameHash(long tagId) {
+    return (int) tagId;
+  }
+
+  /**
+   * globalSerial partition. {@code [1, FIRST_STORED_SERIAL)} is reserved for "virtual" tags that
+   * are specially handled (redirected to span fields or processed by the tag interceptor) and are
+   * NOT stored in the TagMap — these are hand-assigned in tracer core. {@code [FIRST_STORED_SERIAL,
+   * ..]} is for generated convention tags that ARE stored (slotted/bucketed). {@code globalSerial
+   * == 0} means unknown / string-only. Both core and the code generator must agree on this
+   * boundary.
+   */
+  public static final int FIRST_STORED_SERIAL = 256;
+
+  /** True if the tagId names a reserved "virtual"/specially-handled tag (not stored in the map). */
+  public static boolean isReserved(long tagId) {
+    int globalSerial = globalSerial(tagId);
+    return globalSerial > 0 && globalSerial < FIRST_STORED_SERIAL;
+  }
+
+  /** True if the tagId names a generated, map-stored (slotted/bucketed) tag. */
+  public static boolean isStored(long tagId) {
+    return globalSerial(tagId) >= FIRST_STORED_SERIAL;
+  }
+
+  /**
+   * Dense-store routing gate, decoupled from name resolution. The {@link Resolver} is registered
+   * unconditionally at tracer init (so {@code keyOf}/{@code nameOf} — and OTel name mapping —
+   * always work); this flag, captured once from {@code trace.experimental.dense.tags.enabled},
+   * separately decides whether known tags actually take the dense store. As a {@code static final}
+   * it constant-folds, so the dense branches in {@link TagMap} dead-code-eliminate when off.
+   */
+  public static final boolean DENSE_STORE = Config.get().isTraceDenseTagsEnabled();
+
+  /**
+   * True iff the tagId should route to the dense store: it names a stored tag AND the dense store
+   * is enabled. This is the single predicate {@link TagMap} branches on — {@link #isStored} alone
+   * is layout identity, independent of whether dense routing is switched on.
+   */
+  public static boolean routesToDense(long tagId) {
+    return DENSE_STORE && isStored(tagId);
+  }
+
+  /**
+   * Sentinel {@code fieldPos} meaning "no positional slot". It is the maximum value the 16-bit
+   * fieldPos field can hold, so it always compares {@code >= slotCount()} and routes to the hash
+   * buckets rather than the fast positional array. Two kinds of tagId use it:
+   *
+   * <ul>
+   *   <li>Reserved/virtual tags ({@code globalSerial < FIRST_STORED_SERIAL}) — not stored at all;
+   *       the sentinel just guarantees an incidental store never lands in a slot.
+   *   <li>Unslotted stored tags ({@code globalSerial >= FIRST_STORED_SERIAL}) — "low-priority" tags
+   *       that get a stable id (and so {@code keyOf}/{@code nameOf} unification with their string
+   *       form) but are deliberately not given a slot, so they live in the buckets and don't widen
+   *       {@code knownEntries[]} for every span. {@code getEntry(long)} for these resolves the name
+   *       and rehashes — the cost of not owning a slot.
+   * </ul>
+   */
+  public static final int NO_SLOT = 0xFFFF;
+
+  /**
+   * True if the tagId names a stored tag that deliberately has no positional slot (bucket-only).
+   */
+  public static boolean isUnslotted(long tagId) {
+    return isStored(tagId) && fieldPos(tagId) == NO_SLOT;
+  }
+
+  /**
+   * Builds a tagId from its parts: {@code globalSerial} (globally unique per known tag), {@code
+   * fieldPos} (the tag's slot within its span type's positional table), and the tag {@code name}
+   * (whose hash is computed via the same function the runtime uses, so the low 32 bits match {@link
+   * TagMap.Entry#hash()}). Inverse of {@link #globalSerial}/{@link #fieldPos}/{@link #nameHash}.
+   * Intended for the code generator and tests.
+   */
+  public static long tagId(int globalSerial, int fieldPos, String name) {
+    long nameHash = TagMap.Entry._hash(name) & 0xFFFFFFFFL;
+    return ((long) globalSerial << 48) | ((long) (fieldPos & 0xFFFF) << 32) | nameHash;
+  }
+
+  /**
+   * Builds a tagId with no positional slot ({@code fieldPos == }{@link #NO_SLOT}). Use for reserved
+   * "virtual" tags and for "low-priority" stored tags that get a stable id but are intentionally
+   * kept out of the fast slot array (they route to the hash buckets). See {@link #NO_SLOT}.
+   */
+  public static long tagId(int globalSerial, String name) {
+    return tagId(globalSerial, NO_SLOT, name);
+  }
+
+  // Number of positional slots in the global layout = (max stored fieldPos) + 1, declared by the
+  // registered provider. Captured once at registration and read as a dynamic constant; TagMap sizes
+  // its knownEntries array to exactly this rather than a hardcoded max. 0 when no resolver.
+  private static int slotCount;
+
+  /** Slot count of the registered provider (max stored fieldPos + 1); 0 if none. */
+  public static int slotCount() {
+    return slotCount;
+  }
+
+  public interface Resolver {
+    String nameOf(long tagId);
+
+    long keyOf(String name);
+
+    /** Number of positional slots this provider uses: (max stored fieldPos) + 1. */
+    int slotCount();
+  }
+
+  /**
+   * Empty null-object codec: no name&harr;id mappings, no slots. Installed lazily on first use when
+   * nothing was registered, so the codec is always present. Its behavior is byte-identical to the
+   * pre-registry world — {@code keyOf} returns 0, {@code nameOf} returns null, every tag is unknown
+   * and takes the hash buckets.
+   */
+  private static final class NoKnownTagCodec implements Resolver {
+    static final NoKnownTagCodec INSTANCE = new NoKnownTagCodec();
+
+    @Override
+    public String nameOf(long tagId) {
+      return null;
+    }
+
+    @Override
+    public long keyOf(String name) {
+      return 0L;
+    }
+
+    @Override
+    public int slotCount() {
+      return 0;
+    }
+  }
+
+  // active/slotCount are plain by design: written once here at tracer-init registration (before any
+  // span processing) and read plain on the hot path. A stale read is benign — the tag is treated as
+  // unknown and takes the hash-bucket path — so plain reads are deliberately preferred over a
+  // costly
+  // volatile read on weak memory models.
+  public static synchronized void register(Resolver resolver) {
+    if (resolver == null) {
+      throw new NullPointerException("resolver");
+    }
+    if (locked) {
+      if (KnownTagCodec.resolver == resolver) {
+        return; // idempotent: the same resolver may be registered again (e.g. repeated init())
+      }
+      throw new IllegalStateException(
+          "KnownTagCodec is already locked; a resolver cannot be registered after first use");
+    }
+    KnownTagCodec.resolver = resolver; // volatile write publishes the resolver
+    KnownTagCodec.slotCount = resolver.slotCount();
+    KnownTagCodec.locked = true;
+    KnownTagCodec.active = true; // plain write; readers re-read resolver volatile anyway
+  }
+
+  // Freeze the codec as the empty NoKnownTagCodec when nothing was registered by first use. Keeps
+  // `active` false (No has no mappings) so the hot path stays a plain-boolean short-circuit.
+  private static synchronized void freezeAsNoCodec() {
+    if (locked) {
+      return;
+    }
+    KnownTagCodec.resolver = NoKnownTagCodec.INSTANCE;
+    KnownTagCodec.locked = true;
+  }
+
+  public static String nameOf(long tagId) {
+    if (active) {
+      return resolver.nameOf(tagId);
+    }
+    if (!locked) {
+      freezeAsNoCodec();
+    }
+    return null;
+  }
+
+  public static long keyOf(String name) {
+    if (active) {
+      return resolver.keyOf(name);
+    }
+    if (!locked) {
+      freezeAsNoCodec();
+    }
+    return 0L;
+  }
+
+  private KnownTagCodec() {}
+}

--- a/internal-api/src/main/java/datadog/trace/api/KnownTags.java
+++ b/internal-api/src/main/java/datadog/trace/api/KnownTags.java
@@ -1,0 +1,328 @@
+package datadog.trace.api;
+
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.util.StringIndex;
+
+/**
+ * Hand-assigned tag-id constants for well-known tags, plus the {@link KnownTagCodec.Resolver} that
+ * resolves them. This is the single registry shared by the tracer core and by instrumentation
+ * (decorators) — it lives in {@code internal-api} so both layers can reference the ids; the
+ * eventual code generator will replace the hand assignment here.
+ *
+ * <p>Reserved serials {@code [1, KnownTagCodec.FIRST_STORED_SERIAL)} name "virtual" tags handled by
+ * the tag interceptor / span fields and are NOT stored in the {@code TagMap}; their {@code
+ * fieldPos} is the {@link KnownTagCodec#NO_SLOT} sentinel that is out of slot range, so any
+ * incidental store routes to the hash buckets rather than a positional slot. Serials {@code >=
+ * FIRST_STORED_SERIAL} name stored tags that slot/bucket normally (or, with {@code NO_SLOT}, are
+ * stored bucket-only).
+ *
+ * <p>The resolver registers on class initialization, so simply referencing any constant here makes
+ * tag-id resolution live before the first span is built.
+ *
+ * <p><b>Slice-1 note (keyOf substrate):</b> the {@code fieldPos} assignments below (and {@link
+ * #SLOT_COUNT}) describe a single <i>universal</i> positional layout (slots 0..25). That layout is
+ * currently dormant — no dense store consumes {@code fieldPos} yet — and is <b>provisional</b>: the
+ * dense-store slice replaces the universal layout with per-role / per-type sizing (see the
+ * over-provision finding in {@code dense-tagmap-design.md}). {@code keyOf}/{@code nameOf} depend
+ * only on {@code globalSerial} + name, not {@code fieldPos}, so the ids themselves are stable
+ * across any layout scheme.
+ */
+public final class KnownTags {
+  // slot count = (max stored fieldPos) + 1. Stored tags use fieldPos 0..25. PROVISIONAL universal
+  // layout — see the slice-1 note above; the dense-store slice supersedes this with role/type
+  // sizing.
+  static final int SLOT_COUNT = 26;
+
+  // ---- reserved / virtual (tag-interceptor handled, not stored) ----
+  // Reserved tags are always intercepted -> set the INTERCEPTED flag.
+  public static final int ERROR_SERIAL = 1;
+  public static final long ERROR_ID =
+      KnownTagCodec.intercepted(KnownTagCodec.tagId(ERROR_SERIAL, Tags.ERROR));
+
+  // ---- stored (slotted / bucketed) ----
+  public static final int PARENT_ID_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL;
+  public static final long PARENT_ID = KnownTagCodec.tagId(PARENT_ID_SERIAL, 0, DDTags.PARENT_ID);
+
+  // common (process-constant) tags added by InternalTagsAdder to ~every span
+  public static final int BASE_SERVICE_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 1;
+  public static final long BASE_SERVICE_ID =
+      KnownTagCodec.tagId(BASE_SERVICE_SERIAL, 1, DDTags.BASE_SERVICE);
+
+  public static final int VERSION_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 2;
+  public static final long VERSION_ID = KnownTagCodec.tagId(VERSION_SERIAL, 2, Tags.VERSION);
+
+  // build-time-known constant tags merged into defaultSpanTags (see CoreTracer.withTracerTags).
+  // "env" is a base-mixin tag; the *_ENABLED flags are product-mixin tags. Hand-assigned for now.
+  public static final String ENV = "env";
+  public static final int ENV_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 3;
+  public static final long ENV_ID = KnownTagCodec.tagId(ENV_SERIAL, 3, ENV);
+
+  public static final int DJM_ENABLED_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 4;
+  public static final long DJM_ENABLED_ID =
+      KnownTagCodec.tagId(DJM_ENABLED_SERIAL, 4, DDTags.DJM_ENABLED);
+
+  public static final int DSM_ENABLED_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 5;
+  public static final long DSM_ENABLED_ID =
+      KnownTagCodec.tagId(DSM_ENABLED_SERIAL, 5, DDTags.DSM_ENABLED);
+
+  // common tags added by the tag post-processors (RemoteHostnameAdder / IntegrationAdder /
+  // ServiceNameSourceAdder). Not intercepted; stored.
+  public static final int TRACER_HOST_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 6;
+  public static final long TRACER_HOST_ID =
+      KnownTagCodec.tagId(TRACER_HOST_SERIAL, 6, DDTags.TRACER_HOST);
+
+  public static final int INTEGRATION_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 7;
+  public static final long INTEGRATION_ID =
+      KnownTagCodec.tagId(INTEGRATION_SERIAL, 7, DDTags.DD_INTEGRATION);
+
+  public static final int SVC_SRC_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 8;
+  public static final long SVC_SRC_ID = KnownTagCodec.tagId(SVC_SRC_SERIAL, 8, DDTags.DD_SVC_SRC);
+
+  // peer.service tags, read/written by PeerServiceCalculator (post-processor; uses Map put/get that
+  // bypass the interceptor). peer.service is intercepted on the set-path but STORED, so it slots.
+  public static final int PEER_SERVICE_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 9;
+  public static final long PEER_SERVICE_ID =
+      KnownTagCodec.intercepted(KnownTagCodec.tagId(PEER_SERVICE_SERIAL, 9, Tags.PEER_SERVICE));
+
+  public static final int PEER_SERVICE_REMAPPED_FROM_SERIAL =
+      KnownTagCodec.FIRST_STORED_SERIAL + 10;
+  public static final long PEER_SERVICE_REMAPPED_FROM_ID =
+      KnownTagCodec.tagId(PEER_SERVICE_REMAPPED_FROM_SERIAL, 10, DDTags.PEER_SERVICE_REMAPPED_FROM);
+
+  // HTTP tags read by HttpEndpointPostProcessor. http.method/http.url are intercepted-but-stored
+  // (interceptTag side-effects then returns false → stored); http.route is not intercepted. All
+  // stored, so the string set-path slots them via keyOf and the id reads here find them.
+  public static final int HTTP_METHOD_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 11;
+  public static final long HTTP_METHOD_ID =
+      KnownTagCodec.intercepted(KnownTagCodec.tagId(HTTP_METHOD_SERIAL, 11, Tags.HTTP_METHOD));
+
+  public static final int HTTP_ROUTE_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 12;
+  public static final long HTTP_ROUTE_ID =
+      KnownTagCodec.tagId(HTTP_ROUTE_SERIAL, 12, Tags.HTTP_ROUTE);
+
+  public static final int HTTP_URL_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 13;
+  public static final long HTTP_URL_ID =
+      KnownTagCodec.intercepted(KnownTagCodec.tagId(HTTP_URL_SERIAL, 13, Tags.HTTP_URL));
+
+  // peer connection tags set by BaseDecorator.onPeerConnection on ~every client/producer span.
+  // Not intercepted; stored. Slotted (common across client instrumentations).
+  public static final int PEER_HOSTNAME_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 14;
+  public static final long PEER_HOSTNAME_ID =
+      KnownTagCodec.tagId(PEER_HOSTNAME_SERIAL, 14, Tags.PEER_HOSTNAME);
+
+  public static final int PEER_HOST_IPV4_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 15;
+  public static final long PEER_HOST_IPV4_ID =
+      KnownTagCodec.tagId(PEER_HOST_IPV4_SERIAL, 15, Tags.PEER_HOST_IPV4);
+
+  public static final int PEER_HOST_IPV6_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 16;
+  public static final long PEER_HOST_IPV6_ID =
+      KnownTagCodec.tagId(PEER_HOST_IPV6_SERIAL, 16, Tags.PEER_HOST_IPV6);
+
+  public static final int PEER_PORT_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 17;
+  public static final long PEER_PORT_ID = KnownTagCodec.tagId(PEER_PORT_SERIAL, 17, Tags.PEER_PORT);
+
+  // Universal decorator tags — set on ~every span (component/span.kind via Base/Server/Client
+  // decorators, language via ServerDecorator). span.kind is intercepted (setSpanKindOrdinal).
+  public static final int COMPONENT_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 18;
+  public static final long COMPONENT_ID = KnownTagCodec.tagId(COMPONENT_SERIAL, 18, Tags.COMPONENT);
+
+  public static final int SPAN_KIND_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 19;
+  public static final long SPAN_KIND_ID =
+      KnownTagCodec.intercepted(KnownTagCodec.tagId(SPAN_KIND_SERIAL, 19, Tags.SPAN_KIND));
+
+  public static final int LANGUAGE_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 20;
+  public static final long LANGUAGE_ID =
+      KnownTagCodec.tagId(LANGUAGE_SERIAL, 20, DDTags.LANGUAGE_TAG_KEY);
+
+  // JDBC / database-client tags — set on every db span (58% of petclinic spans). Not intercepted
+  // (only db.statement is, and that's handled separately).
+  public static final int DB_TYPE_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 21;
+  public static final long DB_TYPE_ID = KnownTagCodec.tagId(DB_TYPE_SERIAL, 21, Tags.DB_TYPE);
+
+  public static final int DB_INSTANCE_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 22;
+  public static final long DB_INSTANCE_ID =
+      KnownTagCodec.tagId(DB_INSTANCE_SERIAL, 22, Tags.DB_INSTANCE);
+
+  public static final int DB_USER_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 23;
+  public static final long DB_USER_ID = KnownTagCodec.tagId(DB_USER_SERIAL, 23, Tags.DB_USER);
+
+  public static final int DB_OPERATION_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 24;
+  public static final long DB_OPERATION_ID =
+      KnownTagCodec.tagId(DB_OPERATION_SERIAL, 24, Tags.DB_OPERATION);
+
+  public static final int DB_POOL_NAME_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 25;
+  public static final long DB_POOL_NAME_ID =
+      KnownTagCodec.tagId(DB_POOL_NAME_SERIAL, 25, Tags.DB_POOL_NAME);
+
+  // Open-addressed name -> id table backing keyOf (data, not a switch): scales flat as the known
+  // set grows, where a generated switch eventually falls off the inline threshold. KEYOF_NAMES and
+  // KEYOF_VALUES are parallel; the table places names by hash and a parallel ids[] by slot.
+  private static final String[] KEYOF_NAMES = {
+    Tags.ERROR,
+    DDTags.PARENT_ID,
+    DDTags.BASE_SERVICE,
+    Tags.VERSION,
+    ENV,
+    DDTags.DJM_ENABLED,
+    DDTags.DSM_ENABLED,
+    DDTags.TRACER_HOST,
+    DDTags.DD_INTEGRATION,
+    DDTags.DD_SVC_SRC,
+    Tags.PEER_SERVICE,
+    DDTags.PEER_SERVICE_REMAPPED_FROM,
+    Tags.HTTP_METHOD,
+    Tags.HTTP_ROUTE,
+    Tags.HTTP_URL,
+    Tags.PEER_HOSTNAME,
+    Tags.PEER_HOST_IPV4,
+    Tags.PEER_HOST_IPV6,
+    Tags.PEER_PORT,
+    Tags.COMPONENT,
+    Tags.SPAN_KIND,
+    DDTags.LANGUAGE_TAG_KEY,
+    Tags.DB_TYPE,
+    Tags.DB_INSTANCE,
+    Tags.DB_USER,
+    Tags.DB_OPERATION,
+    Tags.DB_POOL_NAME,
+  };
+
+  private static final long[] KEYOF_VALUES = {
+    ERROR_ID,
+    PARENT_ID,
+    BASE_SERVICE_ID,
+    VERSION_ID,
+    ENV_ID,
+    DJM_ENABLED_ID,
+    DSM_ENABLED_ID,
+    TRACER_HOST_ID,
+    INTEGRATION_ID,
+    SVC_SRC_ID,
+    PEER_SERVICE_ID,
+    PEER_SERVICE_REMAPPED_FROM_ID,
+    HTTP_METHOD_ID,
+    HTTP_ROUTE_ID,
+    HTTP_URL_ID,
+    PEER_HOSTNAME_ID,
+    PEER_HOST_IPV4_ID,
+    PEER_HOST_IPV6_ID,
+    PEER_PORT_ID,
+    COMPONENT_ID,
+    SPAN_KIND_ID,
+    LANGUAGE_ID,
+    DB_TYPE_ID,
+    DB_INSTANCE_ID,
+    DB_USER_ID,
+    DB_OPERATION_ID,
+    DB_POOL_NAME_ID,
+  };
+
+  // Static-final raw arrays placed by StringIndex.EmbeddingSupport: the JIT folds these refs to
+  // constants on
+  // the keyOf hot path (the fastest of StringIndex's three usage modes — no instance dereference).
+  private static final int[] KEYOF_HASHES;
+  private static final String[] KEYOF_KEYS;
+  private static final long[] KEYOF_IDS;
+
+  static {
+    StringIndex.Data data = StringIndex.EmbeddingSupport.create(KEYOF_NAMES);
+    long[] ids = new long[data.names.length];
+    for (int j = 0; j < KEYOF_NAMES.length; j++) {
+      ids[StringIndex.EmbeddingSupport.indexOf(data.hashes, data.names, KEYOF_NAMES[j])] =
+          KEYOF_VALUES[j];
+    }
+    KEYOF_HASHES = data.hashes;
+    KEYOF_KEYS = data.names;
+    KEYOF_IDS = ids;
+  }
+
+  static final KnownTagCodec.Resolver RESOLVER =
+      new KnownTagCodec.Resolver() {
+        @Override
+        public String nameOf(long tagId) {
+          switch (KnownTagCodec.globalSerial(tagId)) {
+            case ERROR_SERIAL:
+              return Tags.ERROR;
+            case PARENT_ID_SERIAL:
+              return DDTags.PARENT_ID;
+            case BASE_SERVICE_SERIAL:
+              return DDTags.BASE_SERVICE;
+            case VERSION_SERIAL:
+              return Tags.VERSION;
+            case ENV_SERIAL:
+              return ENV;
+            case DJM_ENABLED_SERIAL:
+              return DDTags.DJM_ENABLED;
+            case DSM_ENABLED_SERIAL:
+              return DDTags.DSM_ENABLED;
+            case TRACER_HOST_SERIAL:
+              return DDTags.TRACER_HOST;
+            case INTEGRATION_SERIAL:
+              return DDTags.DD_INTEGRATION;
+            case SVC_SRC_SERIAL:
+              return DDTags.DD_SVC_SRC;
+            case PEER_SERVICE_SERIAL:
+              return Tags.PEER_SERVICE;
+            case PEER_SERVICE_REMAPPED_FROM_SERIAL:
+              return DDTags.PEER_SERVICE_REMAPPED_FROM;
+            case HTTP_METHOD_SERIAL:
+              return Tags.HTTP_METHOD;
+            case HTTP_ROUTE_SERIAL:
+              return Tags.HTTP_ROUTE;
+            case HTTP_URL_SERIAL:
+              return Tags.HTTP_URL;
+            case PEER_HOSTNAME_SERIAL:
+              return Tags.PEER_HOSTNAME;
+            case PEER_HOST_IPV4_SERIAL:
+              return Tags.PEER_HOST_IPV4;
+            case PEER_HOST_IPV6_SERIAL:
+              return Tags.PEER_HOST_IPV6;
+            case PEER_PORT_SERIAL:
+              return Tags.PEER_PORT;
+            case COMPONENT_SERIAL:
+              return Tags.COMPONENT;
+            case SPAN_KIND_SERIAL:
+              return Tags.SPAN_KIND;
+            case LANGUAGE_SERIAL:
+              return DDTags.LANGUAGE_TAG_KEY;
+            case DB_TYPE_SERIAL:
+              return Tags.DB_TYPE;
+            case DB_INSTANCE_SERIAL:
+              return Tags.DB_INSTANCE;
+            case DB_USER_SERIAL:
+              return Tags.DB_USER;
+            case DB_OPERATION_SERIAL:
+              return Tags.DB_OPERATION;
+            case DB_POOL_NAME_SERIAL:
+              return Tags.DB_POOL_NAME;
+            default:
+              return null;
+          }
+        }
+
+        @Override
+        public int slotCount() {
+          return SLOT_COUNT;
+        }
+
+        @Override
+        public long keyOf(String name) {
+          int slot = StringIndex.EmbeddingSupport.indexOf(KEYOF_HASHES, KEYOF_KEYS, name);
+          return slot < 0 ? 0L : KEYOF_IDS[slot];
+        }
+      };
+
+  static {
+    KnownTagCodec.register(RESOLVER);
+  }
+
+  /**
+   * Forces resolver registration. Merely invoking this static method runs {@code <clinit>} (which
+   * registers {@link #RESOLVER}), so calling it once at tracer init flips the dense store live;
+   * idempotent. Until something references this class the registry stays dormant and {@code keyOf}
+   * returns 0, so tag storage is byte-identical to the bucket-only behavior.
+   */
+  public static void init() {}
+
+  private KnownTags() {}
+}

--- a/internal-api/src/main/java/datadog/trace/api/KnownTags.java
+++ b/internal-api/src/main/java/datadog/trace/api/KnownTags.java
@@ -1,0 +1,330 @@
+package datadog.trace.api;
+
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.util.StringIndex;
+
+/**
+ * Hand-assigned tag-id constants for well-known tags, plus the {@link KnownTagCodec.Resolver} that
+ * resolves them. This is the single registry shared by the tracer core and by instrumentation
+ * (decorators) — it lives in {@code internal-api} so both layers can reference the ids; the
+ * eventual code generator will replace the hand assignment here.
+ *
+ * <p>Reserved serials {@code [1, KnownTagCodec.FIRST_STORED_SERIAL)} name "virtual" tags handled by
+ * the tag interceptor / span fields and are NOT stored in the {@code TagMap}; their {@code
+ * fieldPos} is the {@link KnownTagCodec#NO_SLOT} sentinel that is out of slot range, so any
+ * incidental store routes to the hash buckets rather than a positional slot. Serials {@code >=
+ * FIRST_STORED_SERIAL} name stored tags that slot/bucket normally (or, with {@code NO_SLOT}, are
+ * stored bucket-only).
+ *
+ * <p>The resolver registers on class initialization, so simply referencing any constant here makes
+ * tag-id resolution live before the first span is built.
+ *
+ * <p><b>Slice-1 note (keyOf substrate):</b> the {@code fieldPos} assignments below (and {@link
+ * #SLOT_COUNT}) describe a single <i>universal</i> positional layout (slots 0..25). That layout is
+ * currently dormant — no dense store consumes {@code fieldPos} yet — and is <b>provisional</b>: the
+ * dense-store slice replaces the universal layout with per-role / per-type sizing (see the
+ * over-provision finding in {@code dense-tagmap-design.md}). {@code keyOf}/{@code nameOf} depend
+ * only on {@code globalSerial} + name, not {@code fieldPos}, so the ids themselves are stable
+ * across any layout scheme.
+ */
+public final class KnownTags {
+  // slot count = (max stored fieldPos) + 1. Stored tags use fieldPos 0..25. PROVISIONAL universal
+  // layout — see the slice-1 note above; the dense-store slice supersedes this with role/type
+  // sizing.
+  static final int SLOT_COUNT = 26;
+
+  // ---- reserved / virtual (tag-interceptor handled, not stored) ----
+  // Reserved tags are always intercepted -> set the INTERCEPTED flag.
+  public static final int ERROR_SERIAL = 1;
+  public static final long ERROR_ID =
+      KnownTagCodec.intercepted(KnownTagCodec.tagId(ERROR_SERIAL, Tags.ERROR));
+
+  // ---- stored (slotted / bucketed) ----
+  public static final int PARENT_ID_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL;
+  public static final long PARENT_ID = KnownTagCodec.tagId(PARENT_ID_SERIAL, 0, DDTags.PARENT_ID);
+
+  // common (process-constant) tags added by InternalTagsAdder to ~every span
+  public static final int BASE_SERVICE_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 1;
+  public static final long BASE_SERVICE_ID =
+      KnownTagCodec.tagId(BASE_SERVICE_SERIAL, 1, DDTags.BASE_SERVICE);
+
+  public static final int VERSION_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 2;
+  public static final long VERSION_ID = KnownTagCodec.tagId(VERSION_SERIAL, 2, Tags.VERSION);
+
+  // build-time-known constant tags merged into defaultSpanTags (see CoreTracer.withTracerTags).
+  // "env" is a base-mixin tag; the *_ENABLED flags are product-mixin tags. Hand-assigned for now.
+  public static final String ENV = "env";
+  public static final int ENV_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 3;
+  public static final long ENV_ID = KnownTagCodec.tagId(ENV_SERIAL, 3, ENV);
+
+  public static final int DJM_ENABLED_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 4;
+  public static final long DJM_ENABLED_ID =
+      KnownTagCodec.tagId(DJM_ENABLED_SERIAL, 4, DDTags.DJM_ENABLED);
+
+  public static final int DSM_ENABLED_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 5;
+  public static final long DSM_ENABLED_ID =
+      KnownTagCodec.tagId(DSM_ENABLED_SERIAL, 5, DDTags.DSM_ENABLED);
+
+  // common tags added by the tag post-processors (RemoteHostnameAdder / IntegrationAdder /
+  // ServiceNameSourceAdder). Not intercepted; stored.
+  public static final int TRACER_HOST_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 6;
+  public static final long TRACER_HOST_ID =
+      KnownTagCodec.tagId(TRACER_HOST_SERIAL, 6, DDTags.TRACER_HOST);
+
+  public static final int INTEGRATION_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 7;
+  public static final long INTEGRATION_ID =
+      KnownTagCodec.tagId(INTEGRATION_SERIAL, 7, DDTags.DD_INTEGRATION);
+
+  public static final int SVC_SRC_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 8;
+  public static final long SVC_SRC_ID = KnownTagCodec.tagId(SVC_SRC_SERIAL, 8, DDTags.DD_SVC_SRC);
+
+  // peer.service tags, read/written by PeerServiceCalculator (post-processor; uses Map put/get that
+  // bypass the interceptor). peer.service is intercepted on the set-path but STORED, so it slots.
+  public static final int PEER_SERVICE_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 9;
+  public static final long PEER_SERVICE_ID =
+      KnownTagCodec.intercepted(KnownTagCodec.tagId(PEER_SERVICE_SERIAL, 9, Tags.PEER_SERVICE));
+
+  public static final int PEER_SERVICE_REMAPPED_FROM_SERIAL =
+      KnownTagCodec.FIRST_STORED_SERIAL + 10;
+  public static final long PEER_SERVICE_REMAPPED_FROM_ID =
+      KnownTagCodec.tagId(PEER_SERVICE_REMAPPED_FROM_SERIAL, 10, DDTags.PEER_SERVICE_REMAPPED_FROM);
+
+  // HTTP tags read by HttpEndpointPostProcessor. http.method/http.url are intercepted-but-stored
+  // (interceptTag side-effects then returns false → stored); http.route is not intercepted. All
+  // stored, so the string set-path slots them via keyOf and the id reads here find them.
+  public static final int HTTP_METHOD_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 11;
+  public static final long HTTP_METHOD_ID =
+      KnownTagCodec.intercepted(KnownTagCodec.tagId(HTTP_METHOD_SERIAL, 11, Tags.HTTP_METHOD));
+
+  public static final int HTTP_ROUTE_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 12;
+  public static final long HTTP_ROUTE_ID =
+      KnownTagCodec.tagId(HTTP_ROUTE_SERIAL, 12, Tags.HTTP_ROUTE);
+
+  public static final int HTTP_URL_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 13;
+  public static final long HTTP_URL_ID =
+      KnownTagCodec.intercepted(KnownTagCodec.tagId(HTTP_URL_SERIAL, 13, Tags.HTTP_URL));
+
+  // peer connection tags set by BaseDecorator.onPeerConnection on ~every client/producer span.
+  // Not intercepted; stored. Slotted (common across client instrumentations).
+  public static final int PEER_HOSTNAME_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 14;
+  public static final long PEER_HOSTNAME_ID =
+      KnownTagCodec.tagId(PEER_HOSTNAME_SERIAL, 14, Tags.PEER_HOSTNAME);
+
+  public static final int PEER_HOST_IPV4_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 15;
+  public static final long PEER_HOST_IPV4_ID =
+      KnownTagCodec.tagId(PEER_HOST_IPV4_SERIAL, 15, Tags.PEER_HOST_IPV4);
+
+  public static final int PEER_HOST_IPV6_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 16;
+  public static final long PEER_HOST_IPV6_ID =
+      KnownTagCodec.tagId(PEER_HOST_IPV6_SERIAL, 16, Tags.PEER_HOST_IPV6);
+
+  public static final int PEER_PORT_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 17;
+  public static final long PEER_PORT_ID = KnownTagCodec.tagId(PEER_PORT_SERIAL, 17, Tags.PEER_PORT);
+
+  // Universal decorator tags — set on ~every span (component/span.kind via Base/Server/Client
+  // decorators, language via ServerDecorator). span.kind is intercepted (setSpanKindOrdinal).
+  public static final int COMPONENT_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 18;
+  public static final long COMPONENT_ID = KnownTagCodec.tagId(COMPONENT_SERIAL, 18, Tags.COMPONENT);
+
+  public static final int SPAN_KIND_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 19;
+  public static final long SPAN_KIND_ID =
+      KnownTagCodec.intercepted(KnownTagCodec.tagId(SPAN_KIND_SERIAL, 19, Tags.SPAN_KIND));
+
+  public static final int LANGUAGE_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 20;
+  public static final long LANGUAGE_ID =
+      KnownTagCodec.tagId(LANGUAGE_SERIAL, 20, DDTags.LANGUAGE_TAG_KEY);
+
+  // JDBC / database-client tags — set on every db span (58% of petclinic spans). Not intercepted
+  // (only db.statement is, and that's handled separately).
+  public static final int DB_TYPE_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 21;
+  public static final long DB_TYPE_ID = KnownTagCodec.tagId(DB_TYPE_SERIAL, 21, Tags.DB_TYPE);
+
+  public static final int DB_INSTANCE_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 22;
+  public static final long DB_INSTANCE_ID =
+      KnownTagCodec.tagId(DB_INSTANCE_SERIAL, 22, Tags.DB_INSTANCE);
+
+  public static final int DB_USER_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 23;
+  public static final long DB_USER_ID = KnownTagCodec.tagId(DB_USER_SERIAL, 23, Tags.DB_USER);
+
+  public static final int DB_OPERATION_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 24;
+  public static final long DB_OPERATION_ID =
+      KnownTagCodec.tagId(DB_OPERATION_SERIAL, 24, Tags.DB_OPERATION);
+
+  public static final int DB_POOL_NAME_SERIAL = KnownTagCodec.FIRST_STORED_SERIAL + 25;
+  public static final long DB_POOL_NAME_ID =
+      KnownTagCodec.tagId(DB_POOL_NAME_SERIAL, 25, Tags.DB_POOL_NAME);
+
+  // Open-addressed name -> id table backing keyOf (data, not a switch): scales flat as the known
+  // set grows, where a generated switch eventually falls off the inline threshold. KEYOF_NAMES and
+  // KEYOF_VALUES are parallel; the table places names by hash and a parallel ids[] by slot.
+  private static final String[] KEYOF_NAMES = {
+    Tags.ERROR,
+    DDTags.PARENT_ID,
+    DDTags.BASE_SERVICE,
+    Tags.VERSION,
+    ENV,
+    DDTags.DJM_ENABLED,
+    DDTags.DSM_ENABLED,
+    DDTags.TRACER_HOST,
+    DDTags.DD_INTEGRATION,
+    DDTags.DD_SVC_SRC,
+    Tags.PEER_SERVICE,
+    DDTags.PEER_SERVICE_REMAPPED_FROM,
+    Tags.HTTP_METHOD,
+    Tags.HTTP_ROUTE,
+    Tags.HTTP_URL,
+    Tags.PEER_HOSTNAME,
+    Tags.PEER_HOST_IPV4,
+    Tags.PEER_HOST_IPV6,
+    Tags.PEER_PORT,
+    Tags.COMPONENT,
+    Tags.SPAN_KIND,
+    DDTags.LANGUAGE_TAG_KEY,
+    Tags.DB_TYPE,
+    Tags.DB_INSTANCE,
+    Tags.DB_USER,
+    Tags.DB_OPERATION,
+    Tags.DB_POOL_NAME,
+  };
+
+  private static final long[] KEYOF_VALUES = {
+    ERROR_ID,
+    PARENT_ID,
+    BASE_SERVICE_ID,
+    VERSION_ID,
+    ENV_ID,
+    DJM_ENABLED_ID,
+    DSM_ENABLED_ID,
+    TRACER_HOST_ID,
+    INTEGRATION_ID,
+    SVC_SRC_ID,
+    PEER_SERVICE_ID,
+    PEER_SERVICE_REMAPPED_FROM_ID,
+    HTTP_METHOD_ID,
+    HTTP_ROUTE_ID,
+    HTTP_URL_ID,
+    PEER_HOSTNAME_ID,
+    PEER_HOST_IPV4_ID,
+    PEER_HOST_IPV6_ID,
+    PEER_PORT_ID,
+    COMPONENT_ID,
+    SPAN_KIND_ID,
+    LANGUAGE_ID,
+    DB_TYPE_ID,
+    DB_INSTANCE_ID,
+    DB_USER_ID,
+    DB_OPERATION_ID,
+    DB_POOL_NAME_ID,
+  };
+
+  // Static-final raw arrays placed by StringIndex.EmbeddingSupport: the JIT folds these refs to
+  // constants on
+  // the keyOf hot path (the fastest of StringIndex's three usage modes — no instance dereference).
+  private static final int[] KEYOF_HASHES;
+  private static final String[] KEYOF_KEYS;
+  private static final long[] KEYOF_IDS;
+
+  static {
+    StringIndex.Data data = StringIndex.EmbeddingSupport.create(KEYOF_NAMES);
+    long[] ids = new long[data.names.length];
+    for (int j = 0; j < KEYOF_NAMES.length; j++) {
+      ids[StringIndex.EmbeddingSupport.indexOf(data.hashes, data.names, KEYOF_NAMES[j])] =
+          KEYOF_VALUES[j];
+    }
+    KEYOF_HASHES = data.hashes;
+    KEYOF_KEYS = data.names;
+    KEYOF_IDS = ids;
+  }
+
+  static final KnownTagCodec.Resolver RESOLVER =
+      new KnownTagCodec.Resolver() {
+        @Override
+        public String nameOf(long tagId) {
+          switch (KnownTagCodec.globalSerial(tagId)) {
+            case ERROR_SERIAL:
+              return Tags.ERROR;
+            case PARENT_ID_SERIAL:
+              return DDTags.PARENT_ID;
+            case BASE_SERVICE_SERIAL:
+              return DDTags.BASE_SERVICE;
+            case VERSION_SERIAL:
+              return Tags.VERSION;
+            case ENV_SERIAL:
+              return ENV;
+            case DJM_ENABLED_SERIAL:
+              return DDTags.DJM_ENABLED;
+            case DSM_ENABLED_SERIAL:
+              return DDTags.DSM_ENABLED;
+            case TRACER_HOST_SERIAL:
+              return DDTags.TRACER_HOST;
+            case INTEGRATION_SERIAL:
+              return DDTags.DD_INTEGRATION;
+            case SVC_SRC_SERIAL:
+              return DDTags.DD_SVC_SRC;
+            case PEER_SERVICE_SERIAL:
+              return Tags.PEER_SERVICE;
+            case PEER_SERVICE_REMAPPED_FROM_SERIAL:
+              return DDTags.PEER_SERVICE_REMAPPED_FROM;
+            case HTTP_METHOD_SERIAL:
+              return Tags.HTTP_METHOD;
+            case HTTP_ROUTE_SERIAL:
+              return Tags.HTTP_ROUTE;
+            case HTTP_URL_SERIAL:
+              return Tags.HTTP_URL;
+            case PEER_HOSTNAME_SERIAL:
+              return Tags.PEER_HOSTNAME;
+            case PEER_HOST_IPV4_SERIAL:
+              return Tags.PEER_HOST_IPV4;
+            case PEER_HOST_IPV6_SERIAL:
+              return Tags.PEER_HOST_IPV6;
+            case PEER_PORT_SERIAL:
+              return Tags.PEER_PORT;
+            case COMPONENT_SERIAL:
+              return Tags.COMPONENT;
+            case SPAN_KIND_SERIAL:
+              return Tags.SPAN_KIND;
+            case LANGUAGE_SERIAL:
+              return DDTags.LANGUAGE_TAG_KEY;
+            case DB_TYPE_SERIAL:
+              return Tags.DB_TYPE;
+            case DB_INSTANCE_SERIAL:
+              return Tags.DB_INSTANCE;
+            case DB_USER_SERIAL:
+              return Tags.DB_USER;
+            case DB_OPERATION_SERIAL:
+              return Tags.DB_OPERATION;
+            case DB_POOL_NAME_SERIAL:
+              return Tags.DB_POOL_NAME;
+            default:
+              return null;
+          }
+        }
+
+        @Override
+        public int slotCount() {
+          return SLOT_COUNT;
+        }
+
+        @Override
+        public long keyOf(String name) {
+          int slot = StringIndex.EmbeddingSupport.indexOf(KEYOF_HASHES, KEYOF_KEYS, name);
+          return slot < 0 ? 0L : KEYOF_IDS[slot];
+        }
+      };
+
+  static {
+    KnownTagCodec.register(RESOLVER);
+  }
+
+  /**
+   * Forces resolver registration. Merely invoking this static method runs {@code <clinit>} (which
+   * registers {@link #RESOLVER}), so calling it once at tracer init makes tag-id name resolution
+   * ({@code keyOf}/{@code nameOf}) live; idempotent. Whether known tags then take the dense store
+   * is a separate, const-folded decision ({@link KnownTagCodec#DENSE_STORE}). Until something
+   * references this class the registry stays dormant and {@code keyOf} returns 0, so tag storage is
+   * byte-identical to the bucket-only behavior.
+   */
+  public static void init() {}
+
+  private KnownTags() {}
+}

--- a/internal-api/src/main/java/datadog/trace/api/TagMap.java
+++ b/internal-api/src/main/java/datadog/trace/api/TagMap.java
@@ -47,10 +47,9 @@ import javax.annotation.Nullable;
  */
 public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryReader> {
   /** Immutable empty TagMap - similar to {@link Collections#emptyMap()} */
-  // Frozen view over a length-1 array: bucket masking needs a power-of-two array length (size 0
-  // would fail with ArrayIndexOutOfBoundsException, size 1 works), and the private constructor
-  // reads no statics, so this is safe to build directly during TagMap's <clinit>.
-  public static final TagMap EMPTY = new TagMap(new Object[1], 0);
+  // Frozen view over a power-of-two array; the private constructor reads no statics, so this is
+  // safe to build directly during TagMap's <clinit>.
+  public static final TagMap EMPTY = new TagMap(new Object[1 << 4], 0);
 
   /** Creates a new mutable TagMap that contains the contents of <code>map</code> */
   public static final TagMap fromMap(@Nonnull Map<String, ?> map) {
@@ -1018,9 +1017,43 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
    * removed from the collision chain.
    */
 
-  private final Object[] buckets;
+  // Shared immutable empty buckets (all null, length 16). Every map points here until its first
+  // custom-tag write copies-on-write to a private array (materializeBuckets), so an all-known /
+  // known-heavy map (e.g. the trace-tier read-through parent) allocates ZERO buckets. Length is
+  // always 16, so reads need no null guard and read-through bucket alignment (hash & 15) holds.
+  private static final Object[] EMPTY_BUCKETS = new Object[1 << 4];
+
+  private Object[] buckets;
   private int size;
   private boolean frozen;
+
+  /**
+   * Dense known-tag store (dense-tagmap-design §5). Values for KNOWN tags (those {@link
+   * KnownTagCodec#keyOf} resolves to a stored id) live in these INSERTION-ORDERED parallel arrays
+   * with NO per-tag {@link Entry} object — the allocation win. Lazily allocated on the first
+   * known-tag write ({@code null} until then, so all-unknown maps pay nothing) and grown x2 from
+   * {@link #KNOWN_INIT_CAP}. Matched by globalSerial via a linear scan ({@link #knownIndexOf});
+   * reads aren't hot, so O(knownCount) is fine and positional indexing is deferred. Dormant until a
+   * resolver is registered: {@code keyOf} returns 0, so nothing routes here and production is
+   * byte-identical.
+   *
+   * <p>Disjoint from {@link #buckets} by construction: known-ness is global ({@code keyOf} is
+   * deterministic), so a known tag is ALWAYS dense and never bucketed, and vice-versa. That
+   * disjointness keeps read-through shadow checks within-region — an ancestor dense entry can only
+   * be shadowed by a nearer level's dense entry of the same id, an ancestor bucket entry only by a
+   * nearer level's bucket entry — so the bucket read-through chain walk is unchanged and the dense
+   * one mirrors it ({@link #parentDenseVisible}).
+   *
+   * <p>{@link #size} counts bucket entries only; {@link #knownCount} counts dense entries; the
+   * local total is {@code size + knownCount}.
+   */
+  private long[] knownIds;
+
+  private Object[] knownValues;
+  private int knownCount;
+
+  private static final int KNOWN_INIT_CAP =
+      12; // generous per-type max stopgap; exact per-type sizing comes with the tag registry
 
   /**
    * Optional frozen parent for read-through. When non-null, reads that miss the local buckets fall
@@ -1053,8 +1086,9 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
    * optimizations can treat it as fixed.
    */
   private TagMap(TagMap parent) {
-    // needs to be a power of 2 for bucket masking calculation to work as intended
-    this.buckets = new Object[1 << 4];
+    // Start on the shared empty buckets; materializeBuckets() COWs to a private power-of-two array
+    // on the first custom-tag write. All-known maps never allocate buckets.
+    this.buckets = EMPTY_BUCKETS;
     this.size = 0;
     this.frozen = false;
     this.parent = parent;
@@ -1075,8 +1109,9 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   @Override
   public int size() {
     // Exact (Map contract). Under read-through resolves the union; prefer estimateSize() for hints.
+    int local = this.size + this.knownCount; // buckets + dense
     TagMap parent = this.parent;
-    return parent == null ? this.size : this.size + this.visibleParentCount();
+    return parent == null ? local : local + this.visibleParentCount();
   }
 
   /**
@@ -1086,6 +1121,12 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   private int visibleParentCount() {
     int count = 0;
     for (TagMap ancestor = this.parent; ancestor != null; ancestor = ancestor.parent) {
+      // dense entries at this ancestor not shadowed/tombstoned by a nearer level
+      long[] ancestorIds = ancestor.knownIds;
+      int ancestorKnownCount = ancestor.knownCount;
+      for (int i = 0; i < ancestorKnownCount; ++i) {
+        if (this.parentDenseVisible(ancestorIds[i], ancestor)) count++;
+      }
       Object[] parentBuckets = ancestor.buckets;
       for (int i = 0; i < parentBuckets.length; ++i) {
         Object parentBucket = parentBuckets[i];
@@ -1109,7 +1150,7 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   @Override
   public boolean isEmpty() {
     // Exact (Map contract). Under read-through resolves the parent; prefer isDefinitelyEmpty().
-    if (this.size != 0) {
+    if (this.size != 0 || this.knownCount != 0) {
       return false;
     }
     TagMap parent = this.parent;
@@ -1128,7 +1169,7 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   public boolean isDefinitelyEmpty() {
     // Cheap: empty iff no level in the chain holds a local entry (ignores shadowing/tombstones).
     for (TagMap level = this; level != null; level = level.parent) {
-      if (level.size != 0) {
+      if (level.size != 0 || level.knownCount != 0) {
         return false;
       }
     }
@@ -1136,10 +1177,10 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   }
 
   public int estimateSize() {
-    // Upper bound: sum of every level's local size, ignoring read-through shadowing/removals.
+    // Upper bound: sum of every level's local size (buckets + dense), ignoring shadowing/removals.
     int total = 0;
     for (TagMap level = this; level != null; level = level.parent) {
-      total += level.size;
+      total += level.size + level.knownCount;
     }
     return total;
   }
@@ -1267,8 +1308,15 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
     return parent.getEntry(tag);
   }
 
-  /** Looks up an entry in this map's own buckets only — no read-through to the parent. */
+  /** Looks up an entry in this map's own storage only (dense then buckets) — no read-through. */
   private Entry getLocalEntry(String tag) {
+    // Known tags live in the dense store; resolve identity and check there first. keyOf is a no-op
+    // (returns 0 -> isStored false) until a resolver is registered, so this is inert in production.
+    long id = KnownTagCodec.keyOf(tag);
+    if (KnownTagCodec.isStored(id)) {
+      Object known = this.knownRawValue(id);
+      return known == null ? null : Entry.newAnyEntry(tag, known);
+    }
     Object[] thisBuckets = this.buckets;
     int hash = TagMap.Entry._hash(tag);
     return findInBucket(thisBuckets[hash & (thisBuckets.length - 1)], hash, tag);
@@ -1316,10 +1364,102 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
     return true;
   }
 
+  // ---- dense known-tag store (see the knownIds field doc)
+  // ----------------------------------------
+
+  /**
+   * Linear scan of the dense store for {@code tagId}, returning its index or -1. Ids are canonical
+   * (the only way one enters is {@link KnownTagCodec#keyOf} or a {@code KnownTags} constant, both
+   * canonical), so a full {@code long} compare is exact and cheaper than extracting globalSerial.
+   */
+  private int knownIndexOf(long tagId) {
+    long[] ids = this.knownIds;
+    int n = this.knownCount;
+    for (int i = 0; i < n; ++i) {
+      if (ids[i] == tagId) return i;
+    }
+    return -1;
+  }
+
+  private void ensureKnownCapacity() {
+    if (this.knownIds == null) {
+      this.knownIds = new long[KNOWN_INIT_CAP];
+      this.knownValues = new Object[KNOWN_INIT_CAP];
+    } else if (this.knownCount == this.knownIds.length) {
+      int newCap = this.knownIds.length << 1;
+      this.knownIds = Arrays.copyOf(this.knownIds, newCap);
+      this.knownValues = Arrays.copyOf(this.knownValues, newCap);
+    }
+  }
+
+  /**
+   * Stores a known tag's value densely (no {@link Entry} alloc). Overwrites in place when present
+   * (returning the prior value materialized as an Entry, per the {@code Map} contract — usually
+   * discarded by {@code set}); otherwise appends, growing x2 as needed.
+   */
+  private Entry putKnownValue(long tagId, Object value) {
+    int i = this.knownIndexOf(tagId);
+    if (i >= 0) {
+      Object prior = this.knownValues[i];
+      this.knownValues[i] = value;
+      return materializeKnown(tagId, prior);
+    }
+    this.ensureKnownCapacity();
+    int slot = this.knownCount++;
+    this.knownIds[slot] = tagId;
+    this.knownValues[slot] = value;
+    return null;
+  }
+
+  /** Raw dense value for {@code tagId}, or {@code null} when absent (no Entry, no boxing). */
+  private Object knownRawValue(long tagId) {
+    int i = this.knownIndexOf(tagId);
+    return i < 0 ? null : this.knownValues[i];
+  }
+
+  /**
+   * Removes a known tag from the dense store (swap-with-last), returning the prior Entry or null.
+   */
+  private Entry removeKnown(long tagId) {
+    int i = this.knownIndexOf(tagId);
+    if (i < 0) return null;
+    Object prior = this.knownValues[i];
+    int last = --this.knownCount;
+    this.knownIds[i] = this.knownIds[last];
+    this.knownValues[i] = this.knownValues[last];
+    this.knownIds[last] = 0L;
+    this.knownValues[last] = null;
+    return materializeKnown(tagId, prior);
+  }
+
+  /** Materializes a transient Entry for a dense (id, value) pair — only on explicit get/iterate. */
+  private static Entry materializeKnown(long tagId, Object value) {
+    return Entry.newAnyEntry(KnownTagCodec.nameOf(tagId), value);
+  }
+
+  /**
+   * Whether an ancestor dense entry ({@code tagId}, declared at level {@code fromAncestor}) is
+   * visible from this leaf under read-through: not shadowed by a nearer level's dense entry of the
+   * same id and not tombstoned by a nearer level. Chain-aware mirror of {@link #parentEntryVisible}
+   * for the dense store. (Disjointness: a known tag never buckets, so no bucket shadow check is
+   * needed.)
+   */
+  private boolean parentDenseVisible(long tagId, TagMap fromAncestor) {
+    String tag = null; // resolved lazily, only if a nearer level carries tombstones
+    for (TagMap nearer = this; nearer != fromAncestor; nearer = nearer.parent) {
+      if (nearer.knownIndexOf(tagId) >= 0) return false; // shadowed by a nearer dense entry
+      if (nearer.removedFromParent != null) {
+        if (tag == null) tag = KnownTagCodec.nameOf(tagId);
+        if (nearer.removedFromParent.contains(tag)) return false; // tombstoned by a nearer level
+      }
+    }
+    return true;
+  }
+
   @Deprecated
   @Override
   public Object put(@Nonnull String tag, Object value) {
-    TagMap.Entry entry = this.getAndSet(Entry.newAnyEntry(tag, value));
+    TagMap.Entry entry = this.getAndSet(tag, value);
     return entry == null ? null : entry.objectValue();
   }
 
@@ -1334,32 +1474,70 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
     }
   }
 
+  // The set(String, ...) family resolves keyOf FIRST: a known tag stores its value densely with no
+  // Entry (boxing the primitive only on that branch) and no parent-fallback lookup (set discards
+  // the prior value); a custom tag takes the typed bucket insert (no boxing for primitives).
   public void set(@Nonnull String tag, @Nonnull Object value) {
-    this.putEntry(Entry.newAnyEntry(tag, value));
+    long id = KnownTagCodec.keyOf(tag);
+    if (KnownTagCodec.isStored(id)) {
+      this.putKnownLocal(id, tag, value);
+    } else {
+      this.putBucketEntry(Entry.newAnyEntry(tag, value));
+    }
   }
 
   public void set(@Nonnull String tag, @Nonnull CharSequence value) {
-    this.putEntry(Entry.newObjectEntry(tag, value));
+    long id = KnownTagCodec.keyOf(tag);
+    if (KnownTagCodec.isStored(id)) {
+      this.putKnownLocal(id, tag, value);
+    } else {
+      this.putBucketEntry(Entry.newObjectEntry(tag, value));
+    }
   }
 
   public void set(@Nonnull String tag, boolean value) {
-    this.putEntry(Entry.newBooleanEntry(tag, value));
+    long id = KnownTagCodec.keyOf(tag);
+    if (KnownTagCodec.isStored(id)) {
+      this.putKnownLocal(id, tag, Boolean.valueOf(value));
+    } else {
+      this.putBucketEntry(Entry.newBooleanEntry(tag, value));
+    }
   }
 
   public void set(@Nonnull String tag, int value) {
-    this.putEntry(Entry.newIntEntry(tag, value));
+    long id = KnownTagCodec.keyOf(tag);
+    if (KnownTagCodec.isStored(id)) {
+      this.putKnownLocal(id, tag, Integer.valueOf(value));
+    } else {
+      this.putBucketEntry(Entry.newIntEntry(tag, value));
+    }
   }
 
   public void set(@Nonnull String tag, long value) {
-    this.putEntry(Entry.newLongEntry(tag, value));
+    long id = KnownTagCodec.keyOf(tag);
+    if (KnownTagCodec.isStored(id)) {
+      this.putKnownLocal(id, tag, Long.valueOf(value));
+    } else {
+      this.putBucketEntry(Entry.newLongEntry(tag, value));
+    }
   }
 
   public void set(@Nonnull String tag, float value) {
-    this.putEntry(Entry.newFloatEntry(tag, value));
+    long id = KnownTagCodec.keyOf(tag);
+    if (KnownTagCodec.isStored(id)) {
+      this.putKnownLocal(id, tag, Float.valueOf(value));
+    } else {
+      this.putBucketEntry(Entry.newFloatEntry(tag, value));
+    }
   }
 
   public void set(@Nonnull String tag, double value) {
-    this.putEntry(Entry.newDoubleEntry(tag, value));
+    long id = KnownTagCodec.keyOf(tag);
+    if (KnownTagCodec.isStored(id)) {
+      this.putKnownLocal(id, tag, Double.valueOf(value));
+    } else {
+      this.putBucketEntry(Entry.newDoubleEntry(tag, value));
+    }
   }
 
   /**
@@ -1372,6 +1550,17 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
     if (newEntry == null) {
       return null;
     }
+    return this.getAndSetWithFallback(newEntry);
+  }
+
+  /**
+   * Local insert (via {@link #putEntry}) plus the read-through parent fallback for the prior
+   * visible value (Map contract). When no local entry was replaced and the key was not tombstoned,
+   * the prior visible value is the nearest ancestor's, resolved through {@link #getEntry} (which
+   * handles both dense known tags and bucketed custom tags). Shared by {@link #getAndSet(Entry)}
+   * and the {@code getAndSet(String, ...)} overloads.
+   */
+  private Entry getAndSetWithFallback(@Nonnull Entry newEntry) {
     // Capture whether the key was tombstoned BEFORE putEntry clears it: a tombstoned key had no
     // visible prior value (it was removed), so getAndSet must report null rather than the parent's.
     boolean wasTombstoned =
@@ -1392,10 +1581,44 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   /**
    * Inserts or replaces a local entry, returning the replaced local Entry (or null if none). Does
    * NOT consult the read-through parent -- the {@code set(...)} methods use this so they never pay
-   * for a prior-value lookup they discard; {@link #getAndSet(Entry)} layers the parent fallback on
-   * top.
+   * for a prior-value lookup they discard; {@link #getAndSetWithFallback} layers the parent
+   * fallback on top. Routes a known tag to the dense store, a custom tag to the hash buckets.
    */
   private Entry putEntry(@Nonnull Entry newEntry) {
+    long id = KnownTagCodec.keyOf(newEntry.tag);
+    if (KnownTagCodec.isStored(id)) {
+      return this.putKnownLocal(id, newEntry.tag, newEntry.objectValue());
+    }
+    return this.putBucketEntry(newEntry);
+  }
+
+  /**
+   * Stores a known tag's value densely with NO Entry retained (the alloc win) and NO parent
+   * fallback — the local-only counterpart used by {@code set} and {@link #putEntry}. Returns the
+   * prior LOCAL dense value materialized as an Entry (Map contract); usually discarded.
+   */
+  private Entry putKnownLocal(long id, String tag, Object value) {
+    this.checkWriteAccess();
+    if (this.removedFromParent != null) {
+      this.removedFromParent.remove(tag);
+    }
+    return this.putKnownValue(id, value);
+  }
+
+  /** Copy-on-write the shared empty buckets to a private array on the first bucket write. */
+  private Object[] materializeBuckets() {
+    Object[] b = this.buckets;
+    if (b == EMPTY_BUCKETS) {
+      b = new Object[1 << 4];
+      this.buckets = b;
+    }
+    return b;
+  }
+
+  /**
+   * Stores an entry in the hash buckets — the unknown/custom-tag local path (no parent fallback).
+   */
+  private Entry putBucketEntry(@Nonnull Entry newEntry) {
     this.checkWriteAccess();
 
     // Re-setting a key clears any read-through tombstone for it (the new value overrides the
@@ -1404,7 +1627,7 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
       this.removedFromParent.remove(newEntry.tag);
     }
 
-    Object[] thisBuckets = this.buckets;
+    Object[] thisBuckets = this.materializeBuckets();
 
     int newHash = newEntry.hash();
     int bucketIndex = newHash & (thisBuckets.length - 1);
@@ -1449,32 +1672,36 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
     return null;
   }
 
+  // Each getAndSet(String, ...) builds the typed Entry (no boxing for primitives) then funnels
+  // through getAndSetWithFallback, which routes a known tag to the dense store (dropping the Entry)
+  // and a custom tag to the buckets, layering the read-through parent fallback on top. The Entry-
+  // free hot path is set(String, ...), which discards the prior value; getAndSet returns it.
   public Entry getAndSet(@Nonnull String tag, Object value) {
-    return this.getAndSet(Entry.newAnyEntry(tag, value));
+    return this.getAndSetWithFallback(Entry.newAnyEntry(tag, value));
   }
 
   public Entry getAndSet(@Nonnull String tag, CharSequence value) {
-    return this.getAndSet(Entry.newObjectEntry(tag, value));
+    return this.getAndSetWithFallback(Entry.newObjectEntry(tag, value));
   }
 
   public TagMap.Entry getAndSet(@Nonnull String tag, boolean value) {
-    return this.getAndSet(Entry.newBooleanEntry(tag, value));
+    return this.getAndSetWithFallback(Entry.newBooleanEntry(tag, value));
   }
 
   public TagMap.Entry getAndSet(@Nonnull String tag, int value) {
-    return this.getAndSet(Entry.newIntEntry(tag, value));
+    return this.getAndSetWithFallback(Entry.newIntEntry(tag, value));
   }
 
   public TagMap.Entry getAndSet(@Nonnull String tag, long value) {
-    return this.getAndSet(Entry.newLongEntry(tag, value));
+    return this.getAndSetWithFallback(Entry.newLongEntry(tag, value));
   }
 
   public TagMap.Entry getAndSet(@Nonnull String tag, float value) {
-    return this.getAndSet(Entry.newFloatEntry(tag, value));
+    return this.getAndSetWithFallback(Entry.newFloatEntry(tag, value));
   }
 
   public TagMap.Entry getAndSet(@Nonnull String tag, double value) {
-    return this.getAndSet(Entry.newDoubleEntry(tag, value));
+    return this.getAndSetWithFallback(Entry.newDoubleEntry(tag, value));
   }
 
   public void putAll(Map<? extends String, ? extends Object> map) {
@@ -1515,7 +1742,9 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
       that.forEach(this, (self, entry) -> self.set(entry));
       return;
     }
-    if (this.size == 0) {
+    // "empty" must consider BOTH local regions — a map with only dense entries has size == 0 but is
+    // not empty, and putAllIntoEmptyMap would clobber its dense store.
+    if (this.size == 0 && this.knownCount == 0) {
       this.putAllIntoEmptyMap(that);
     } else {
       this.putAllMerge(that);
@@ -1523,7 +1752,9 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   }
 
   private void putAllMerge(TagMap that) {
-    Object[] thisBuckets = this.buckets;
+    // COW our buckets only if the source has bucket entries to merge in; otherwise the loop below
+    // writes nothing and the shared empty buckets stay shared.
+    Object[] thisBuckets = (that.size > 0) ? this.materializeBuckets() : this.buckets;
     Object[] thatBuckets = that.buckets;
 
     // Since TagMap-s don't support expansion, buckets are perfectly aligned
@@ -1634,33 +1865,49 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
         }
       }
     }
+
+    // merge the source's dense known-tag entries; incoming clobbers existing (same as buckets)
+    for (int i = 0; i < that.knownCount; ++i) {
+      this.putKnownValue(that.knownIds[i], that.knownValues[i]);
+    }
   }
 
   /*
    * Specially optimized version of putAll for the common case of destination map being empty
    */
   private void putAllIntoEmptyMap(TagMap that) {
-    Object[] thisBuckets = this.buckets;
-    Object[] thatBuckets = that.buckets;
+    // Only copy buckets (and COW ours) when the source actually has bucket entries; an all-known
+    // source leaves us on the shared empty buckets.
+    if (that.size > 0) {
+      Object[] thisBuckets = this.materializeBuckets();
+      Object[] thatBuckets = that.buckets;
 
-    // Check against both thisBuckets.length && thatBuckets.length is to help the JIT do bound check
-    // elimination
-    for (int i = 0; i < thisBuckets.length && i < thatBuckets.length; ++i) {
-      Object thatBucket = thatBuckets[i];
+      // Check against both thisBuckets.length && thatBuckets.length is to help the JIT do bound
+      // check elimination
+      for (int i = 0; i < thisBuckets.length && i < thatBuckets.length; ++i) {
+        Object thatBucket = thatBuckets[i];
 
-      // faster to explicitly null check first, then do instanceof
-      if (thatBucket == null) {
-        // do nothing
-      } else if (thatBucket instanceof BucketGroup) {
-        // if it is a BucketGroup, then need to clone
-        BucketGroup thatGroup = (BucketGroup) thatBucket;
+        // faster to explicitly null check first, then do instanceof
+        if (thatBucket == null) {
+          // do nothing
+        } else if (thatBucket instanceof BucketGroup) {
+          // if it is a BucketGroup, then need to clone
+          BucketGroup thatGroup = (BucketGroup) thatBucket;
 
-        thisBuckets[i] = thatGroup.cloneChain();
-      } else { // if ( thatBucket instanceof Entry )
-        thisBuckets[i] = thatBucket;
+          thisBuckets[i] = thatGroup.cloneChain();
+        } else { // if ( thatBucket instanceof Entry )
+          thisBuckets[i] = thatBucket;
+        }
       }
+      this.size = that.size;
     }
-    this.size = that.size;
+
+    // clone the dense known-tag store (values are immutable boxes/objects -> safe to share refs)
+    if (that.knownCount > 0) {
+      this.knownIds = Arrays.copyOf(that.knownIds, that.knownIds.length);
+      this.knownValues = Arrays.copyOf(that.knownValues, that.knownValues.length);
+      this.knownCount = that.knownCount;
+    }
   }
 
   public void fillMap(Map<? super String, Object> map) {
@@ -1679,6 +1926,9 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
         thisGroup.fillMapFromChain(map);
       }
     }
+    for (int i = 0; i < this.knownCount; ++i) {
+      map.put(KnownTagCodec.nameOf(this.knownIds[i]), this.knownValues[i]);
+    }
   }
 
   public void fillStringMap(Map<? super String, ? super String> stringMap) {
@@ -1696,6 +1946,11 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
 
         thisGroup.fillStringMapFromChain(stringMap);
       }
+    }
+    for (int i = 0; i < this.knownCount; ++i) {
+      stringMap.put(
+          KnownTagCodec.nameOf(this.knownIds[i]),
+          TagValueConversions.toString(this.knownValues[i]));
     }
   }
 
@@ -1738,8 +1993,13 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
     return localRemoved;
   }
 
-  /** Removes an entry from this map's own buckets only — no parent/tombstone handling. */
+  /** Removes an entry from this map's own storage only — no parent/tombstone handling. */
   private Entry removeLocal(String tag) {
+    long id = KnownTagCodec.keyOf(tag);
+    if (KnownTagCodec.isStored(id)) {
+      return this.removeKnown(id);
+    }
+
     Object[] thisBuckets = this.buckets;
 
     int hash = TagMap.Entry._hash(tag);
@@ -1807,6 +2067,15 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
 
   @Override
   public void forEach(Consumer<? super TagMap.EntryReader> consumer) {
+    // local dense known tags via a reused flyweight (no per-entry Entry alloc — the serialize win)
+    if (this.knownCount > 0) {
+      EntryReadingHelper reader = new EntryReadingHelper();
+      for (int i = 0; i < this.knownCount; ++i) {
+        reader.set(KnownTagCodec.nameOf(this.knownIds[i]), this.knownValues[i]);
+        consumer.accept(reader);
+      }
+    }
+
     Object[] thisBuckets = this.buckets;
 
     for (int i = 0; i < thisBuckets.length; ++i) {
@@ -1832,8 +2101,23 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
 
   private void forEachParent(Consumer<? super TagMap.EntryReader> consumer) {
     // Walk the ancestor chain, nearest first. Each entry is emitted once, by the nearest level that
-    // defines its key, when not shadowed by a nearer level and not tombstoned.
+    // defines its key, when not shadowed by a nearer level and not tombstoned. Dense known tags are
+    // emitted via a reused flyweight (no per-entry Entry alloc — the serialize win).
+    EntryReadingHelper reader = null;
     for (TagMap ancestor = this.parent; ancestor != null; ancestor = ancestor.parent) {
+      long[] ancestorIds = ancestor.knownIds;
+      int ancestorKnownCount = ancestor.knownCount;
+      if (ancestorKnownCount > 0) {
+        Object[] ancestorValues = ancestor.knownValues;
+        if (reader == null) reader = new EntryReadingHelper();
+        for (int i = 0; i < ancestorKnownCount; ++i) {
+          long id = ancestorIds[i];
+          if (this.parentDenseVisible(id, ancestor)) {
+            reader.set(KnownTagCodec.nameOf(id), ancestorValues[i]);
+            consumer.accept(reader);
+          }
+        }
+      }
       Object[] parentBuckets = ancestor.buckets;
       for (int i = 0; i < parentBuckets.length; ++i) {
         Object parentBucket = parentBuckets[i];
@@ -1856,6 +2140,14 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   }
 
   public <T> void forEach(T thisObj, BiConsumer<T, ? super TagMap.EntryReader> consumer) {
+    if (this.knownCount > 0) {
+      EntryReadingHelper reader = new EntryReadingHelper();
+      for (int i = 0; i < this.knownCount; ++i) {
+        reader.set(KnownTagCodec.nameOf(this.knownIds[i]), this.knownValues[i]);
+        consumer.accept(thisObj, reader);
+      }
+    }
+
     Object[] thisBuckets = this.buckets;
 
     for (int i = 0; i < thisBuckets.length; ++i) {
@@ -1879,7 +2171,21 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   }
 
   private <T> void forEachParent(T thisObj, BiConsumer<T, ? super TagMap.EntryReader> consumer) {
+    EntryReadingHelper reader = null;
     for (TagMap ancestor = this.parent; ancestor != null; ancestor = ancestor.parent) {
+      int ancestorKnownCount = ancestor.knownCount;
+      if (ancestorKnownCount > 0) {
+        long[] ancestorIds = ancestor.knownIds;
+        Object[] ancestorValues = ancestor.knownValues;
+        if (reader == null) reader = new EntryReadingHelper();
+        for (int i = 0; i < ancestorKnownCount; ++i) {
+          long id = ancestorIds[i];
+          if (this.parentDenseVisible(id, ancestor)) {
+            reader.set(KnownTagCodec.nameOf(id), ancestorValues[i]);
+            consumer.accept(thisObj, reader);
+          }
+        }
+      }
       Object[] parentBuckets = ancestor.buckets;
       for (int i = 0; i < parentBuckets.length; ++i) {
         Object parentBucket = parentBuckets[i];
@@ -1904,6 +2210,14 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
 
   public <T, U> void forEach(
       T thisObj, U otherObj, TriConsumer<T, U, ? super TagMap.EntryReader> consumer) {
+    if (this.knownCount > 0) {
+      EntryReadingHelper reader = new EntryReadingHelper();
+      for (int i = 0; i < this.knownCount; ++i) {
+        reader.set(KnownTagCodec.nameOf(this.knownIds[i]), this.knownValues[i]);
+        consumer.accept(thisObj, otherObj, reader);
+      }
+    }
+
     Object[] thisBuckets = this.buckets;
 
     for (int i = 0; i < thisBuckets.length; ++i) {
@@ -1928,7 +2242,21 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
 
   private <T, U> void forEachParent(
       T thisObj, U otherObj, TriConsumer<T, U, ? super TagMap.EntryReader> consumer) {
+    EntryReadingHelper reader = null;
     for (TagMap ancestor = this.parent; ancestor != null; ancestor = ancestor.parent) {
+      int ancestorKnownCount = ancestor.knownCount;
+      if (ancestorKnownCount > 0) {
+        long[] ancestorIds = ancestor.knownIds;
+        Object[] ancestorValues = ancestor.knownValues;
+        if (reader == null) reader = new EntryReadingHelper();
+        for (int i = 0; i < ancestorKnownCount; ++i) {
+          long id = ancestorIds[i];
+          if (this.parentDenseVisible(id, ancestor)) {
+            reader.set(KnownTagCodec.nameOf(id), ancestorValues[i]);
+            consumer.accept(thisObj, otherObj, reader);
+          }
+        }
+      }
       Object[] parentBuckets = ancestor.buckets;
       for (int i = 0; i < parentBuckets.length; ++i) {
         Object parentBucket = parentBuckets[i];
@@ -1955,13 +2283,17 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   public void clear() {
     this.checkWriteAccess();
 
-    Arrays.fill(this.buckets, null);
+    // Drop the private bucket array back to the shared empty sentinel (also avoids mutating it).
+    this.buckets = EMPTY_BUCKETS;
     this.size = 0;
     // clear() removes ALL mappings, including any inherited through read-through. Detaching the
     // parent (rather than tombstoning every inherited key) is simpler and cheaper, and leaves an
     // empty, parent-less map. Detach is one-way -- the parent is never re-pointed.
     this.parent = null;
     this.removedFromParent = null;
+    this.knownIds = null;
+    this.knownValues = null;
+    this.knownCount = 0;
   }
 
   public TagMap freeze() {
@@ -2011,6 +2343,20 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
             if (expectedBucket != i) {
               throw new IllegalStateException("incorrect bucket");
             }
+          }
+        }
+      }
+    }
+
+    // dense store: ids must be unique (no tag stored twice) and the count within array bounds.
+    if (this.knownCount > 0) {
+      if (this.knownIds == null || this.knownCount > this.knownIds.length) {
+        throw new IllegalStateException("incorrect known count");
+      }
+      for (int i = 0; i < this.knownCount; ++i) {
+        for (int j = i + 1; j < this.knownCount; ++j) {
+          if (this.knownIds[i] == this.knownIds[j]) {
+            throw new IllegalStateException("duplicate known id");
           }
         }
       }
@@ -2146,12 +2492,22 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
     private TagMap level;
     private Object[] buckets;
 
-    private Entry nextEntry;
+    // Currency is EntryReader, not Entry: a BUCKET entry is its own (real, retain-safe) Entry, but
+    // a
+    // DENSE entry is emitted via the reused denseReader flyweight (alloc-free, "use now"). This is
+    // the contract of TagMap.iterator()/keySet()/values(). entrySet() (Iterator<Map.Entry>) sits on
+    // top and calls .entry() per next() to get a real retain-safe Entry (see EntriesIterator).
+    private EntryReader nextEntry;
+    private EntryReadingHelper denseReader; // lazily created on the first dense emit
 
     private int bucketIndex = -1;
 
     private BucketGroup group = null;
     private int groupIndex = 0;
+
+    // dense-store cursor for the current level's known tags; advance() resets it when it moves to
+    // the next ancestor level (read-through union).
+    private int knownIndex = 0;
 
     IteratorBase(TagMap map) {
       this.map = map;
@@ -2166,9 +2522,9 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
       return this.nextEntry != null;
     }
 
-    final Entry nextEntryOrThrowNoSuchElement() {
+    final EntryReader nextEntryOrThrowNoSuchElement() {
       if (this.nextEntry != null) {
-        Entry nextEntry = this.nextEntry;
+        EntryReader nextEntry = this.nextEntry;
         this.nextEntry = null;
         return nextEntry;
       }
@@ -2180,9 +2536,9 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
       }
     }
 
-    final Entry nextEntryOrNull() {
+    final EntryReader nextEntryOrNull() {
       if (this.nextEntry != null) {
-        Entry nextEntry = this.nextEntry;
+        EntryReader nextEntry = this.nextEntry;
         this.nextEntry = null;
         return nextEntry;
       }
@@ -2190,8 +2546,22 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
       return this.hasNext() ? this.nextEntry : null;
     }
 
-    private final Entry advance() {
+    private final EntryReader advance() {
       while (true) {
+        // phase 1: drain the current level's dense known tags before its buckets. Leaf dense always
+        // emits; ancestor dense only if visible from the leaf (not shadowed by a nearer dense entry
+        // and not tombstoned). Emitted via the reused denseReader flyweight -- NO per-entry Entry
+        // alloc (the read/serialize alloc win).
+        if (this.knownIndex < this.level.knownCount) {
+          int i = this.knownIndex++;
+          long id = this.level.knownIds[i];
+          if (this.level == this.map || this.map.parentDenseVisible(id, this.level)) {
+            return this.emitDense(id, this.level.knownValues[i]);
+          }
+          continue; // ancestor dense entry shadowed/tombstoned -> skip
+        }
+
+        // phase 2: the current level's buckets.
         Entry tagEntry = this.rawAdvance();
         if (tagEntry != null) {
           // leaf entries emit as-is; ancestor entries only if visible from the leaf -- not shadowed
@@ -2202,9 +2572,12 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
           continue; // ancestor entry shadowed/tombstoned -> skip
         }
 
-        // current level exhausted; advance to the next ancestor's buckets (read-through union)
+        // current level exhausted; advance to the next ancestor (read-through union), resetting
+        // both
+        // the per-level dense cursor and the bucket cursor for the new level.
         if (this.level.parent != null) {
           this.level = this.level.parent;
+          this.knownIndex = 0;
           this.buckets = this.level.buckets;
           this.bucketIndex = -1;
           this.group = null;
@@ -2213,6 +2586,16 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
         }
         return null;
       }
+    }
+
+    /** Sets and returns the reused dense flyweight (lazily created); "use now", do not retain. */
+    private EntryReader emitDense(long tagId, Object value) {
+      EntryReadingHelper reader = this.denseReader;
+      if (reader == null) {
+        reader = this.denseReader = new EntryReadingHelper();
+      }
+      reader.set(KnownTagCodec.nameOf(tagId), value);
+      return reader;
     }
 
     /** Next raw entry in the current bucket array, ignoring shadowing/tombstones. */
@@ -2744,9 +3127,26 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
 
     @Override
     public Iterator<Map.Entry<String, Object>> iterator() {
-      @SuppressWarnings({"rawtypes", "unchecked"})
-      Iterator<Map.Entry<String, Object>> iter = (Iterator) this.map.iterator();
-      return iter;
+      return new EntriesIterator(this.map);
+    }
+  }
+
+  /**
+   * entrySet() yields real, retain-safe {@code Map.Entry} objects. It sits on top of the
+   * EntryReader iterator and materializes each via {@code .entry()}: a bucket entry's reader IS the
+   * real stored Entry (returns {@code this}, free); a dense entry's flyweight materializes a fresh
+   * Entry. Deliberately NOT alloc-optimized for dense — bulk reads use {@code forEach}/EntryReader,
+   * and manual instrumentation does point get/set, not bulk entrySet iteration.
+   */
+  static final class EntriesIterator extends IteratorBase
+      implements Iterator<Map.Entry<String, Object>> {
+    EntriesIterator(TagMap map) {
+      super(map);
+    }
+
+    @Override
+    public Map.Entry<String, Object> next() {
+      return this.nextEntryOrThrowNoSuchElement().entry();
     }
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/TagMap.java
+++ b/internal-api/src/main/java/datadog/trace/api/TagMap.java
@@ -48,10 +48,9 @@ import javax.annotation.Nullable;
  */
 public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryReader> {
   /** Immutable empty TagMap - similar to {@link Collections#emptyMap()} */
-  // Frozen view over a length-1 array: bucket masking needs a power-of-two array length (size 0
-  // would fail with ArrayIndexOutOfBoundsException, size 1 works), and the private constructor
-  // reads no statics, so this is safe to build directly during TagMap's <clinit>.
-  public static final TagMap EMPTY = new TagMap(new Object[1], 0);
+  // Frozen view over a power-of-two array; the private constructor reads no statics, so this is
+  // safe to build directly during TagMap's <clinit>.
+  public static final TagMap EMPTY = new TagMap(new Object[1 << 4], 0);
 
   /** Creates a new mutable TagMap that contains the contents of <code>map</code> */
   public static final TagMap fromMap(@Nonnull Map<String, ?> map) {
@@ -1023,9 +1022,43 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
    * removed from the collision chain.
    */
 
-  private final Object[] buckets;
+  // Shared immutable empty buckets (all null, length 16). Every map points here until its first
+  // custom-tag write copies-on-write to a private array (materializeBuckets), so an all-known /
+  // known-heavy map (e.g. the trace-tier read-through parent) allocates ZERO buckets. Length is
+  // always 16, so reads need no null guard and read-through bucket alignment (hash & 15) holds.
+  private static final Object[] EMPTY_BUCKETS = new Object[1 << 4];
+
+  private Object[] buckets;
   private int size;
   private boolean frozen;
+
+  /**
+   * Dense known-tag store (dense-tagmap-design §5). Values for KNOWN tags (those {@link
+   * KnownTagCodec#keyOf} resolves to a stored id) live in these INSERTION-ORDERED parallel arrays
+   * with NO per-tag {@link Entry} object — the allocation win. Lazily allocated on the first
+   * known-tag write ({@code null} until then, so all-unknown maps pay nothing) and grown x2 from
+   * {@link #KNOWN_INIT_CAP}. Matched by globalSerial via a linear scan ({@link #knownIndexOf});
+   * reads aren't hot, so O(knownCount) is fine and positional indexing is deferred. Dormant until a
+   * resolver is registered: {@code keyOf} returns 0, so nothing routes here and production is
+   * byte-identical.
+   *
+   * <p>Disjoint from {@link #buckets} by construction: known-ness is global ({@code keyOf} is
+   * deterministic), so a known tag is ALWAYS dense and never bucketed, and vice-versa. That
+   * disjointness keeps read-through shadow checks within-region — an ancestor dense entry can only
+   * be shadowed by a nearer level's dense entry of the same id, an ancestor bucket entry only by a
+   * nearer level's bucket entry — so the bucket read-through chain walk is unchanged and the dense
+   * one mirrors it ({@link #parentDenseVisible}).
+   *
+   * <p>{@link #size} counts bucket entries only; {@link #knownCount} counts dense entries; the
+   * local total is {@code size + knownCount}.
+   */
+  private long[] knownIds;
+
+  private Object[] knownValues;
+  private int knownCount;
+
+  private static final int KNOWN_INIT_CAP =
+      12; // generous per-type max stopgap; exact per-type sizing comes with the tag registry
 
   /**
    * Optional frozen parent for read-through. When non-null, reads that miss the local buckets fall
@@ -1058,8 +1091,9 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
    * optimizations can treat it as fixed.
    */
   private TagMap(TagMap parent) {
-    // needs to be a power of 2 for bucket masking calculation to work as intended
-    this.buckets = new Object[1 << 4];
+    // Start on the shared empty buckets; materializeBuckets() COWs to a private power-of-two array
+    // on the first custom-tag write. All-known maps never allocate buckets.
+    this.buckets = EMPTY_BUCKETS;
     this.size = 0;
     this.frozen = false;
     this.parent = parent;
@@ -1076,8 +1110,9 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   @Override
   public int size() {
     // Exact (Map contract). Under read-through resolves the union; prefer estimateSize() for hints.
+    int local = this.size + this.knownCount; // buckets + dense
     TagMap parent = this.parent;
-    return parent == null ? this.size : this.size + this.visibleParentCount();
+    return parent == null ? local : local + this.visibleParentCount();
   }
 
   /**
@@ -1087,6 +1122,12 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   private int visibleParentCount() {
     int count = 0;
     for (TagMap ancestor = this.parent; ancestor != null; ancestor = ancestor.parent) {
+      // dense entries at this ancestor not shadowed/tombstoned by a nearer level
+      long[] ancestorIds = ancestor.knownIds;
+      int ancestorKnownCount = ancestor.knownCount;
+      for (int i = 0; i < ancestorKnownCount; ++i) {
+        if (this.parentDenseVisible(ancestorIds[i], ancestor)) count++;
+      }
       Object[] parentBuckets = ancestor.buckets;
       for (int i = 0; i < parentBuckets.length; ++i) {
         Object parentBucket = parentBuckets[i];
@@ -1110,7 +1151,7 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   @Override
   public boolean isEmpty() {
     // Exact (Map contract). Under read-through resolves the parent; prefer isDefinitelyEmpty().
-    if (this.size != 0) {
+    if (this.size != 0 || this.knownCount != 0) {
       return false;
     }
     TagMap parent = this.parent;
@@ -1131,7 +1172,7 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   public boolean isDefinitelyEmpty() {
     // Cheap: empty iff no level in the chain holds a local entry (ignores shadowing/tombstones).
     for (TagMap level = this; level != null; level = level.parent) {
-      if (level.size != 0) {
+      if (level.size != 0 || level.knownCount != 0) {
         return false;
       }
     }
@@ -1139,10 +1180,10 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   }
 
   public int estimateSize() {
-    // Upper bound: sum of every level's local size, ignoring read-through shadowing/removals.
+    // Upper bound: sum of every level's local size (buckets + dense), ignoring shadowing/removals.
     int total = 0;
     for (TagMap level = this; level != null; level = level.parent) {
-      total += level.size;
+      total += level.size + level.knownCount;
     }
     return total;
   }
@@ -1270,8 +1311,15 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
     return parent.getEntry(tag);
   }
 
-  /** Looks up an entry in this map's own buckets only — no read-through to the parent. */
+  /** Looks up an entry in this map's own storage only (dense then buckets) — no read-through. */
   private Entry getLocalEntry(String tag) {
+    // Known tags live in the dense store; resolve identity and check there first. keyOf is a no-op
+    // (returns 0 -> isStored false) until a resolver is registered, so this is inert in production.
+    long id = KnownTagCodec.DENSE_STORE ? KnownTagCodec.keyOf(tag) : 0L;
+    if (KnownTagCodec.isStored(id)) {
+      Object known = this.knownRawValue(id);
+      return known == null ? null : Entry.newAnyEntry(tag, known);
+    }
     Object[] thisBuckets = this.buckets;
     int hash = TagMap.Entry._hash(tag);
     return findInBucket(thisBuckets[hash & (thisBuckets.length - 1)], hash, tag);
@@ -1319,10 +1367,102 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
     return true;
   }
 
+  // ---- dense known-tag store (see the knownIds field doc)
+  // ----------------------------------------
+
+  /**
+   * Linear scan of the dense store for {@code tagId}, returning its index or -1. Ids are canonical
+   * (the only way one enters is {@link KnownTagCodec#keyOf} or a {@code KnownTags} constant, both
+   * canonical), so a full {@code long} compare is exact and cheaper than extracting globalSerial.
+   */
+  private int knownIndexOf(long tagId) {
+    long[] ids = this.knownIds;
+    int n = this.knownCount;
+    for (int i = 0; i < n; ++i) {
+      if (ids[i] == tagId) return i;
+    }
+    return -1;
+  }
+
+  private void ensureKnownCapacity() {
+    if (this.knownIds == null) {
+      this.knownIds = new long[KNOWN_INIT_CAP];
+      this.knownValues = new Object[KNOWN_INIT_CAP];
+    } else if (this.knownCount == this.knownIds.length) {
+      int newCap = this.knownIds.length << 1;
+      this.knownIds = Arrays.copyOf(this.knownIds, newCap);
+      this.knownValues = Arrays.copyOf(this.knownValues, newCap);
+    }
+  }
+
+  /**
+   * Stores a known tag's value densely (no {@link Entry} alloc). Overwrites in place when present
+   * (returning the prior value materialized as an Entry, per the {@code Map} contract — usually
+   * discarded by {@code set}); otherwise appends, growing x2 as needed.
+   */
+  private Entry putKnownValue(long tagId, Object value) {
+    int i = this.knownIndexOf(tagId);
+    if (i >= 0) {
+      Object prior = this.knownValues[i];
+      this.knownValues[i] = value;
+      return materializeKnown(tagId, prior);
+    }
+    this.ensureKnownCapacity();
+    int slot = this.knownCount++;
+    this.knownIds[slot] = tagId;
+    this.knownValues[slot] = value;
+    return null;
+  }
+
+  /** Raw dense value for {@code tagId}, or {@code null} when absent (no Entry, no boxing). */
+  private Object knownRawValue(long tagId) {
+    int i = this.knownIndexOf(tagId);
+    return i < 0 ? null : this.knownValues[i];
+  }
+
+  /**
+   * Removes a known tag from the dense store (swap-with-last), returning the prior Entry or null.
+   */
+  private Entry removeKnown(long tagId) {
+    int i = this.knownIndexOf(tagId);
+    if (i < 0) return null;
+    Object prior = this.knownValues[i];
+    int last = --this.knownCount;
+    this.knownIds[i] = this.knownIds[last];
+    this.knownValues[i] = this.knownValues[last];
+    this.knownIds[last] = 0L;
+    this.knownValues[last] = null;
+    return materializeKnown(tagId, prior);
+  }
+
+  /** Materializes a transient Entry for a dense (id, value) pair — only on explicit get/iterate. */
+  private static Entry materializeKnown(long tagId, Object value) {
+    return Entry.newAnyEntry(KnownTagCodec.nameOf(tagId), value);
+  }
+
+  /**
+   * Whether an ancestor dense entry ({@code tagId}, declared at level {@code fromAncestor}) is
+   * visible from this leaf under read-through: not shadowed by a nearer level's dense entry of the
+   * same id and not tombstoned by a nearer level. Chain-aware mirror of {@link #parentEntryVisible}
+   * for the dense store. (Disjointness: a known tag never buckets, so no bucket shadow check is
+   * needed.)
+   */
+  private boolean parentDenseVisible(long tagId, TagMap fromAncestor) {
+    String tag = null; // resolved lazily, only if a nearer level carries tombstones
+    for (TagMap nearer = this; nearer != fromAncestor; nearer = nearer.parent) {
+      if (nearer.knownIndexOf(tagId) >= 0) return false; // shadowed by a nearer dense entry
+      if (nearer.removedFromParent != null) {
+        if (tag == null) tag = KnownTagCodec.nameOf(tagId);
+        if (nearer.removedFromParent.contains(tag)) return false; // tombstoned by a nearer level
+      }
+    }
+    return true;
+  }
+
   @Deprecated
   @Override
   public Object put(@Nonnull String tag, Object value) {
-    TagMap.Entry entry = this.getAndSet(Entry.newAnyEntry(tag, value));
+    TagMap.Entry entry = this.getAndSet(tag, value);
     return entry == null ? null : entry.objectValue();
   }
 
@@ -1337,32 +1477,70 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
     }
   }
 
+  // The set(String, ...) family resolves keyOf FIRST: a known tag stores its value densely with no
+  // Entry (boxing the primitive only on that branch) and no parent-fallback lookup (set discards
+  // the prior value); a custom tag takes the typed bucket insert (no boxing for primitives).
   public void set(@Nonnull String tag, @Nonnull Object value) {
-    this.putEntry(Entry.newAnyEntry(tag, value));
+    long id = KnownTagCodec.DENSE_STORE ? KnownTagCodec.keyOf(tag) : 0L;
+    if (KnownTagCodec.isStored(id)) {
+      this.putKnownLocal(id, tag, value);
+    } else {
+      this.putBucketEntry(Entry.newAnyEntry(tag, value));
+    }
   }
 
   public void set(@Nonnull String tag, @Nonnull CharSequence value) {
-    this.putEntry(Entry.newObjectEntry(tag, value));
+    long id = KnownTagCodec.DENSE_STORE ? KnownTagCodec.keyOf(tag) : 0L;
+    if (KnownTagCodec.isStored(id)) {
+      this.putKnownLocal(id, tag, value);
+    } else {
+      this.putBucketEntry(Entry.newObjectEntry(tag, value));
+    }
   }
 
   public void set(@Nonnull String tag, boolean value) {
-    this.putEntry(Entry.newBooleanEntry(tag, value));
+    long id = KnownTagCodec.DENSE_STORE ? KnownTagCodec.keyOf(tag) : 0L;
+    if (KnownTagCodec.isStored(id)) {
+      this.putKnownLocal(id, tag, Boolean.valueOf(value));
+    } else {
+      this.putBucketEntry(Entry.newBooleanEntry(tag, value));
+    }
   }
 
   public void set(@Nonnull String tag, int value) {
-    this.putEntry(Entry.newIntEntry(tag, value));
+    long id = KnownTagCodec.DENSE_STORE ? KnownTagCodec.keyOf(tag) : 0L;
+    if (KnownTagCodec.isStored(id)) {
+      this.putKnownLocal(id, tag, Integer.valueOf(value));
+    } else {
+      this.putBucketEntry(Entry.newIntEntry(tag, value));
+    }
   }
 
   public void set(@Nonnull String tag, long value) {
-    this.putEntry(Entry.newLongEntry(tag, value));
+    long id = KnownTagCodec.DENSE_STORE ? KnownTagCodec.keyOf(tag) : 0L;
+    if (KnownTagCodec.isStored(id)) {
+      this.putKnownLocal(id, tag, Long.valueOf(value));
+    } else {
+      this.putBucketEntry(Entry.newLongEntry(tag, value));
+    }
   }
 
   public void set(@Nonnull String tag, float value) {
-    this.putEntry(Entry.newFloatEntry(tag, value));
+    long id = KnownTagCodec.DENSE_STORE ? KnownTagCodec.keyOf(tag) : 0L;
+    if (KnownTagCodec.isStored(id)) {
+      this.putKnownLocal(id, tag, Float.valueOf(value));
+    } else {
+      this.putBucketEntry(Entry.newFloatEntry(tag, value));
+    }
   }
 
   public void set(@Nonnull String tag, double value) {
-    this.putEntry(Entry.newDoubleEntry(tag, value));
+    long id = KnownTagCodec.DENSE_STORE ? KnownTagCodec.keyOf(tag) : 0L;
+    if (KnownTagCodec.isStored(id)) {
+      this.putKnownLocal(id, tag, Double.valueOf(value));
+    } else {
+      this.putBucketEntry(Entry.newDoubleEntry(tag, value));
+    }
   }
 
   /**
@@ -1375,6 +1553,17 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
     if (newEntry == null) {
       return null;
     }
+    return this.getAndSetWithFallback(newEntry);
+  }
+
+  /**
+   * Local insert (via {@link #putEntry}) plus the read-through parent fallback for the prior
+   * visible value (Map contract). When no local entry was replaced and the key was not tombstoned,
+   * the prior visible value is the nearest ancestor's, resolved through {@link #getEntry} (which
+   * handles both dense known tags and bucketed custom tags). Shared by {@link #getAndSet(Entry)}
+   * and the {@code getAndSet(String, ...)} overloads.
+   */
+  private Entry getAndSetWithFallback(@Nonnull Entry newEntry) {
     // Capture whether the key was tombstoned BEFORE putEntry clears it: a tombstoned key had no
     // visible prior value (it was removed), so getAndSet must report null rather than the parent's.
     boolean wasTombstoned =
@@ -1395,10 +1584,44 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   /**
    * Inserts or replaces a local entry, returning the replaced local Entry (or null if none). Does
    * NOT consult the read-through parent -- the {@code set(...)} methods use this so they never pay
-   * for a prior-value lookup they discard; {@link #getAndSet(Entry)} layers the parent fallback on
-   * top.
+   * for a prior-value lookup they discard; {@link #getAndSetWithFallback} layers the parent
+   * fallback on top. Routes a known tag to the dense store, a custom tag to the hash buckets.
    */
   private Entry putEntry(@Nonnull Entry newEntry) {
+    long id = KnownTagCodec.DENSE_STORE ? KnownTagCodec.keyOf(newEntry.tag) : 0L;
+    if (KnownTagCodec.isStored(id)) {
+      return this.putKnownLocal(id, newEntry.tag, newEntry.objectValue());
+    }
+    return this.putBucketEntry(newEntry);
+  }
+
+  /**
+   * Stores a known tag's value densely with NO Entry retained (the alloc win) and NO parent
+   * fallback — the local-only counterpart used by {@code set} and {@link #putEntry}. Returns the
+   * prior LOCAL dense value materialized as an Entry (Map contract); usually discarded.
+   */
+  private Entry putKnownLocal(long id, String tag, Object value) {
+    this.checkWriteAccess();
+    if (this.removedFromParent != null) {
+      this.removedFromParent.remove(tag);
+    }
+    return this.putKnownValue(id, value);
+  }
+
+  /** Copy-on-write the shared empty buckets to a private array on the first bucket write. */
+  private Object[] materializeBuckets() {
+    Object[] b = this.buckets;
+    if (b == EMPTY_BUCKETS) {
+      b = new Object[1 << 4];
+      this.buckets = b;
+    }
+    return b;
+  }
+
+  /**
+   * Stores an entry in the hash buckets — the unknown/custom-tag local path (no parent fallback).
+   */
+  private Entry putBucketEntry(@Nonnull Entry newEntry) {
     this.checkWriteAccess();
 
     // Re-setting a key clears any read-through tombstone for it (the new value overrides the
@@ -1407,7 +1630,7 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
       this.removedFromParent.remove(newEntry.tag);
     }
 
-    Object[] thisBuckets = this.buckets;
+    Object[] thisBuckets = this.materializeBuckets();
 
     int newHash = newEntry.hash();
     int bucketIndex = newHash & (thisBuckets.length - 1);
@@ -1452,32 +1675,36 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
     return null;
   }
 
+  // Each getAndSet(String, ...) builds the typed Entry (no boxing for primitives) then funnels
+  // through getAndSetWithFallback, which routes a known tag to the dense store (dropping the Entry)
+  // and a custom tag to the buckets, layering the read-through parent fallback on top. The Entry-
+  // free hot path is set(String, ...), which discards the prior value; getAndSet returns it.
   public Entry getAndSet(@Nonnull String tag, Object value) {
-    return this.getAndSet(Entry.newAnyEntry(tag, value));
+    return this.getAndSetWithFallback(Entry.newAnyEntry(tag, value));
   }
 
   public Entry getAndSet(@Nonnull String tag, CharSequence value) {
-    return this.getAndSet(Entry.newObjectEntry(tag, value));
+    return this.getAndSetWithFallback(Entry.newObjectEntry(tag, value));
   }
 
   public TagMap.Entry getAndSet(@Nonnull String tag, boolean value) {
-    return this.getAndSet(Entry.newBooleanEntry(tag, value));
+    return this.getAndSetWithFallback(Entry.newBooleanEntry(tag, value));
   }
 
   public TagMap.Entry getAndSet(@Nonnull String tag, int value) {
-    return this.getAndSet(Entry.newIntEntry(tag, value));
+    return this.getAndSetWithFallback(Entry.newIntEntry(tag, value));
   }
 
   public TagMap.Entry getAndSet(@Nonnull String tag, long value) {
-    return this.getAndSet(Entry.newLongEntry(tag, value));
+    return this.getAndSetWithFallback(Entry.newLongEntry(tag, value));
   }
 
   public TagMap.Entry getAndSet(@Nonnull String tag, float value) {
-    return this.getAndSet(Entry.newFloatEntry(tag, value));
+    return this.getAndSetWithFallback(Entry.newFloatEntry(tag, value));
   }
 
   public TagMap.Entry getAndSet(@Nonnull String tag, double value) {
-    return this.getAndSet(Entry.newDoubleEntry(tag, value));
+    return this.getAndSetWithFallback(Entry.newDoubleEntry(tag, value));
   }
 
   public void putAll(Map<? extends String, ? extends Object> map) {
@@ -1518,7 +1745,9 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
       that.forEach(this, (self, entry) -> self.set(entry));
       return;
     }
-    if (this.size == 0) {
+    // "empty" must consider BOTH local regions — a map with only dense entries has size == 0 but is
+    // not empty, and putAllIntoEmptyMap would clobber its dense store.
+    if (this.size == 0 && this.knownCount == 0) {
       this.putAllIntoEmptyMap(that);
     } else {
       this.putAllMerge(that);
@@ -1526,7 +1755,9 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   }
 
   private void putAllMerge(TagMap that) {
-    Object[] thisBuckets = this.buckets;
+    // COW our buckets only if the source has bucket entries to merge in; otherwise the loop below
+    // writes nothing and the shared empty buckets stay shared.
+    Object[] thisBuckets = (that.size > 0) ? this.materializeBuckets() : this.buckets;
     Object[] thatBuckets = that.buckets;
 
     // Since TagMap-s don't support expansion, buckets are perfectly aligned
@@ -1637,33 +1868,49 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
         }
       }
     }
+
+    // merge the source's dense known-tag entries; incoming clobbers existing (same as buckets)
+    for (int i = 0; i < that.knownCount; ++i) {
+      this.putKnownValue(that.knownIds[i], that.knownValues[i]);
+    }
   }
 
   /*
    * Specially optimized version of putAll for the common case of destination map being empty
    */
   private void putAllIntoEmptyMap(TagMap that) {
-    Object[] thisBuckets = this.buckets;
-    Object[] thatBuckets = that.buckets;
+    // Only copy buckets (and COW ours) when the source actually has bucket entries; an all-known
+    // source leaves us on the shared empty buckets.
+    if (that.size > 0) {
+      Object[] thisBuckets = this.materializeBuckets();
+      Object[] thatBuckets = that.buckets;
 
-    // Check against both thisBuckets.length && thatBuckets.length is to help the JIT do bound check
-    // elimination
-    for (int i = 0; i < thisBuckets.length && i < thatBuckets.length; ++i) {
-      Object thatBucket = thatBuckets[i];
+      // Check against both thisBuckets.length && thatBuckets.length is to help the JIT do bound
+      // check elimination
+      for (int i = 0; i < thisBuckets.length && i < thatBuckets.length; ++i) {
+        Object thatBucket = thatBuckets[i];
 
-      // faster to explicitly null check first, then do instanceof
-      if (thatBucket == null) {
-        // do nothing
-      } else if (thatBucket instanceof BucketGroup) {
-        // if it is a BucketGroup, then need to clone
-        BucketGroup thatGroup = (BucketGroup) thatBucket;
+        // faster to explicitly null check first, then do instanceof
+        if (thatBucket == null) {
+          // do nothing
+        } else if (thatBucket instanceof BucketGroup) {
+          // if it is a BucketGroup, then need to clone
+          BucketGroup thatGroup = (BucketGroup) thatBucket;
 
-        thisBuckets[i] = thatGroup.cloneChain();
-      } else { // if ( thatBucket instanceof Entry )
-        thisBuckets[i] = thatBucket;
+          thisBuckets[i] = thatGroup.cloneChain();
+        } else { // if ( thatBucket instanceof Entry )
+          thisBuckets[i] = thatBucket;
+        }
       }
+      this.size = that.size;
     }
-    this.size = that.size;
+
+    // clone the dense known-tag store (values are immutable boxes/objects -> safe to share refs)
+    if (that.knownCount > 0) {
+      this.knownIds = Arrays.copyOf(that.knownIds, that.knownIds.length);
+      this.knownValues = Arrays.copyOf(that.knownValues, that.knownValues.length);
+      this.knownCount = that.knownCount;
+    }
   }
 
   public void fillMap(Map<? super String, Object> map) {
@@ -1690,6 +1937,9 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
         thisGroup.fillMapFromChain(map);
       }
     }
+    for (int i = 0; i < this.knownCount; ++i) {
+      map.put(KnownTagCodec.nameOf(this.knownIds[i]), this.knownValues[i]);
+    }
   }
 
   public void fillStringMap(Map<? super String, ? super String> stringMap) {
@@ -1714,6 +1964,11 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
 
         thisGroup.fillStringMapFromChain(stringMap);
       }
+    }
+    for (int i = 0; i < this.knownCount; ++i) {
+      stringMap.put(
+          KnownTagCodec.nameOf(this.knownIds[i]),
+          TagValueConversions.toString(this.knownValues[i]));
     }
   }
 
@@ -1758,8 +2013,13 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
     return localRemoved;
   }
 
-  /** Removes an entry from this map's own buckets only — no parent/tombstone handling. */
+  /** Removes an entry from this map's own storage only — no parent/tombstone handling. */
   private Entry removeLocal(String tag) {
+    long id = KnownTagCodec.DENSE_STORE ? KnownTagCodec.keyOf(tag) : 0L;
+    if (KnownTagCodec.isStored(id)) {
+      return this.removeKnown(id);
+    }
+
     Object[] thisBuckets = this.buckets;
 
     int hash = TagMap.Entry._hash(tag);
@@ -1827,6 +2087,15 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
 
   @Override
   public void forEach(Consumer<? super TagMap.EntryReader> consumer) {
+    // local dense known tags via a reused flyweight (no per-entry Entry alloc — the serialize win)
+    if (this.knownCount > 0) {
+      EntryReadingHelper reader = new EntryReadingHelper();
+      for (int i = 0; i < this.knownCount; ++i) {
+        reader.set(KnownTagCodec.nameOf(this.knownIds[i]), this.knownValues[i]);
+        consumer.accept(reader);
+      }
+    }
+
     Object[] thisBuckets = this.buckets;
 
     for (int i = 0; i < thisBuckets.length; ++i) {
@@ -1852,8 +2121,23 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
 
   private void forEachParent(Consumer<? super TagMap.EntryReader> consumer) {
     // Walk the ancestor chain, nearest first. Each entry is emitted once, by the nearest level that
-    // defines its key, when not shadowed by a nearer level and not tombstoned.
+    // defines its key, when not shadowed by a nearer level and not tombstoned. Dense known tags are
+    // emitted via a reused flyweight (no per-entry Entry alloc — the serialize win).
+    EntryReadingHelper reader = null;
     for (TagMap ancestor = this.parent; ancestor != null; ancestor = ancestor.parent) {
+      long[] ancestorIds = ancestor.knownIds;
+      int ancestorKnownCount = ancestor.knownCount;
+      if (ancestorKnownCount > 0) {
+        Object[] ancestorValues = ancestor.knownValues;
+        if (reader == null) reader = new EntryReadingHelper();
+        for (int i = 0; i < ancestorKnownCount; ++i) {
+          long id = ancestorIds[i];
+          if (this.parentDenseVisible(id, ancestor)) {
+            reader.set(KnownTagCodec.nameOf(id), ancestorValues[i]);
+            consumer.accept(reader);
+          }
+        }
+      }
       Object[] parentBuckets = ancestor.buckets;
       for (int i = 0; i < parentBuckets.length; ++i) {
         Object parentBucket = parentBuckets[i];
@@ -1876,6 +2160,14 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   }
 
   public <T> void forEach(T thisObj, BiConsumer<T, ? super TagMap.EntryReader> consumer) {
+    if (this.knownCount > 0) {
+      EntryReadingHelper reader = new EntryReadingHelper();
+      for (int i = 0; i < this.knownCount; ++i) {
+        reader.set(KnownTagCodec.nameOf(this.knownIds[i]), this.knownValues[i]);
+        consumer.accept(thisObj, reader);
+      }
+    }
+
     Object[] thisBuckets = this.buckets;
 
     for (int i = 0; i < thisBuckets.length; ++i) {
@@ -1899,7 +2191,21 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   }
 
   private <T> void forEachParent(T thisObj, BiConsumer<T, ? super TagMap.EntryReader> consumer) {
+    EntryReadingHelper reader = null;
     for (TagMap ancestor = this.parent; ancestor != null; ancestor = ancestor.parent) {
+      int ancestorKnownCount = ancestor.knownCount;
+      if (ancestorKnownCount > 0) {
+        long[] ancestorIds = ancestor.knownIds;
+        Object[] ancestorValues = ancestor.knownValues;
+        if (reader == null) reader = new EntryReadingHelper();
+        for (int i = 0; i < ancestorKnownCount; ++i) {
+          long id = ancestorIds[i];
+          if (this.parentDenseVisible(id, ancestor)) {
+            reader.set(KnownTagCodec.nameOf(id), ancestorValues[i]);
+            consumer.accept(thisObj, reader);
+          }
+        }
+      }
       Object[] parentBuckets = ancestor.buckets;
       for (int i = 0; i < parentBuckets.length; ++i) {
         Object parentBucket = parentBuckets[i];
@@ -1924,6 +2230,14 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
 
   public <T, U> void forEach(
       T thisObj, U otherObj, TriConsumer<T, U, ? super TagMap.EntryReader> consumer) {
+    if (this.knownCount > 0) {
+      EntryReadingHelper reader = new EntryReadingHelper();
+      for (int i = 0; i < this.knownCount; ++i) {
+        reader.set(KnownTagCodec.nameOf(this.knownIds[i]), this.knownValues[i]);
+        consumer.accept(thisObj, otherObj, reader);
+      }
+    }
+
     Object[] thisBuckets = this.buckets;
 
     for (int i = 0; i < thisBuckets.length; ++i) {
@@ -1948,7 +2262,21 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
 
   private <T, U> void forEachParent(
       T thisObj, U otherObj, TriConsumer<T, U, ? super TagMap.EntryReader> consumer) {
+    EntryReadingHelper reader = null;
     for (TagMap ancestor = this.parent; ancestor != null; ancestor = ancestor.parent) {
+      int ancestorKnownCount = ancestor.knownCount;
+      if (ancestorKnownCount > 0) {
+        long[] ancestorIds = ancestor.knownIds;
+        Object[] ancestorValues = ancestor.knownValues;
+        if (reader == null) reader = new EntryReadingHelper();
+        for (int i = 0; i < ancestorKnownCount; ++i) {
+          long id = ancestorIds[i];
+          if (this.parentDenseVisible(id, ancestor)) {
+            reader.set(KnownTagCodec.nameOf(id), ancestorValues[i]);
+            consumer.accept(thisObj, otherObj, reader);
+          }
+        }
+      }
       Object[] parentBuckets = ancestor.buckets;
       for (int i = 0; i < parentBuckets.length; ++i) {
         Object parentBucket = parentBuckets[i];
@@ -1975,13 +2303,17 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
   public void clear() {
     this.checkWriteAccess();
 
-    Arrays.fill(this.buckets, null);
+    // Drop the private bucket array back to the shared empty sentinel (also avoids mutating it).
+    this.buckets = EMPTY_BUCKETS;
     this.size = 0;
     // clear() removes ALL mappings, including any inherited through read-through. Detaching the
     // parent (rather than tombstoning every inherited key) is simpler and cheaper, and leaves an
     // empty, parent-less map. Detach is one-way -- the parent is never re-pointed.
     this.parent = null;
     this.removedFromParent = null;
+    this.knownIds = null;
+    this.knownValues = null;
+    this.knownCount = 0;
   }
 
   public TagMap freeze() {
@@ -2031,6 +2363,20 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
             if (expectedBucket != i) {
               throw new IllegalStateException("incorrect bucket");
             }
+          }
+        }
+      }
+    }
+
+    // dense store: ids must be unique (no tag stored twice) and the count within array bounds.
+    if (this.knownCount > 0) {
+      if (this.knownIds == null || this.knownCount > this.knownIds.length) {
+        throw new IllegalStateException("incorrect known count");
+      }
+      for (int i = 0; i < this.knownCount; ++i) {
+        for (int j = i + 1; j < this.knownCount; ++j) {
+          if (this.knownIds[i] == this.knownIds[j]) {
+            throw new IllegalStateException("duplicate known id");
           }
         }
       }
@@ -2166,12 +2512,22 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
     private TagMap level;
     private Object[] buckets;
 
-    private Entry nextEntry;
+    // Currency is EntryReader, not Entry: a BUCKET entry is its own (real, retain-safe) Entry, but
+    // a
+    // DENSE entry is emitted via the reused denseReader flyweight (alloc-free, "use now"). This is
+    // the contract of TagMap.iterator()/keySet()/values(). entrySet() (Iterator<Map.Entry>) sits on
+    // top and calls .entry() per next() to get a real retain-safe Entry (see EntriesIterator).
+    private EntryReader nextEntry;
+    private EntryReadingHelper denseReader; // lazily created on the first dense emit
 
     private int bucketIndex = -1;
 
     private BucketGroup group = null;
     private int groupIndex = 0;
+
+    // dense-store cursor for the current level's known tags; advance() resets it when it moves to
+    // the next ancestor level (read-through union).
+    private int knownIndex = 0;
 
     IteratorBase(TagMap map) {
       this.map = map;
@@ -2186,9 +2542,9 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
       return this.nextEntry != null;
     }
 
-    final Entry nextEntryOrThrowNoSuchElement() {
+    final EntryReader nextEntryOrThrowNoSuchElement() {
       if (this.nextEntry != null) {
-        Entry nextEntry = this.nextEntry;
+        EntryReader nextEntry = this.nextEntry;
         this.nextEntry = null;
         return nextEntry;
       }
@@ -2200,9 +2556,9 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
       }
     }
 
-    final Entry nextEntryOrNull() {
+    final EntryReader nextEntryOrNull() {
       if (this.nextEntry != null) {
-        Entry nextEntry = this.nextEntry;
+        EntryReader nextEntry = this.nextEntry;
         this.nextEntry = null;
         return nextEntry;
       }
@@ -2210,8 +2566,22 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
       return this.hasNext() ? this.nextEntry : null;
     }
 
-    private final Entry advance() {
+    private final EntryReader advance() {
       while (true) {
+        // phase 1: drain the current level's dense known tags before its buckets. Leaf dense always
+        // emits; ancestor dense only if visible from the leaf (not shadowed by a nearer dense entry
+        // and not tombstoned). Emitted via the reused denseReader flyweight -- NO per-entry Entry
+        // alloc (the read/serialize alloc win).
+        if (this.knownIndex < this.level.knownCount) {
+          int i = this.knownIndex++;
+          long id = this.level.knownIds[i];
+          if (this.level == this.map || this.map.parentDenseVisible(id, this.level)) {
+            return this.emitDense(id, this.level.knownValues[i]);
+          }
+          continue; // ancestor dense entry shadowed/tombstoned -> skip
+        }
+
+        // phase 2: the current level's buckets.
         Entry tagEntry = this.rawAdvance();
         if (tagEntry != null) {
           // leaf entries emit as-is; ancestor entries only if visible from the leaf -- not shadowed
@@ -2222,9 +2592,12 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
           continue; // ancestor entry shadowed/tombstoned -> skip
         }
 
-        // current level exhausted; advance to the next ancestor's buckets (read-through union)
+        // current level exhausted; advance to the next ancestor (read-through union), resetting
+        // both
+        // the per-level dense cursor and the bucket cursor for the new level.
         if (this.level.parent != null) {
           this.level = this.level.parent;
+          this.knownIndex = 0;
           this.buckets = this.level.buckets;
           this.bucketIndex = -1;
           this.group = null;
@@ -2233,6 +2606,16 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
         }
         return null;
       }
+    }
+
+    /** Sets and returns the reused dense flyweight (lazily created); "use now", do not retain. */
+    private EntryReader emitDense(long tagId, Object value) {
+      EntryReadingHelper reader = this.denseReader;
+      if (reader == null) {
+        reader = this.denseReader = new EntryReadingHelper();
+      }
+      reader.set(KnownTagCodec.nameOf(tagId), value);
+      return reader;
     }
 
     /** Next raw entry in the current bucket array, ignoring shadowing/tombstones. */
@@ -2764,9 +3147,26 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
 
     @Override
     public Iterator<Map.Entry<String, Object>> iterator() {
-      @SuppressWarnings({"rawtypes", "unchecked"})
-      Iterator<Map.Entry<String, Object>> iter = (Iterator) this.map.iterator();
-      return iter;
+      return new EntriesIterator(this.map);
+    }
+  }
+
+  /**
+   * entrySet() yields real, retain-safe {@code Map.Entry} objects. It sits on top of the
+   * EntryReader iterator and materializes each via {@code .entry()}: a bucket entry's reader IS the
+   * real stored Entry (returns {@code this}, free); a dense entry's flyweight materializes a fresh
+   * Entry. Deliberately NOT alloc-optimized for dense — bulk reads use {@code forEach}/EntryReader,
+   * and manual instrumentation does point get/set, not bulk entrySet iteration.
+   */
+  static final class EntriesIterator extends IteratorBase
+      implements Iterator<Map.Entry<String, Object>> {
+    EntriesIterator(TagMap map) {
+      super(map);
+    }
+
+    @Override
+    public Map.Entry<String, Object> next() {
+      return this.nextEntryOrThrowNoSuchElement().entry();
     }
   }
 

--- a/internal-api/src/test/java/datadog/trace/api/KnownTagsTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/KnownTagsTest.java
@@ -1,0 +1,152 @@
+package datadog.trace.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Parity test for the keyOf substrate (slice 1): the {@link KnownTags} registry + the {@link
+ * KnownTagCodec.Resolver} it registers. Verifies name &harr; id resolution without any dense store
+ * — {@code keyOf}/{@code nameOf} depend only on globalSerial + name, not on the (dormant)
+ * positional layout.
+ */
+class KnownTagsTest {
+
+  /** (name, id) pairs — the full registry. keyOf returns the id verbatim (incl. INTERCEPTED). */
+  static Stream<Arguments> knownTags() {
+    return Stream.of(
+        Arguments.of(Tags.ERROR, KnownTags.ERROR_ID),
+        Arguments.of(DDTags.PARENT_ID, KnownTags.PARENT_ID),
+        Arguments.of(DDTags.BASE_SERVICE, KnownTags.BASE_SERVICE_ID),
+        Arguments.of(Tags.VERSION, KnownTags.VERSION_ID),
+        Arguments.of(KnownTags.ENV, KnownTags.ENV_ID),
+        Arguments.of(DDTags.DJM_ENABLED, KnownTags.DJM_ENABLED_ID),
+        Arguments.of(DDTags.DSM_ENABLED, KnownTags.DSM_ENABLED_ID),
+        Arguments.of(DDTags.TRACER_HOST, KnownTags.TRACER_HOST_ID),
+        Arguments.of(DDTags.DD_INTEGRATION, KnownTags.INTEGRATION_ID),
+        Arguments.of(DDTags.DD_SVC_SRC, KnownTags.SVC_SRC_ID),
+        Arguments.of(Tags.PEER_SERVICE, KnownTags.PEER_SERVICE_ID),
+        Arguments.of(DDTags.PEER_SERVICE_REMAPPED_FROM, KnownTags.PEER_SERVICE_REMAPPED_FROM_ID),
+        Arguments.of(Tags.HTTP_METHOD, KnownTags.HTTP_METHOD_ID),
+        Arguments.of(Tags.HTTP_ROUTE, KnownTags.HTTP_ROUTE_ID),
+        Arguments.of(Tags.HTTP_URL, KnownTags.HTTP_URL_ID),
+        Arguments.of(Tags.PEER_HOSTNAME, KnownTags.PEER_HOSTNAME_ID),
+        Arguments.of(Tags.PEER_HOST_IPV4, KnownTags.PEER_HOST_IPV4_ID),
+        Arguments.of(Tags.PEER_HOST_IPV6, KnownTags.PEER_HOST_IPV6_ID),
+        Arguments.of(Tags.PEER_PORT, KnownTags.PEER_PORT_ID),
+        Arguments.of(Tags.COMPONENT, KnownTags.COMPONENT_ID),
+        Arguments.of(Tags.SPAN_KIND, KnownTags.SPAN_KIND_ID),
+        Arguments.of(DDTags.LANGUAGE_TAG_KEY, KnownTags.LANGUAGE_ID),
+        Arguments.of(Tags.DB_TYPE, KnownTags.DB_TYPE_ID),
+        Arguments.of(Tags.DB_INSTANCE, KnownTags.DB_INSTANCE_ID),
+        Arguments.of(Tags.DB_USER, KnownTags.DB_USER_ID),
+        Arguments.of(Tags.DB_OPERATION, KnownTags.DB_OPERATION_ID),
+        Arguments.of(Tags.DB_POOL_NAME, KnownTags.DB_POOL_NAME_ID));
+  }
+
+  /**
+   * The subset flagged INTERCEPTED (sign bit) — must agree with the interceptor's needsIntercept.
+   */
+  static Stream<Arguments> interceptedTags() {
+    return Stream.of(
+        Arguments.of(KnownTags.ERROR_ID),
+        Arguments.of(KnownTags.PEER_SERVICE_ID),
+        Arguments.of(KnownTags.HTTP_METHOD_ID),
+        Arguments.of(KnownTags.HTTP_URL_ID),
+        Arguments.of(KnownTags.SPAN_KIND_ID));
+  }
+
+  @Test
+  void resolverIsActiveOnceReferenced() {
+    // referencing any constant triggers KnownTags.<clinit> -> KnownTagCodec.register
+    assertTrue(KnownTags.ERROR_ID != 0L);
+    assertTrue(KnownTagCodec.isActive());
+    assertEquals(KnownTags.SLOT_COUNT, KnownTagCodec.slotCount());
+  }
+
+  @ParameterizedTest
+  @MethodSource("knownTags")
+  void keyOfResolvesNameToId(String name, long id) {
+    assertEquals(id, KnownTagCodec.keyOf(name), "keyOf(" + name + ")");
+  }
+
+  @ParameterizedTest
+  @MethodSource("knownTags")
+  void nameOfResolvesIdToName(String name, long id) {
+    assertEquals(name, KnownTagCodec.nameOf(id), "nameOf(" + name + ")");
+  }
+
+  @ParameterizedTest
+  @MethodSource("knownTags")
+  void nameHashMatchesEntryHash(String name, long id) {
+    assertEquals(
+        (int) TagMap.Entry._hash(name), KnownTagCodec.nameHash(id), "nameHash(" + name + ")");
+  }
+
+  @ParameterizedTest
+  @MethodSource("interceptedTags")
+  void interceptedTagsCarryFlag(long id) {
+    assertTrue(KnownTagCodec.isIntercepted(id), "isIntercepted");
+  }
+
+  @Test
+  void nonInterceptedTagsDoNotCarryFlag() {
+    Set<Long> intercepted = new HashSet<>();
+    interceptedTags().forEach(a -> intercepted.add((Long) a.get()[0]));
+    knownTags()
+        .forEach(
+            a -> {
+              long id = (Long) a.get()[1];
+              if (!intercepted.contains(id)) {
+                assertFalse(KnownTagCodec.isIntercepted(id), "not intercepted: " + a.get()[0]);
+              }
+            });
+  }
+
+  @Test
+  void unknownNamesResolveToZero() {
+    assertEquals(0L, KnownTagCodec.keyOf("definitely.not.a.known.tag"));
+    assertEquals(0L, KnownTagCodec.keyOf("http.statuscode")); // close-but-not-listed
+    assertEquals(0L, KnownTagCodec.keyOf(""));
+  }
+
+  @Test
+  void unknownIdsResolveToNullName() {
+    assertNull(KnownTagCodec.nameOf(0L));
+    assertNull(KnownTagCodec.nameOf(KnownTagCodec.tagId(9999, "made.up")));
+  }
+
+  @Test
+  void errorIsReservedTheRestAreStored() {
+    assertTrue(KnownTagCodec.isReserved(KnownTags.ERROR_ID), "ERROR reserved");
+    assertFalse(KnownTagCodec.isStored(KnownTags.ERROR_ID), "ERROR not stored");
+    knownTags()
+        .forEach(
+            a -> {
+              long id = (Long) a.get()[1];
+              if (id != KnownTags.ERROR_ID) {
+                assertTrue(KnownTagCodec.isStored(id), "stored: " + a.get()[0]);
+                assertFalse(KnownTagCodec.isReserved(id), "not reserved: " + a.get()[0]);
+              }
+            });
+  }
+
+  @Test
+  void globalSerialsAreUnique() {
+    List<Long> serials = new ArrayList<>();
+    knownTags().forEach(a -> serials.add((long) KnownTagCodec.globalSerial((Long) a.get()[1])));
+    assertEquals(serials.size(), new HashSet<>(serials).size(), "globalSerials must be unique");
+  }
+}

--- a/internal-api/src/test/java/datadog/trace/api/TagMapDenseForkedTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/TagMapDenseForkedTest.java
@@ -1,0 +1,273 @@
+package datadog.trace.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the dense known-tag store with a LIVE resolver. Registration ({@link KnownTagCodec}) is
+ * a global static with no un-register, so this lives in a {@code ForkedTest} (isolated JVM) to keep
+ * dense routing from leaking into the bucket-only tests in the shared JVM. The dense store is
+ * dormant in production (no resolver) — this is where it actually executes.
+ *
+ * <p>Stored tags (globalSerial &ge; {@code FIRST_STORED_SERIAL}) route to the dense store; reserved
+ * tags (e.g. {@code error}) and arbitrary tags stay in the hash buckets. Behavior must be
+ * observationally identical to the bucket store.
+ */
+class TagMapDenseForkedTest {
+
+  // stored (dense-routed) tags
+  static final String BASE_SERVICE = DDTags.BASE_SERVICE;
+  static final String COMPONENT = Tags.COMPONENT;
+  static final String DB_TYPE = Tags.DB_TYPE;
+  static final String HTTP_METHOD = Tags.HTTP_METHOD; // stored + intercepted
+  static final String DB_INSTANCE = Tags.DB_INSTANCE;
+  // arbitrary (bucket-routed) tags
+  static final String CUSTOM_A = "custom.tag.a";
+  static final String CUSTOM_B = "custom.tag.b";
+
+  @BeforeAll
+  static void registerResolver() {
+    // referencing any KnownTags constant triggers its <clinit> -> KnownTagCodec.register
+    assertTrue(KnownTags.BASE_SERVICE_ID != 0L);
+    assertTrue(KnownTagCodec.isActive(), "resolver must be live for the dense store to engage");
+    assertTrue(
+        KnownTagCodec.isStored(KnownTagCodec.keyOf(BASE_SERVICE)), "base_service routes dense");
+    assertFalse(
+        KnownTagCodec.isStored(KnownTagCodec.keyOf(CUSTOM_A)), "custom tag stays in buckets");
+    assertFalse(
+        KnownTagCodec.isStored(KnownTagCodec.keyOf(Tags.ERROR)), "error is reserved, not stored");
+  }
+
+  private static TagMap map() {
+    return (TagMap) TagMap.create();
+  }
+
+  @Test
+  void knownTagRoundTripsThroughDenseStore() {
+    TagMap map = map();
+    map.set(BASE_SERVICE, "billing");
+    map.set(COMPONENT, "spring-web");
+
+    assertEquals("billing", map.getObject(BASE_SERVICE));
+    assertEquals("spring-web", map.getString(COMPONENT));
+    assertEquals("billing", map.getEntry(BASE_SERVICE).objectValue());
+    assertTrue(map.containsKey(BASE_SERVICE));
+    assertEquals(2, map.size());
+    map.checkIntegrity();
+  }
+
+  @Test
+  void typedKnownValuesRoundTrip() {
+    TagMap map = map();
+    map.set(DB_TYPE, "postgresql");
+    map.set(HTTP_METHOD, "GET");
+    map.set(Tags.PEER_PORT, 5432);
+
+    assertEquals("postgresql", map.getString(DB_TYPE));
+    assertEquals("GET", map.getString(HTTP_METHOD));
+    assertEquals(5432, map.getInt(Tags.PEER_PORT));
+    assertEquals(3, map.size());
+    map.checkIntegrity();
+  }
+
+  @Test
+  void knownAndUnknownCoexist() {
+    TagMap map = map();
+    map.set(BASE_SERVICE, "billing"); // dense
+    map.set(CUSTOM_A, "alpha"); // bucket
+    map.set(DB_TYPE, "h2"); // dense
+    map.set(CUSTOM_B, "beta"); // bucket
+
+    assertEquals("billing", map.getObject(BASE_SERVICE));
+    assertEquals("alpha", map.getObject(CUSTOM_A));
+    assertEquals("h2", map.getObject(DB_TYPE));
+    assertEquals("beta", map.getObject(CUSTOM_B));
+    assertEquals(4, map.size());
+    assertFalse(map.isEmpty());
+    map.checkIntegrity();
+
+    Map<String, Object> collected = new HashMap<>();
+    map.fillMap(collected);
+    assertEquals(4, collected.size());
+    assertEquals("billing", collected.get(BASE_SERVICE));
+    assertEquals("alpha", collected.get(CUSTOM_A));
+    assertEquals("h2", collected.get(DB_TYPE));
+    assertEquals("beta", collected.get(CUSTOM_B));
+  }
+
+  @Test
+  void overwriteKnownReplacesInPlace() {
+    TagMap map = map();
+    map.set(COMPONENT, "first");
+    assertEquals("first", map.getObject(COMPONENT));
+    map.set(COMPONENT, "second");
+    assertEquals("second", map.getObject(COMPONENT));
+    assertEquals(1, map.size()); // overwrite, not append
+    map.checkIntegrity();
+  }
+
+  @Test
+  void removeKnownClearsIt() {
+    TagMap map = map();
+    map.set(BASE_SERVICE, "billing");
+    map.set(DB_TYPE, "h2");
+    map.set(CUSTOM_A, "alpha");
+    assertEquals(3, map.size());
+
+    TagMap.Entry removed = map.getAndRemove(BASE_SERVICE);
+    assertEquals("billing", removed.objectValue());
+    assertNull(map.getObject(BASE_SERVICE));
+    assertEquals("h2", map.getObject(DB_TYPE)); // sibling dense entry intact
+    assertEquals("alpha", map.getObject(CUSTOM_A));
+    assertEquals(2, map.size());
+    map.checkIntegrity();
+  }
+
+  @Test
+  void forEachAndIteratorEmitDenseAndBucketEntries() {
+    TagMap map = map();
+    map.set(BASE_SERVICE, "billing");
+    map.set(COMPONENT, "web");
+    map.set(CUSTOM_A, "alpha");
+
+    Map<String, Object> viaForEach = new HashMap<>();
+    map.forEach(reader -> viaForEach.put(reader.tag(), reader.objectValue()));
+    assertEquals(3, viaForEach.size());
+    assertEquals("billing", viaForEach.get(BASE_SERVICE));
+    assertEquals("web", viaForEach.get(COMPONENT));
+    assertEquals("alpha", viaForEach.get(CUSTOM_A));
+
+    Map<String, Object> viaIterator = new HashMap<>();
+    for (TagMap.EntryReader reader : map) {
+      viaIterator.put(reader.tag(), reader.objectValue());
+    }
+    assertEquals(viaForEach, viaIterator);
+  }
+
+  @Test
+  void copyPreservesDenseStore() {
+    TagMap map = map();
+    map.set(BASE_SERVICE, "billing");
+    map.set(CUSTOM_A, "alpha");
+
+    TagMap copy = (TagMap) map.copy();
+    assertEquals("billing", copy.getObject(BASE_SERVICE));
+    assertEquals("alpha", copy.getObject(CUSTOM_A));
+    assertEquals(2, copy.size());
+
+    // independence: mutating the copy doesn't touch the original's dense store
+    copy.set(BASE_SERVICE, "shipping");
+    assertEquals("shipping", copy.getObject(BASE_SERVICE));
+    assertEquals("billing", map.getObject(BASE_SERVICE));
+    copy.checkIntegrity();
+    map.checkIntegrity();
+  }
+
+  @Test
+  void clearEmptiesDenseStore() {
+    TagMap map = map();
+    map.set(BASE_SERVICE, "billing");
+    map.set(CUSTOM_A, "alpha");
+    map.clear();
+    assertEquals(0, map.size());
+    assertTrue(map.isEmpty());
+    assertNull(map.getObject(BASE_SERVICE));
+    map.checkIntegrity();
+  }
+
+  @Test
+  void putAllMergesDenseStore() {
+    TagMap src = map();
+    src.set(BASE_SERVICE, "billing");
+    src.set(DB_TYPE, "h2");
+    src.set(CUSTOM_A, "alpha");
+
+    TagMap dst = map();
+    dst.set(COMPONENT, "web"); // dense, distinct
+    dst.set(BASE_SERVICE, "old"); // dense, clobbered by src
+    dst.putAll((TagMap) src);
+
+    assertEquals("billing", dst.getObject(BASE_SERVICE)); // src clobbers
+    assertEquals("h2", dst.getObject(DB_TYPE));
+    assertEquals("web", dst.getObject(COMPONENT));
+    assertEquals("alpha", dst.getObject(CUSTOM_A));
+    assertEquals(4, dst.size());
+    dst.checkIntegrity();
+  }
+
+  // ---- read-through union (dense parent + dense child) ----
+
+  private static TagMap frozenParent() {
+    TagMap parent = map();
+    parent.set(BASE_SERVICE, "billing"); // dense
+    parent.set(COMPONENT, "web"); // dense
+    parent.set(CUSTOM_A, "alpha"); // bucket
+    parent.freeze();
+    return parent;
+  }
+
+  @Test
+  void childReadsThroughToParentDense() {
+    TagMap child = TagMap.createFromParent(frozenParent());
+    child.set(DB_TYPE, "h2"); // child-only dense
+    child.set(CUSTOM_B, "beta"); // child-only bucket
+
+    // inherited from parent
+    assertEquals("billing", child.getObject(BASE_SERVICE));
+    assertEquals("web", child.getObject(COMPONENT));
+    assertEquals("alpha", child.getObject(CUSTOM_A));
+    // own
+    assertEquals("h2", child.getObject(DB_TYPE));
+    assertEquals("beta", child.getObject(CUSTOM_B));
+    // union size: 3 parent + 2 child
+    assertEquals(5, child.size());
+    assertFalse(child.isEmpty());
+
+    Map<String, Object> union = new HashMap<>();
+    child.forEach(reader -> union.put(reader.tag(), reader.objectValue()));
+    assertEquals(5, union.size());
+    assertEquals("billing", union.get(BASE_SERVICE));
+    assertEquals("h2", union.get(DB_TYPE));
+    child.checkIntegrity();
+  }
+
+  @Test
+  void childDenseShadowsParentDense() {
+    TagMap child = TagMap.createFromParent(frozenParent());
+    child.set(BASE_SERVICE, "shipping"); // shadows parent's dense base_service
+
+    assertEquals("shipping", child.getObject(BASE_SERVICE)); // local wins
+    assertEquals("web", child.getObject(COMPONENT)); // still inherited
+    assertEquals(3, child.size()); // base_service counted once (shadowed, not doubled)
+
+    Map<String, Object> union = new HashMap<>();
+    child.forEach(reader -> union.put(reader.tag(), reader.objectValue()));
+    assertEquals(3, union.size());
+    assertEquals("shipping", union.get(BASE_SERVICE)); // shadow value, parent suppressed
+  }
+
+  @Test
+  void removingParentDenseKeyTombstonesIt() {
+    TagMap child = TagMap.createFromParent(frozenParent());
+
+    TagMap.Entry removed = child.getAndRemove(BASE_SERVICE); // parent-only dense key
+    assertEquals("billing", removed.objectValue()); // prior visible value was the parent's
+    assertNull(child.getObject(BASE_SERVICE)); // tombstoned: no read-through
+    assertEquals("web", child.getObject(COMPONENT)); // sibling still inherited
+    assertEquals(2, child.size()); // 3 parent - 1 tombstoned
+
+    Map<String, Object> union = new HashMap<>();
+    child.forEach(reader -> union.put(reader.tag(), reader.objectValue()));
+    assertEquals(2, union.size());
+    assertFalse(union.containsKey(BASE_SERVICE));
+    child.checkIntegrity();
+  }
+}

--- a/internal-api/src/test/java/datadog/trace/api/TagMapDenseForkedTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/TagMapDenseForkedTest.java
@@ -1,0 +1,283 @@
+package datadog.trace.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the dense known-tag store with a LIVE resolver. Registration ({@link KnownTagCodec}) is
+ * a global static with no un-register, so this lives in a {@code ForkedTest} (isolated JVM) to keep
+ * dense routing from leaking into the bucket-only tests in the shared JVM. The dense store is
+ * dormant in production (no resolver) — this is where it actually executes.
+ *
+ * <p>Stored tags (globalSerial &ge; {@code FIRST_STORED_SERIAL}) route to the dense store; reserved
+ * tags (e.g. {@code error}) and arbitrary tags stay in the hash buckets. Behavior must be
+ * observationally identical to the bucket store.
+ */
+class TagMapDenseForkedTest {
+
+  static {
+    // Dense routing is a const-folded gate (KnownTagCodec.DENSE_STORE, captured from Config at
+    // KnownTagCodec's class-init). Set the flag before anything touches Config/KnownTagCodec so the
+    // gate reads true in this forked JVM. Registering the resolver alone no longer engages dense.
+    System.setProperty("dd.trace.experimental.dense.tags.enabled", "true");
+  }
+
+  // stored (dense-routed) tags
+  static final String BASE_SERVICE = DDTags.BASE_SERVICE;
+  static final String COMPONENT = Tags.COMPONENT;
+  static final String DB_TYPE = Tags.DB_TYPE;
+  static final String HTTP_METHOD = Tags.HTTP_METHOD; // stored + intercepted
+  static final String DB_INSTANCE = Tags.DB_INSTANCE;
+  // arbitrary (bucket-routed) tags
+  static final String CUSTOM_A = "custom.tag.a";
+  static final String CUSTOM_B = "custom.tag.b";
+
+  @BeforeAll
+  static void registerResolver() {
+    // referencing any KnownTags constant triggers its <clinit> -> KnownTagCodec.register
+    assertTrue(KnownTags.BASE_SERVICE_ID != 0L);
+    assertTrue(KnownTagCodec.isActive(), "resolver must be live for the dense store to engage");
+    assertTrue(KnownTagCodec.DENSE_STORE, "dense store must be enabled in this forked JVM");
+    assertTrue(
+        KnownTagCodec.routesToDense(KnownTagCodec.keyOf(BASE_SERVICE)),
+        "base_service routes dense");
+    assertFalse(
+        KnownTagCodec.routesToDense(KnownTagCodec.keyOf(CUSTOM_A)), "custom tag stays in buckets");
+    assertFalse(
+        KnownTagCodec.routesToDense(KnownTagCodec.keyOf(Tags.ERROR)),
+        "error is reserved, not stored");
+  }
+
+  private static TagMap map() {
+    return (TagMap) TagMap.create();
+  }
+
+  @Test
+  void knownTagRoundTripsThroughDenseStore() {
+    TagMap map = map();
+    map.set(BASE_SERVICE, "billing");
+    map.set(COMPONENT, "spring-web");
+
+    assertEquals("billing", map.getObject(BASE_SERVICE));
+    assertEquals("spring-web", map.getString(COMPONENT));
+    assertEquals("billing", map.getEntry(BASE_SERVICE).objectValue());
+    assertTrue(map.containsKey(BASE_SERVICE));
+    assertEquals(2, map.size());
+    map.checkIntegrity();
+  }
+
+  @Test
+  void typedKnownValuesRoundTrip() {
+    TagMap map = map();
+    map.set(DB_TYPE, "postgresql");
+    map.set(HTTP_METHOD, "GET");
+    map.set(Tags.PEER_PORT, 5432);
+
+    assertEquals("postgresql", map.getString(DB_TYPE));
+    assertEquals("GET", map.getString(HTTP_METHOD));
+    assertEquals(5432, map.getInt(Tags.PEER_PORT));
+    assertEquals(3, map.size());
+    map.checkIntegrity();
+  }
+
+  @Test
+  void knownAndUnknownCoexist() {
+    TagMap map = map();
+    map.set(BASE_SERVICE, "billing"); // dense
+    map.set(CUSTOM_A, "alpha"); // bucket
+    map.set(DB_TYPE, "h2"); // dense
+    map.set(CUSTOM_B, "beta"); // bucket
+
+    assertEquals("billing", map.getObject(BASE_SERVICE));
+    assertEquals("alpha", map.getObject(CUSTOM_A));
+    assertEquals("h2", map.getObject(DB_TYPE));
+    assertEquals("beta", map.getObject(CUSTOM_B));
+    assertEquals(4, map.size());
+    assertFalse(map.isEmpty());
+    map.checkIntegrity();
+
+    Map<String, Object> collected = new HashMap<>();
+    map.fillMap(collected);
+    assertEquals(4, collected.size());
+    assertEquals("billing", collected.get(BASE_SERVICE));
+    assertEquals("alpha", collected.get(CUSTOM_A));
+    assertEquals("h2", collected.get(DB_TYPE));
+    assertEquals("beta", collected.get(CUSTOM_B));
+  }
+
+  @Test
+  void overwriteKnownReplacesInPlace() {
+    TagMap map = map();
+    map.set(COMPONENT, "first");
+    assertEquals("first", map.getObject(COMPONENT));
+    map.set(COMPONENT, "second");
+    assertEquals("second", map.getObject(COMPONENT));
+    assertEquals(1, map.size()); // overwrite, not append
+    map.checkIntegrity();
+  }
+
+  @Test
+  void removeKnownClearsIt() {
+    TagMap map = map();
+    map.set(BASE_SERVICE, "billing");
+    map.set(DB_TYPE, "h2");
+    map.set(CUSTOM_A, "alpha");
+    assertEquals(3, map.size());
+
+    TagMap.Entry removed = map.getAndRemove(BASE_SERVICE);
+    assertEquals("billing", removed.objectValue());
+    assertNull(map.getObject(BASE_SERVICE));
+    assertEquals("h2", map.getObject(DB_TYPE)); // sibling dense entry intact
+    assertEquals("alpha", map.getObject(CUSTOM_A));
+    assertEquals(2, map.size());
+    map.checkIntegrity();
+  }
+
+  @Test
+  void forEachAndIteratorEmitDenseAndBucketEntries() {
+    TagMap map = map();
+    map.set(BASE_SERVICE, "billing");
+    map.set(COMPONENT, "web");
+    map.set(CUSTOM_A, "alpha");
+
+    Map<String, Object> viaForEach = new HashMap<>();
+    map.forEach(reader -> viaForEach.put(reader.tag(), reader.objectValue()));
+    assertEquals(3, viaForEach.size());
+    assertEquals("billing", viaForEach.get(BASE_SERVICE));
+    assertEquals("web", viaForEach.get(COMPONENT));
+    assertEquals("alpha", viaForEach.get(CUSTOM_A));
+
+    Map<String, Object> viaIterator = new HashMap<>();
+    for (TagMap.EntryReader reader : map) {
+      viaIterator.put(reader.tag(), reader.objectValue());
+    }
+    assertEquals(viaForEach, viaIterator);
+  }
+
+  @Test
+  void copyPreservesDenseStore() {
+    TagMap map = map();
+    map.set(BASE_SERVICE, "billing");
+    map.set(CUSTOM_A, "alpha");
+
+    TagMap copy = (TagMap) map.copy();
+    assertEquals("billing", copy.getObject(BASE_SERVICE));
+    assertEquals("alpha", copy.getObject(CUSTOM_A));
+    assertEquals(2, copy.size());
+
+    // independence: mutating the copy doesn't touch the original's dense store
+    copy.set(BASE_SERVICE, "shipping");
+    assertEquals("shipping", copy.getObject(BASE_SERVICE));
+    assertEquals("billing", map.getObject(BASE_SERVICE));
+    copy.checkIntegrity();
+    map.checkIntegrity();
+  }
+
+  @Test
+  void clearEmptiesDenseStore() {
+    TagMap map = map();
+    map.set(BASE_SERVICE, "billing");
+    map.set(CUSTOM_A, "alpha");
+    map.clear();
+    assertEquals(0, map.size());
+    assertTrue(map.isEmpty());
+    assertNull(map.getObject(BASE_SERVICE));
+    map.checkIntegrity();
+  }
+
+  @Test
+  void putAllMergesDenseStore() {
+    TagMap src = map();
+    src.set(BASE_SERVICE, "billing");
+    src.set(DB_TYPE, "h2");
+    src.set(CUSTOM_A, "alpha");
+
+    TagMap dst = map();
+    dst.set(COMPONENT, "web"); // dense, distinct
+    dst.set(BASE_SERVICE, "old"); // dense, clobbered by src
+    dst.putAll((TagMap) src);
+
+    assertEquals("billing", dst.getObject(BASE_SERVICE)); // src clobbers
+    assertEquals("h2", dst.getObject(DB_TYPE));
+    assertEquals("web", dst.getObject(COMPONENT));
+    assertEquals("alpha", dst.getObject(CUSTOM_A));
+    assertEquals(4, dst.size());
+    dst.checkIntegrity();
+  }
+
+  // ---- read-through union (dense parent + dense child) ----
+
+  private static TagMap frozenParent() {
+    TagMap parent = map();
+    parent.set(BASE_SERVICE, "billing"); // dense
+    parent.set(COMPONENT, "web"); // dense
+    parent.set(CUSTOM_A, "alpha"); // bucket
+    parent.freeze();
+    return parent;
+  }
+
+  @Test
+  void childReadsThroughToParentDense() {
+    TagMap child = TagMap.createFromParent(frozenParent());
+    child.set(DB_TYPE, "h2"); // child-only dense
+    child.set(CUSTOM_B, "beta"); // child-only bucket
+
+    // inherited from parent
+    assertEquals("billing", child.getObject(BASE_SERVICE));
+    assertEquals("web", child.getObject(COMPONENT));
+    assertEquals("alpha", child.getObject(CUSTOM_A));
+    // own
+    assertEquals("h2", child.getObject(DB_TYPE));
+    assertEquals("beta", child.getObject(CUSTOM_B));
+    // union size: 3 parent + 2 child
+    assertEquals(5, child.size());
+    assertFalse(child.isEmpty());
+
+    Map<String, Object> union = new HashMap<>();
+    child.forEach(reader -> union.put(reader.tag(), reader.objectValue()));
+    assertEquals(5, union.size());
+    assertEquals("billing", union.get(BASE_SERVICE));
+    assertEquals("h2", union.get(DB_TYPE));
+    child.checkIntegrity();
+  }
+
+  @Test
+  void childDenseShadowsParentDense() {
+    TagMap child = TagMap.createFromParent(frozenParent());
+    child.set(BASE_SERVICE, "shipping"); // shadows parent's dense base_service
+
+    assertEquals("shipping", child.getObject(BASE_SERVICE)); // local wins
+    assertEquals("web", child.getObject(COMPONENT)); // still inherited
+    assertEquals(3, child.size()); // base_service counted once (shadowed, not doubled)
+
+    Map<String, Object> union = new HashMap<>();
+    child.forEach(reader -> union.put(reader.tag(), reader.objectValue()));
+    assertEquals(3, union.size());
+    assertEquals("shipping", union.get(BASE_SERVICE)); // shadow value, parent suppressed
+  }
+
+  @Test
+  void removingParentDenseKeyTombstonesIt() {
+    TagMap child = TagMap.createFromParent(frozenParent());
+
+    TagMap.Entry removed = child.getAndRemove(BASE_SERVICE); // parent-only dense key
+    assertEquals("billing", removed.objectValue()); // prior visible value was the parent's
+    assertNull(child.getObject(BASE_SERVICE)); // tombstoned: no read-through
+    assertEquals("web", child.getObject(COMPONENT)); // sibling still inherited
+    assertEquals(2, child.size()); // 3 parent - 1 tombstoned
+
+    Map<String, Object> union = new HashMap<>();
+    child.forEach(reader -> union.put(reader.tag(), reader.objectValue()));
+    assertEquals(2, union.size());
+    assertFalse(union.containsKey(BASE_SERVICE));
+    child.checkIntegrity();
+  }
+}

--- a/internal-api/src/test/java/datadog/trace/api/TagMapDenseFuzzForkedTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/TagMapDenseFuzzForkedTest.java
@@ -1,0 +1,202 @@
+package datadog.trace.api;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.api.TagMapFuzzTest.MapAction;
+import datadog.trace.api.TagMapFuzzTest.TestCase;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Fuzz test for the dense store under a LIVE resolver, across three key regimes. Reuses {@link
+ * TagMapFuzzTest}'s oracle machinery ({@code test(TestCase)} replays a random action sequence
+ * against a {@code HashMap}, verifying each step + {@code checkIntegrity}).
+ *
+ * <p>Uses a synthetic prefix resolver ({@code known-N} -> stored / dense, anything else -> bucket)
+ * rather than the real {@link KnownTags}: it gives an UNBOUNDED known key space, so the dense array
+ * actually grows past its initial capacity and the linear scan gets long, and it lets each test pin
+ * the known/custom ratio. The three regimes exercise paths the mixed run alone would miss:
+ *
+ * <ul>
+ *   <li><b>known-only</b> — the all-dense map (dense growth, dense-only putAll/copy/clear/iterate
+ *       with no bucket phase, knownCount-only size).
+ *   <li><b>custom-only</b> — confirms the dense branches stay inert when nothing resolves, even
+ *       with a resolver registered.
+ *   <li><b>mixed</b> — both regions and their interaction.
+ * </ul>
+ *
+ * <p>Forked (isolated JVM) because resolver registration is a global static with no un-register.
+ */
+class TagMapDenseFuzzForkedTest {
+  static final int SINGLE_MAP_CASES = 1500;
+  static final int MERGE_CASES = 400;
+  static final int MAX_ACTIONS = 40;
+  static final int MIN_ACTIONS = 8;
+
+  // unbounded synthetic key spaces — large enough to grow the dense array past cap-8 several times
+  static final int KNOWN_SPACE = 48;
+  static final int CUSTOM_SPACE = 48;
+
+  enum Regime {
+    KNOWN_ONLY,
+    CUSTOM_ONLY,
+    MIXED
+  }
+
+  /**
+   * Synthetic resolver: {@code known-N} -> stored id (serial = FIRST_STORED_SERIAL + N); else 0.
+   */
+  static final KnownTagCodec.Resolver FUZZ_RESOLVER =
+      new KnownTagCodec.Resolver() {
+        @Override
+        public long keyOf(String name) {
+          if (name.startsWith("known-")) {
+            int n = Integer.parseInt(name.substring("known-".length()));
+            return KnownTagCodec.tagId(KnownTagCodec.FIRST_STORED_SERIAL + n, name);
+          }
+          return 0L;
+        }
+
+        @Override
+        public String nameOf(long tagId) {
+          int serial = KnownTagCodec.globalSerial(tagId);
+          return serial >= KnownTagCodec.FIRST_STORED_SERIAL
+              ? "known-" + (serial - KnownTagCodec.FIRST_STORED_SERIAL)
+              : null;
+        }
+
+        @Override
+        public int slotCount() {
+          return 0; // positional unused
+        }
+      };
+
+  @BeforeAll
+  static void registerResolver() {
+    KnownTagCodec.register(FUZZ_RESOLVER);
+    assertTrue(KnownTagCodec.isActive(), "resolver must be live");
+    assertTrue(KnownTagCodec.isStored(KnownTagCodec.keyOf("known-0")), "known- routes dense");
+    assertFalse(
+        KnownTagCodec.isStored(KnownTagCodec.keyOf("custom-0")), "custom- stays in buckets");
+    // round-trip the synthetic encoding
+    long id = KnownTagCodec.keyOf("known-7");
+    assertTrue("known-7".equals(KnownTagCodec.nameOf(id)), "name<->id round-trips");
+  }
+
+  @Test
+  void knownOnlyFuzz() {
+    runRegime(Regime.KNOWN_ONLY);
+  }
+
+  @Test
+  void customOnlyFuzz() {
+    runRegime(Regime.CUSTOM_ONLY);
+  }
+
+  @Test
+  void mixedFuzz() {
+    runRegime(Regime.MIXED);
+  }
+
+  private static void runRegime(Regime regime) {
+    for (int i = 0; i < SINGLE_MAP_CASES; ++i) {
+      TagMapFuzzTest.test(generateTest(regime));
+    }
+    for (int i = 0; i < MERGE_CASES; ++i) {
+      TagMap mapA = TagMapFuzzTest.test(generateTest(regime));
+      TagMap mapB = TagMapFuzzTest.test(generateTest(regime));
+
+      HashMap<String, Object> hashA = new HashMap<>(mapA);
+      HashMap<String, Object> hashB = new HashMap<>(mapB);
+
+      mapA.putAll(mapB);
+      hashA.putAll(hashB);
+
+      TagMapFuzzTest.assertMapEquals(hashA, mapA);
+    }
+  }
+
+  // --- action generation (mirrors TagMapFuzzTest.randomAction, regime-driven key pool) ---
+
+  private static TestCase generateTest(Regime regime) {
+    ThreadLocalRandom r = ThreadLocalRandom.current();
+    int numActions = r.nextInt(MAX_ACTIONS - MIN_ACTIONS) + MIN_ACTIONS;
+    List<MapAction> actions = new ArrayList<>(numActions);
+    for (int i = 0; i < numActions; ++i) {
+      actions.add(randomAction(regime));
+    }
+    return new TestCase(actions);
+  }
+
+  private static MapAction randomAction(Regime regime) {
+    switch (randomChoice(0.02, 0.1, 0.2)) {
+      case 0:
+        return TagMapFuzzTest.clear();
+      case 1:
+        return choose(
+            () -> TagMapFuzzTest.putAll(randomKeysAndValues(regime)),
+            () -> TagMapFuzzTest.putAllTagMap(randomKeysAndValues(regime)),
+            () -> TagMapFuzzTest.putAllLedger(randomKeysAndValues(regime)));
+      case 2:
+        return choose(
+            () -> TagMapFuzzTest.remove(randomKey(regime)),
+            () -> TagMapFuzzTest.removeLight(randomKey(regime)),
+            () -> TagMapFuzzTest.getAndRemove(randomKey(regime)));
+      default:
+        return choose(
+            () -> TagMapFuzzTest.put(randomKey(regime), randomValue()),
+            () -> TagMapFuzzTest.set(randomKey(regime), randomValue()),
+            () -> TagMapFuzzTest.getAndSet(randomKey(regime), randomValue()));
+    }
+  }
+
+  private static String randomKey(Regime regime) {
+    ThreadLocalRandom r = ThreadLocalRandom.current();
+    boolean known;
+    switch (regime) {
+      case KNOWN_ONLY:
+        known = true;
+        break;
+      case CUSTOM_ONLY:
+        known = false;
+        break;
+      default:
+        known = r.nextBoolean();
+    }
+    return known ? "known-" + r.nextInt(KNOWN_SPACE) : "custom-" + r.nextInt(CUSTOM_SPACE);
+  }
+
+  private static String randomValue() {
+    return "values-" + ThreadLocalRandom.current().nextInt();
+  }
+
+  private static String[] randomKeysAndValues(Regime regime) {
+    int numEntries = ThreadLocalRandom.current().nextInt(KNOWN_SPACE + CUSTOM_SPACE);
+    String[] keysAndValues = new String[numEntries << 1];
+    for (int i = 0; i < keysAndValues.length; i += 2) {
+      keysAndValues[i] = randomKey(regime);
+      keysAndValues[i + 1] = randomValue();
+    }
+    return keysAndValues;
+  }
+
+  private static int randomChoice(double... proportions) {
+    double selector = ThreadLocalRandom.current().nextDouble();
+    for (int i = 0; i < proportions.length; ++i) {
+      if (selector < proportions[i]) return i;
+      selector -= proportions[i];
+    }
+    return proportions.length;
+  }
+
+  @SafeVarargs
+  private static MapAction choose(Supplier<MapAction>... choices) {
+    return choices[ThreadLocalRandom.current().nextInt(choices.length)].get();
+  }
+}

--- a/internal-api/src/test/java/datadog/trace/api/TagMapDenseFuzzForkedTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/TagMapDenseFuzzForkedTest.java
@@ -1,0 +1,210 @@
+package datadog.trace.api;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.api.TagMapFuzzTest.MapAction;
+import datadog.trace.api.TagMapFuzzTest.TestCase;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Fuzz test for the dense store under a LIVE resolver, across three key regimes. Reuses {@link
+ * TagMapFuzzTest}'s oracle machinery ({@code test(TestCase)} replays a random action sequence
+ * against a {@code HashMap}, verifying each step + {@code checkIntegrity}).
+ *
+ * <p>Uses a synthetic prefix resolver ({@code known-N} -> stored / dense, anything else -> bucket)
+ * rather than the real {@link KnownTags}: it gives an UNBOUNDED known key space, so the dense array
+ * actually grows past its initial capacity and the linear scan gets long, and it lets each test pin
+ * the known/custom ratio. The three regimes exercise paths the mixed run alone would miss:
+ *
+ * <ul>
+ *   <li><b>known-only</b> — the all-dense map (dense growth, dense-only putAll/copy/clear/iterate
+ *       with no bucket phase, knownCount-only size).
+ *   <li><b>custom-only</b> — confirms the dense branches stay inert when nothing resolves, even
+ *       with a resolver registered.
+ *   <li><b>mixed</b> — both regions and their interaction.
+ * </ul>
+ *
+ * <p>Forked (isolated JVM) because resolver registration is a global static with no un-register.
+ */
+class TagMapDenseFuzzForkedTest {
+  static {
+    // Dense routing is a const-folded gate (KnownTagCodec.DENSE_STORE, captured from Config at
+    // KnownTagCodec's class-init). Set the flag before anything touches Config/KnownTagCodec so the
+    // gate reads true in this forked JVM. Registering the resolver alone no longer engages dense.
+    System.setProperty("dd.trace.experimental.dense.tags.enabled", "true");
+  }
+
+  static final int SINGLE_MAP_CASES = 1500;
+  static final int MERGE_CASES = 400;
+  static final int MAX_ACTIONS = 40;
+  static final int MIN_ACTIONS = 8;
+
+  // unbounded synthetic key spaces — large enough to grow the dense array past cap-8 several times
+  static final int KNOWN_SPACE = 48;
+  static final int CUSTOM_SPACE = 48;
+
+  enum Regime {
+    KNOWN_ONLY,
+    CUSTOM_ONLY,
+    MIXED
+  }
+
+  /**
+   * Synthetic resolver: {@code known-N} -> stored id (serial = FIRST_STORED_SERIAL + N); else 0.
+   */
+  static final KnownTagCodec.Resolver FUZZ_RESOLVER =
+      new KnownTagCodec.Resolver() {
+        @Override
+        public long keyOf(String name) {
+          if (name.startsWith("known-")) {
+            int n = Integer.parseInt(name.substring("known-".length()));
+            return KnownTagCodec.tagId(KnownTagCodec.FIRST_STORED_SERIAL + n, name);
+          }
+          return 0L;
+        }
+
+        @Override
+        public String nameOf(long tagId) {
+          int serial = KnownTagCodec.globalSerial(tagId);
+          return serial >= KnownTagCodec.FIRST_STORED_SERIAL
+              ? "known-" + (serial - KnownTagCodec.FIRST_STORED_SERIAL)
+              : null;
+        }
+
+        @Override
+        public int slotCount() {
+          return 0; // positional unused
+        }
+      };
+
+  @BeforeAll
+  static void registerResolver() {
+    KnownTagCodec.register(FUZZ_RESOLVER);
+    assertTrue(KnownTagCodec.isActive(), "resolver must be live");
+    assertTrue(KnownTagCodec.DENSE_STORE, "dense store must be enabled in this forked JVM");
+    assertTrue(KnownTagCodec.routesToDense(KnownTagCodec.keyOf("known-0")), "known- routes dense");
+    assertFalse(
+        KnownTagCodec.routesToDense(KnownTagCodec.keyOf("custom-0")), "custom- stays in buckets");
+    // round-trip the synthetic encoding
+    long id = KnownTagCodec.keyOf("known-7");
+    assertTrue("known-7".equals(KnownTagCodec.nameOf(id)), "name<->id round-trips");
+  }
+
+  @Test
+  void knownOnlyFuzz() {
+    runRegime(Regime.KNOWN_ONLY);
+  }
+
+  @Test
+  void customOnlyFuzz() {
+    runRegime(Regime.CUSTOM_ONLY);
+  }
+
+  @Test
+  void mixedFuzz() {
+    runRegime(Regime.MIXED);
+  }
+
+  private static void runRegime(Regime regime) {
+    for (int i = 0; i < SINGLE_MAP_CASES; ++i) {
+      TagMapFuzzTest.test(generateTest(regime));
+    }
+    for (int i = 0; i < MERGE_CASES; ++i) {
+      TagMap mapA = TagMapFuzzTest.test(generateTest(regime));
+      TagMap mapB = TagMapFuzzTest.test(generateTest(regime));
+
+      HashMap<String, Object> hashA = new HashMap<>(mapA);
+      HashMap<String, Object> hashB = new HashMap<>(mapB);
+
+      mapA.putAll(mapB);
+      hashA.putAll(hashB);
+
+      TagMapFuzzTest.assertMapEquals(hashA, mapA);
+    }
+  }
+
+  // --- action generation (mirrors TagMapFuzzTest.randomAction, regime-driven key pool) ---
+
+  private static TestCase generateTest(Regime regime) {
+    ThreadLocalRandom r = ThreadLocalRandom.current();
+    int numActions = r.nextInt(MAX_ACTIONS - MIN_ACTIONS) + MIN_ACTIONS;
+    List<MapAction> actions = new ArrayList<>(numActions);
+    for (int i = 0; i < numActions; ++i) {
+      actions.add(randomAction(regime));
+    }
+    return new TestCase(actions);
+  }
+
+  private static MapAction randomAction(Regime regime) {
+    switch (randomChoice(0.02, 0.1, 0.2)) {
+      case 0:
+        return TagMapFuzzTest.clear();
+      case 1:
+        return choose(
+            () -> TagMapFuzzTest.putAll(randomKeysAndValues(regime)),
+            () -> TagMapFuzzTest.putAllTagMap(randomKeysAndValues(regime)),
+            () -> TagMapFuzzTest.putAllLedger(randomKeysAndValues(regime)));
+      case 2:
+        return choose(
+            () -> TagMapFuzzTest.remove(randomKey(regime)),
+            () -> TagMapFuzzTest.removeLight(randomKey(regime)),
+            () -> TagMapFuzzTest.getAndRemove(randomKey(regime)));
+      default:
+        return choose(
+            () -> TagMapFuzzTest.put(randomKey(regime), randomValue()),
+            () -> TagMapFuzzTest.set(randomKey(regime), randomValue()),
+            () -> TagMapFuzzTest.getAndSet(randomKey(regime), randomValue()));
+    }
+  }
+
+  private static String randomKey(Regime regime) {
+    ThreadLocalRandom r = ThreadLocalRandom.current();
+    boolean known;
+    switch (regime) {
+      case KNOWN_ONLY:
+        known = true;
+        break;
+      case CUSTOM_ONLY:
+        known = false;
+        break;
+      default:
+        known = r.nextBoolean();
+    }
+    return known ? "known-" + r.nextInt(KNOWN_SPACE) : "custom-" + r.nextInt(CUSTOM_SPACE);
+  }
+
+  private static String randomValue() {
+    return "values-" + ThreadLocalRandom.current().nextInt();
+  }
+
+  private static String[] randomKeysAndValues(Regime regime) {
+    int numEntries = ThreadLocalRandom.current().nextInt(KNOWN_SPACE + CUSTOM_SPACE);
+    String[] keysAndValues = new String[numEntries << 1];
+    for (int i = 0; i < keysAndValues.length; i += 2) {
+      keysAndValues[i] = randomKey(regime);
+      keysAndValues[i + 1] = randomValue();
+    }
+    return keysAndValues;
+  }
+
+  private static int randomChoice(double... proportions) {
+    double selector = ThreadLocalRandom.current().nextDouble();
+    for (int i = 0; i < proportions.length; ++i) {
+      if (selector < proportions[i]) return i;
+      selector -= proportions[i];
+    }
+    return proportions.length;
+  }
+
+  @SafeVarargs
+  private static MapAction choose(Supplier<MapAction>... choices) {
+    return choices[ThreadLocalRandom.current().nextInt(choices.length)].get();
+  }
+}

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -5780,6 +5780,14 @@
         "aliases": []
       }
     ],
+    "DD_TRACE_EXPERIMENTAL_DENSE_TAGS_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "false",
+        "aliases": []
+      }
+    ],
     "DD_TRACE_EXPERIMENTAL_FEATURES_ENABLED": [
       {
         "version": "A",


### PR DESCRIPTION
## What

Adds a **dense store** for known span tags in `TagMap`: tags resolved to a stable tag-id via `KnownTagCodec.keyOf` are held in insertion-ordered parallel arrays (`knownIds`/`knownValues`) with **no per-tag `Entry` object** — eliminating the `TagMap$Entry` allocation that macro JFR profiling flagged as the #1 tracer allocation lever.

- **Name resolution and dense routing are decoupled.** A `KnownTagCodec` is *always* installed — the real resolver via `KnownTags.register()` at tracer init, or a lazily-locked empty `NoKnownTagCodec` null-object if nothing registers. So `keyOf`/`nameOf` are always available, but whether known tags then take the dense storage path is a **separate** decision.
- **Dense routing is gated behind a const-folded `static final DENSE_STORE`** (`trace.experimental.dense.tags.enabled`, default **off**). When off, HotSpot dead-code-eliminates the `keyOf` call and the dense branches, so the default path is **byte-identical** to the bucket-only store — no new work on the hot path.
- Iteration/serialization emit dense entries through a reused flyweight (`EntryReadingHelper`) — no per-entry `Entry` alloc on the read/serialize path either.
- Read-through is **chain-aware**: dense entries participate in the multi-level ancestor union via `parentDenseVisible` (mirrors `parentEntryVisible`), nearest-level-wins with tombstone/shadow checks. Disjointness (known tags never bucket) keeps the two stores independent by construction.

## Why

Removes `TagMap$Entry` allocation for known tags (the macro alloc win — see the tracer-overhead JFR profiling). CPU is neutral/parity; the headline is allocation on the app thread.

Decoupling name-resolution from dense-routing lets the codec register unconditionally (needed by later PRs in the stack — e.g. OpenTelemetry name resolution) without forcing every tag through the dense store: the store stays opt-in and off-by-default while resolution becomes always-on.

## Stack

Sits on `dougqh/tagset` (StringIndex / #11660 base). Supersedes the old dense PR #11814.

## Test

`TagMapDenseForkedTest`, `TagMapDenseFuzzForkedTest` (dense on), `KnownTagsTest` + default-off `TagMapTest`/`TagMapFuzzTest` green; `spotbugsMain` + `spotlessJavaCheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
