### PR TITLE
Fix concurrent span event recording in OTel shim

### DIFF
--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
@@ -37,8 +37,14 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   private StatusCode statusCode;
   private boolean recording;
 
-  /** Span events ({@code null} until an event is added). */
-  private List<OtelSpanEvent> events;
+  /**
+   * Span events ({@code null} until an event is added). Mutations are guarded by synchronizing on
+   * {@code this}: events can be recorded from application threads while the span is finished (and
+   * its events serialized) from a different thread, so unsynchronized access would corrupt the
+   * backing list. Declared {@code volatile} so {@link #onSpanFinished()} can take a lock-free fast
+   * path for the common case of a span with no events.
+   */
+  private volatile List<OtelSpanEvent> events;
 
   public OtelSpan(AgentSpan delegate) {
     this.delegate = delegate;
@@ -85,10 +91,7 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   @Override
   public Span addEvent(String name, Attributes attributes) {
     if (this.recording) {
-      if (this.events == null) {
-        this.events = new ArrayList<>();
-      }
-      this.events.add(new OtelSpanEvent(name, attributes));
+      addEvent(new OtelSpanEvent(name, attributes));
     }
     return this;
   }
@@ -96,12 +99,16 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   @Override
   public Span addEvent(String name, Attributes attributes, long timestamp, TimeUnit unit) {
     if (this.recording) {
-      if (this.events == null) {
-        this.events = new ArrayList<>();
-      }
-      this.events.add(new OtelSpanEvent(name, attributes, timestamp, unit));
+      addEvent(new OtelSpanEvent(name, attributes, timestamp, unit));
     }
     return this;
+  }
+
+  private synchronized void addEvent(OtelSpanEvent event) {
+    if (this.events == null) {
+      this.events = new ArrayList<>();
+    }
+    this.events.add(event);
   }
 
   @Override
@@ -123,12 +130,9 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   @Override
   public Span recordException(Throwable exception, Attributes additionalAttributes) {
     if (this.recording) {
-      if (this.events == null) {
-        this.events = new ArrayList<>();
-      }
       additionalAttributes = initializeExceptionAttributes(exception, additionalAttributes);
       applySpanEventExceptionAttributesAsTags(this.delegate, additionalAttributes);
-      this.events.add(new OtelSpanEvent(EXCEPTION_SPAN_EVENT_NAME, additionalAttributes));
+      addEvent(new OtelSpanEvent(EXCEPTION_SPAN_EVENT_NAME, additionalAttributes));
     }
     return this;
   }
@@ -179,7 +183,17 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   @Override
   public void onSpanFinished() {
     applyNamingConvention(this.delegate);
-    setEventsAsTag(this.delegate, this.events);
+    // Fast path: most spans have no events, so avoid taking the lock entirely (single volatile
+    // read).
+    List<OtelSpanEvent> eventsSnapshot = this.events;
+    if (eventsSnapshot != null) {
+      // Copy under lock so serialization iterates a private snapshot that cannot be mutated
+      // concurrently by an application thread still recording events.
+      synchronized (this) {
+        eventsSnapshot = new ArrayList<>(this.events);
+      }
+    }
+    setEventsAsTag(this.delegate, eventsSnapshot);
   }
 
   private static class NoopSpan implements Span {

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/java/opentelemetry14/OpenTelemetry14Test.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/java/opentelemetry14/OpenTelemetry14Test.java
@@ -67,9 +67,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import opentelemetry14.context.propagation.TextMap;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -287,6 +289,52 @@ class OpenTelemetry14Test extends AbstractOpenTelemetry14Test {
                     defaultTags(),
                     tag(SPAN_KIND, is(SPAN_KIND_INTERNAL)),
                     tag(SPAN_EVENTS, isJson(expectedEventTag)))));
+  }
+
+  @Test
+  void testConcurrentAddEvents() throws Exception {
+    // Regression test for the concurrent recording of span events. Events used to be stored in a
+    // plain ArrayList mutated without synchronization; recording events from multiple threads (as
+    // GraphQL DataLoaders do on virtual threads) corrupted the backing list, leaving null holes
+    // that
+    // triggered a NullPointerException in OtelSpanEvent.toTag when the span was finished. See trace
+    // b8b8e4edde47f90a92e832b63251a577.
+    int threadCount = 8;
+    int eventsPerThread = 2000;
+    Span span = this.otelTracer.spanBuilder("some-name").startSpan();
+
+    CountDownLatch start = new CountDownLatch(1);
+    List<Thread> threads = new ArrayList<>();
+    for (int t = 0; t < threadCount; t++) {
+      Thread thread =
+          new Thread(
+              () -> {
+                try {
+                  start.await();
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  return;
+                }
+                for (int i = 0; i < eventsPerThread; i++) {
+                  span.addEvent("event");
+                }
+              });
+      thread.start();
+      threads.add(thread);
+    }
+
+    start.countDown();
+    for (Thread thread : threads) {
+      thread.join();
+    }
+    span.end();
+
+    writer.waitForTraces(1);
+    List<DDSpan> firstTrace = writer.firstTrace();
+    assertEquals(1, firstTrace.size());
+    Object eventsTag = firstTrace.get(0).getTags().get(SPAN_EVENTS);
+    JSONArray events = new JSONArray((String) eventsTag);
+    assertEquals(threadCount * eventsPerThread, events.length());
   }
 
   @Test


### PR DESCRIPTION
## What Does This Do

Makes span-event handling in the OpenTelemetry shim (`OtelSpan`) thread-safe.

Span events were stored in a plain `ArrayList` that `addEvent()` / `recordException()` mutated **without synchronization**, and that `onSpanFinished()` iterated at span finish. When events are recorded from multiple threads (e.g. GraphQL DataLoaders running on virtual threads) while the span is being finished on another thread, the backing list gets corrupted, leaving a `null` hole that triggers a `NullPointerException` in `OtelSpanEvent.toTag`:

```
java.lang.NullPointerException: Cannot invoke
  "datadog.opentelemetry.shim.trace.OtelSpanEvent.toJson()" because "event" is null
    at datadog.opentelemetry.shim.trace.OtelSpanEvent.toTag(OtelSpanEvent.java:53)
    at datadog.opentelemetry.shim.trace.OtelConventions.setEventsAsTag(OtelConventions.java:143)
    at datadog.opentelemetry.shim.trace.OtelSpan.onSpanFinished(OtelSpan.java:182)
    at datadog.trace.agent.core.DDSpan.finishAndAddToTrace(DDSpan.java:162)
```

That NPE escapes span finish and can surface to the application as a request failure (observed in production as a `jakarta.servlet.ServletException` → HTTP 500 on a request whose spans were otherwise healthy).

## Motivation

A tracer-internal data race should never turn into an application-visible error. This was hit in production on a Spring Boot + GraphQL service using virtual threads, where DataLoaders record span events concurrently on a span that is then finished from a completion callback.

## Change

- All event-list mutations go through a `private synchronized void addEvent(OtelSpanEvent)`.
- `onSpanFinished()` copies the list under the lock and serializes the private snapshot, so iteration can never observe a concurrent mutation.
- `events` is `volatile` so `onSpanFinished()` keeps a **lock-free fast path** (a single volatile read) for the common case of a span with no events — no monitor acquire and no extra allocation on the hot finish path. The lock/copy cost is paid only by spans that actually record events. Synchronization is on `this`, matching the OTel SDK's own `SdkSpan`, so no per-span lock object is allocated.

## Testing

Added `OpenTelemetry14Test.testConcurrentAddEvents` (8 threads × 2000 events, then finish). It fails with the exact NPE against the current code and passes with the fix. The existing `OpenTelemetry14Test` suite remains green.
