### PR TITLE
Limit growth of OTLP trace buffer

### DIFF
--- a/components/json/src/main/java/datadog/json/JsonWriter.java
+++ b/components/json/src/main/java/datadog/json/JsonWriter.java
@@ -19,6 +19,7 @@ public final class JsonWriter implements Flushable, AutoCloseable {
   private final JsonStructure structure;
 
   private boolean requireComma;
+  private int bytesWritten;
 
   /** Creates a writer with structure check. */
   public JsonWriter() {
@@ -245,6 +246,11 @@ public final class JsonWriter implements Flushable, AutoCloseable {
     }
   }
 
+  /** Approximate number of bytes written so far. */
+  public int sizeInBytes() {
+    return this.bytesWritten;
+  }
+
   @Override
   public void close() {
     try {
@@ -268,6 +274,7 @@ public final class JsonWriter implements Flushable, AutoCloseable {
   private void write(char ch) {
     try {
       this.writer.write(ch);
+      this.bytesWritten++;
     } catch (IOException ignored) {
     }
   }
@@ -275,6 +282,7 @@ public final class JsonWriter implements Flushable, AutoCloseable {
   private void writeStringLiteral(String str) {
     try {
       this.writer.write('"');
+      int count = 1;
 
       for (int i = 0; i < str.length(); ++i) {
         char c = str.charAt(i);
@@ -286,6 +294,7 @@ public final class JsonWriter implements Flushable, AutoCloseable {
           this.writer.write(HEX_DIGITS[(c >>> 8) & 0xF]);
           this.writer.write(HEX_DIGITS[(c >>> 4) & 0xF]);
           this.writer.write(HEX_DIGITS[c & 0xF]);
+          count += 6;
         } else {
           switch (c) {
             case '"': // Quotation mark
@@ -293,26 +302,32 @@ public final class JsonWriter implements Flushable, AutoCloseable {
             case '/': // Solidus
               this.writer.write('\\');
               this.writer.write(c);
+              count += 2;
               break;
             case '\b': // Backspace
               this.writer.write('\\');
               this.writer.write('b');
+              count += 2;
               break;
             case '\f': // Form feed
               this.writer.write('\\');
               this.writer.write('f');
+              count += 2;
               break;
             case '\n': // Line feed
               this.writer.write('\\');
               this.writer.write('n');
+              count += 2;
               break;
             case '\r': // Carriage return
               this.writer.write('\\');
               this.writer.write('r');
+              count += 2;
               break;
             case '\t': // Horizontal tab
               this.writer.write('\\');
               this.writer.write('t');
+              count += 2;
               break;
             default:
               if (c < 0x20) {
@@ -322,8 +337,10 @@ public final class JsonWriter implements Flushable, AutoCloseable {
                 this.writer.write('0');
                 this.writer.write(HEX_DIGITS[(c >>> 4) & 0xF]);
                 this.writer.write(HEX_DIGITS[c & 0xF]);
+                count += 6;
               } else {
                 this.writer.write(c);
+                count += 1;
               }
               break;
           }
@@ -331,6 +348,9 @@ public final class JsonWriter implements Flushable, AutoCloseable {
       }
 
       this.writer.write('"');
+      count += 1;
+
+      this.bytesWritten += count;
     } catch (IOException ignored) {
     }
   }
@@ -338,6 +358,7 @@ public final class JsonWriter implements Flushable, AutoCloseable {
   private void writeStringRaw(String str) {
     try {
       this.writer.write(str);
+      this.bytesWritten += str.length(); // exact if ASCII, estimate otherwise
     } catch (IOException ignored) {
     }
   }

--- a/components/json/src/test/java/datadog/json/JsonWriterTest.java
+++ b/components/json/src/test/java/datadog/json/JsonWriterTest.java
@@ -166,6 +166,54 @@ class JsonWriterTest {
   }
 
   @Test
+  void testSizeInBytes() {
+    try (JsonWriter writer = new JsonWriter()) {
+      assertEquals(0, writer.sizeInBytes(), "Check empty writer size");
+
+      writer.beginArray();
+      assertSizeInBytes(writer, "Check size after plain ASCII string");
+      writer.value("bar");
+
+      assertSizeInBytes(writer, "Check size after escaped characters");
+      writer.value("\"\\/");
+
+      assertSizeInBytes(writer, "Check size after named escapes");
+      writer.value("\b\f\n\r\t");
+
+      assertSizeInBytes(writer, "Check size after control character escape");
+      writer.value("\u0001");
+
+      assertSizeInBytes(writer, "Check size after non-ASCII character escape");
+      writer.value("café");
+
+      assertSizeInBytes(writer, "Check size after int value");
+      writer.value(3);
+
+      assertSizeInBytes(writer, "Check size after long value");
+      writer.value(3456789123L);
+
+      assertSizeInBytes(writer, "Check size after float value");
+      writer.value(3.142f);
+
+      assertSizeInBytes(writer, "Check size after double value");
+      writer.value(PI);
+
+      assertSizeInBytes(writer, "Check size after boolean value");
+      writer.value(true);
+
+      assertSizeInBytes(writer, "Check size after null value");
+      writer.nullValue();
+
+      writer.endArray();
+      assertSizeInBytes(writer, "Check final size matches written bytes");
+    }
+  }
+
+  private static void assertSizeInBytes(JsonWriter writer, String message) {
+    assertEquals(writer.toByteArray().length, writer.sizeInBytes(), message);
+  }
+
+  @Test
   void testCompleteArray() {
     try (JsonWriter writer = new JsonWriter()) {
       writer.beginArray();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpPayloadDispatcher.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpPayloadDispatcher.java
@@ -7,8 +7,14 @@ import datadog.trace.core.otlp.trace.OtlpTraceCollector;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class OtlpPayloadDispatcher implements PayloadDispatcher {
+  private static final Logger log = LoggerFactory.getLogger(OtlpPayloadDispatcher.class);
+
+  private static final int FLUSH_THRESHOLD_BYTES = 5 << 20; // 5 MiB
+
   private final OtlpTraceCollector collector;
   private final OtlpSender sender;
 
@@ -20,13 +26,21 @@ final class OtlpPayloadDispatcher implements PayloadDispatcher {
   @Override
   public void addTrace(List<? extends CoreSpan<?>> trace) {
     collector.addTrace(trace);
+    // flush proactively to keep payload size bounded
+    if (collector.sizeInBytes() >= FLUSH_THRESHOLD_BYTES) {
+      flush();
+    }
   }
 
   @Override
   public void flush() {
-    OtlpPayload payload = collector.collectTraces();
-    if (payload != OtlpPayload.EMPTY) {
-      sender.send(payload);
+    try {
+      OtlpPayload payload = collector.collectTraces();
+      if (payload != OtlpPayload.EMPTY) {
+        sender.send(payload);
+      }
+    } catch (RuntimeException e) { // don't catch severe Errors
+      log.debug("Failed to send OTLP payload", e);
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpProtoBuffer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpProtoBuffer.java
@@ -18,12 +18,23 @@ import java.nio.ByteBuffer;
  * @see GrowableBuffer
  */
 public final class OtlpProtoBuffer {
+  // hard limit to avoid unbounded buffering; matches OTLP spec's recommended default
+  public static final int MAX_CAPACITY_BYTES = 64 << 20; // 64 MiB
+
   private final int initialCapacity;
   private ByteBuffer buffer;
   private int remaining;
 
   public OtlpProtoBuffer(int requiredCapacity) {
     this.initialCapacity = nextPowerOfTwo(requiredCapacity);
+    if (this.initialCapacity > MAX_CAPACITY_BYTES) {
+      throw new IllegalArgumentException(
+          "OTLP payload initial capacity of "
+              + this.initialCapacity
+              + " bytes exceeds maximum buffer size of "
+              + MAX_CAPACITY_BYTES
+              + " bytes");
+    }
     this.buffer = ByteBuffer.allocate(initialCapacity);
     this.remaining = initialCapacity;
   }
@@ -96,6 +107,11 @@ public final class OtlpProtoBuffer {
     return buffer;
   }
 
+  /** Returns the number of bytes currently recorded in the buffer. */
+  public int sizeInBytes() {
+    return buffer.capacity() - remaining;
+  }
+
   /**
    * Returns an {@link OtlpPayload} containing the protobuf encoded content.
    *
@@ -123,10 +139,21 @@ public final class OtlpProtoBuffer {
       ByteBuffer oldBuffer = flip();
       int oldSize = oldBuffer.remaining();
       // round up to next multiple of initialCapacity that can accommodate required
-      int newSize = (oldSize + required + initialCapacity - 1) & -initialCapacity;
-      ByteBuffer newBuffer = ByteBuffer.allocate(newSize);
+      // (uses long arithmetic so overflow can be detected before allocating)
+      long newSize = ((long) oldSize + required + initialCapacity - 1) & -initialCapacity;
+      if (newSize > MAX_CAPACITY_BYTES) {
+        throw new IllegalStateException(
+            "OTLP payload exceeds maximum buffer size of "
+                + MAX_CAPACITY_BYTES
+                + " bytes: "
+                + oldSize
+                + " bytes buffered, "
+                + required
+                + " more requested");
+      }
+      ByteBuffer newBuffer = ByteBuffer.allocate((int) newSize);
       // copy over old content so it stays at the far end
-      remaining = newSize - oldSize;
+      remaining = (int) newSize - oldSize;
       newBuffer.position(remaining);
       newBuffer.put(oldBuffer);
       buffer = newBuffer;

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceCollector.java
@@ -15,6 +15,9 @@ public abstract class OtlpTraceCollector {
   /** Collects all spans added since the last collection. */
   public abstract OtlpPayload collectTraces();
 
+  /** Returns the number of bytes buffered since the last collection. */
+  public abstract int sizeInBytes();
+
   protected final boolean shouldExport(CoreSpan<?> span) {
     return span.samplingPriority() > 0 // trace-level sampling priority
         || span.getTag(SPAN_SAMPLING_MECHANISM_TAG) != null; // span-level sampling priority

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollector.java
@@ -2,6 +2,7 @@ package datadog.trace.core.otlp.trace;
 
 import static datadog.trace.core.otlp.common.OtlpCommonJson.writeScopeAndSchema;
 import static datadog.trace.core.otlp.common.OtlpPayload.JSON_CONTENT_TYPE;
+import static datadog.trace.core.otlp.common.OtlpProtoBuffer.MAX_CAPACITY_BYTES;
 import static datadog.trace.core.otlp.common.OtlpResourceJson.TRACE_RESOURCE_FRAGMENT;
 import static datadog.trace.core.otlp.trace.OtlpTraceJson.writeSpan;
 
@@ -54,9 +55,20 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
       payloadStarted = true;
     }
 
-    for (CoreSpan<?> span : spans) {
-      visitSpan(span);
+    try {
+      for (CoreSpan<?> span : spans) {
+        visitSpan(span);
+      }
+    } catch (Throwable e) {
+      // reset the buffer for subsequent traces
+      stop();
+      throw e;
     }
+  }
+
+  @Override
+  public int sizeInBytes() {
+    return writer == null ? 0 : writer.sizeInBytes();
   }
 
   /**
@@ -178,5 +190,10 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
     // reset temporary elements for next span
     currentSpan = null;
     currentSpanLinks = Collections.emptyList();
+
+    if (writer.sizeInBytes() > MAX_CAPACITY_BYTES) {
+      throw new IllegalStateException(
+          "OTLP payload exceeds maximum buffer size of " + MAX_CAPACITY_BYTES + " bytes");
+    }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProtoCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProtoCollector.java
@@ -56,10 +56,21 @@ public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
       payloadStarted = true;
     }
 
-    // OtlpProtoBuffer collects spans in reverse
-    for (int i = spans.size() - 1; i >= 0; i--) {
-      visitSpan(spans.get(i));
+    try {
+      // OtlpProtoBuffer collects spans in reverse
+      for (int i = spans.size() - 1; i >= 0; i--) {
+        visitSpan(spans.get(i));
+      }
+    } catch (Throwable e) {
+      // reset the buffer for subsequent traces
+      stop();
+      throw e;
     }
+  }
+
+  @Override
+  public int sizeInBytes() {
+    return protobuf.sizeInBytes();
   }
 
   /**

--- a/dd-trace-core/src/test/java/datadog/trace/common/writer/OtlpPayloadDispatcherTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/writer/OtlpPayloadDispatcherTest.java
@@ -5,6 +5,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -96,6 +97,68 @@ class OtlpPayloadDispatcherTest {
   }
 
   @Test
+  void largeTraceTriggersProactiveFlushWithoutExplicitFlush() {
+    OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender, collector);
+    collector.fakeSizeInBytes = Integer.MAX_VALUE;
+
+    dispatcher.addTrace(singletonList(sampledSpan()));
+
+    // no explicit dispatcher.flush() call
+    ArgumentCaptor<OtlpPayload> captor = ArgumentCaptor.forClass(OtlpPayload.class);
+    verify(sender).send(captor.capture());
+    assertEquals(1 /*spans*/, captor.getValue().getContentLength());
+  }
+
+  @Test
+  void belowFlushThresholdDoesNotTriggerProactiveFlush() {
+    OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender, collector);
+    collector.fakeSizeInBytes = (5 << 20) - 1; // one byte under FLUSH_THRESHOLD_BYTES
+
+    dispatcher.addTrace(singletonList(sampledSpan()));
+
+    verifyNoInteractions(sender);
+  }
+
+  @Test
+  void atFlushThresholdTriggersProactiveFlush() {
+    OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender, collector);
+    collector.fakeSizeInBytes = 5 << 20; // exactly FLUSH_THRESHOLD_BYTES
+
+    dispatcher.addTrace(singletonList(sampledSpan()));
+
+    verify(sender).send(any(OtlpPayload.class));
+  }
+
+  @Test
+  void flushSwallowsCollectorFailureInsteadOfPropagating() {
+    // e.g. a held-back span pushes the payload over the buffer's hard cap only once
+    // collectTraces() finalizes it during a scheduled flush, not during addTrace()
+    OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender, collector);
+    dispatcher.addTrace(singletonList(sampledSpan()));
+    collector.throwOnCollect = true;
+
+    dispatcher.flush();
+
+    verifyNoInteractions(sender);
+  }
+
+  @Test
+  void dispatcherRemainsUsableAfterCollectorFailure() {
+    OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender, collector);
+    dispatcher.addTrace(singletonList(sampledSpan()));
+    collector.throwOnCollect = true;
+    dispatcher.flush();
+
+    collector.throwOnCollect = false;
+    dispatcher.addTrace(singletonList(sampledSpan()));
+    dispatcher.flush();
+
+    ArgumentCaptor<OtlpPayload> captor = ArgumentCaptor.forClass(OtlpPayload.class);
+    verify(sender).send(captor.capture());
+    assertEquals(1 /*spans*/, captor.getValue().getContentLength());
+  }
+
+  @Test
   void getApisIsEmpty() {
     OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender, collector);
 
@@ -143,6 +206,12 @@ class OtlpPayloadDispatcherTest {
   private static class TestCollector extends OtlpTraceCollector {
     final List<CoreSpan<?>> spansToExport = new ArrayList<>();
 
+    // lets tests drive the proactive-flush threshold independently of spansToExport
+    int fakeSizeInBytes;
+
+    // lets tests simulate a collectTraces() failure, e.g. a buffer overflow on the held-back span
+    boolean throwOnCollect;
+
     @Override
     public void addTrace(List<? extends CoreSpan<?>> spans) {
       for (CoreSpan<?> span : spans) {
@@ -154,6 +223,11 @@ class OtlpPayloadDispatcherTest {
 
     @Override
     public OtlpPayload collectTraces() {
+      if (throwOnCollect) {
+        // mirrors the real collectors, which always reset state via a finally block
+        spansToExport.clear();
+        throw new IllegalStateException("simulated buffer overflow");
+      }
       if (spansToExport.isEmpty()) {
         return OtlpPayload.EMPTY;
       }
@@ -164,6 +238,11 @@ class OtlpPayloadDispatcherTest {
       } finally {
         spansToExport.clear();
       }
+    }
+
+    @Override
+    public int sizeInBytes() {
+      return fakeSizeInBytes;
     }
   }
 }

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/common/OtlpProtoBufferTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/common/OtlpProtoBufferTest.java
@@ -60,6 +60,14 @@ class OtlpProtoBufferTest {
     assertEquals("application/x-protobuf", payload.getContentType());
   }
 
+  @Test
+  void constructorRejectsCapacityExceedingMaxCapacity() {
+    // rounds up to a power of two above MAX_CAPACITY_BYTES; must reject before allocating
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new OtlpProtoBuffer(OtlpProtoBuffer.MAX_CAPACITY_BYTES + 1));
+  }
+
   // ─── recordMessage(GrowableBuffer, int) ──────────────────────────────────
 
   @Test

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollectorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollectorTest.java
@@ -10,7 +10,10 @@ import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import datadog.json.JsonMapper;
 import datadog.trace.api.DDTraceId;
@@ -204,6 +207,30 @@ class OtlpTraceJsonCollectorTest {
             .findFirst()
             .orElseThrow(() -> new AssertionError("child span not found"));
     assertEquals(hexSpanId(((DDSpan) parent).getSpanId()), parsedChild.get("parentSpanId"));
+  }
+
+  @Test
+  void poisonedSpanResetsCollectorForNextTrace() throws IOException {
+    // mid-trace exception (e.g. from a malformed span) must not leave partial state behind
+    DDSpan realSpan = startAndFinish("op.first", "GET /first", null);
+
+    CoreSpan<?> poison = mock(CoreSpan.class);
+    when(poison.samplingPriority()).thenReturn(1);
+    when(poison.getTraceId()).thenThrow(new RuntimeException("boom"));
+
+    List<CoreSpan<?>> poisonedTrace = new ArrayList<>();
+    poisonedTrace.add((CoreSpan<?>) realSpan);
+    poisonedTrace.add(poison);
+
+    OtlpTraceJsonCollector collector = new OtlpTraceJsonCollector();
+    assertThrows(RuntimeException.class, () -> collector.addTrace(poisonedTrace));
+
+    // a normal trace collected afterwards must not see any leftover state from the poisoned one
+    DDSpan normalSpan = startAndFinish("op.normal", "GET /normal", null);
+    collector.addTrace(asList((CoreSpan<?>) normalSpan));
+    Map<String, Object> parsedSpan = onlySpan(collector.collectTraces());
+
+    assertEquals("GET /normal", parsedSpan.get("name"));
   }
 
   @Test

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceProtoTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceProtoTest.java
@@ -16,7 +16,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.WireFormat;
@@ -29,6 +32,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.SpanAttributes;
 import datadog.trace.bootstrap.instrumentation.api.SpanLink;
 import datadog.trace.common.writer.LoggingWriter;
+import datadog.trace.core.CoreSpan;
 import datadog.trace.core.CoreTracer;
 import datadog.trace.core.DDSpan;
 import datadog.trace.core.otlp.common.OtlpPayload;
@@ -626,6 +630,30 @@ class OtlpTraceProtoTest {
         expectedTraceIds.size(),
         parsedTraceIds.size(),
         "payload must contain spans with all three distinct trace IDs");
+  }
+
+  @Test
+  void poisonedSpanResetsCollectorForNextTrace() {
+    // mid-trace exception (e.g. from a malformed span) must not leave partial state behind
+    DDSpan realSpan = buildSpans(asList(span("first.span", "op.first", "web"))).get(0);
+
+    CoreSpan<?> poison = mock(CoreSpan.class);
+    when(poison.samplingPriority()).thenReturn(1);
+    when(poison.getTraceId()).thenThrow(new RuntimeException("boom"));
+
+    List<CoreSpan<?>> poisonedTrace = new ArrayList<>();
+    poisonedTrace.add(poison);
+    poisonedTrace.add(realSpan);
+
+    OtlpTraceProtoCollector collector = new OtlpTraceProtoCollector();
+    assertThrows(RuntimeException.class, () -> collector.addTrace(poisonedTrace));
+
+    // a normal trace collected afterwards must not see any leftover state from the poisoned one
+    List<DDSpan> normalTrace = buildSpans(asList(span("normal.op", "op.normal", "web")));
+    collector.addTrace(normalTrace);
+    OtlpPayload payload = collector.collectTraces();
+
+    assertTrue(payload.getContentLength() > 0, "normal trace after reset must still export");
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do

* Proactively flush OTLP traces between scheduled flushes to try to keep payload size below 5 MiB
* Add hard limit of 64 MiB to OTLP payloads, as recommended in https://opentelemetry.io/docs/specs/otlp/

# Motivation

Avoids the following exception when large amounts of trace data is collected:
```
java.lang.IllegalArgumentException
  at java.base/java.nio.Buffer.createCapacityException(Buffer.java:279)
  at java.base/java.nio.ByteBuffer.allocate(ByteBuffer.java:362)
  at datadog.trace.agent.core.otlp.common.OtlpProtoBuffer.checkCapacity(OtlpProtoBuffer.java:128)
  at datadog.trace.agent.core.otlp.common.OtlpProtoBuffer.recordMessage(OtlpProtoBuffer.java:60)
  at datadog.trace.agent.core.otlp.trace.OtlpTraceProto.recordSpanMessage(OtlpTraceProto.java:166)
  at datadog.trace.agent.core.otlp.trace.OtlpTraceProtoCollector.completeSpan(OtlpTraceProtoCollector.java:170)
  at datadog.trace.agent.core.otlp.trace.OtlpTraceProtoCollector.completeScope(OtlpTraceProtoCollector.java:155)
  at datadog.trace.agent.core.otlp.trace.OtlpTraceProtoCollector.completePayload(OtlpTraceProtoCollector.java:133)
  at datadog.trace.agent.core.otlp.trace.OtlpTraceProtoCollector.collectTraces(OtlpTraceProtoCollector.java:73)
  at datadog.trace.agent.common.writer.OtlpPayloadDispatcher.flush(OtlpPayloadDispatcher.java:32)
  at datadog.trace.agent.common.writer.TraceProcessingWorker$TraceSerializingHandler.flushIfNecessary(TraceProcessingWorker.java:226)
  at datadog.trace.agent.common.writer.TraceProcessingWorker$TraceSerializingHandler.runDutyCycle(TraceProcessingWorker.java:176)
  at datadog.trace.agent.common.writer.TraceProcessingWorker$TraceSerializingHandler.run(TraceProcessingWorker.java:162)
  at java.base/java.lang.Thread.run(Thread.java:840)
```

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
