### PR TITLE
Fix maxStack for computeFrames

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ASMHelper.java
@@ -19,7 +19,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 import org.objectweb.asm.ClassWriter;
@@ -38,12 +40,21 @@ import org.objectweb.asm.tree.LocalVariableNode;
 import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.TypeInsnNode;
+import org.objectweb.asm.tree.analysis.Analyzer;
+import org.objectweb.asm.tree.analysis.AnalyzerException;
+import org.objectweb.asm.tree.analysis.BasicInterpreter;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.Frame;
 import org.objectweb.asm.util.Printer;
 import org.objectweb.asm.util.Textifier;
 import org.objectweb.asm.util.TraceClassVisitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Helper class for bytecode generation */
 public class ASMHelper {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ASMHelper.class);
+
   public static final Type INT_TYPE = new Type(org.objectweb.asm.Type.INT_TYPE);
   public static final Type OBJECT_TYPE = new Type(Types.OBJECT_TYPE);
   public static final Type STRING_TYPE = new Type(Types.STRING_TYPE);
@@ -426,6 +437,65 @@ public class ASMHelper {
       current = current.getNext();
     }
     return lines;
+  }
+
+  /**
+   * Returns a map for all instructions what is the current frame with value on the stacks Helps to
+   * know at exit points of a method what remains on the stack
+   */
+  protected static Map<AbstractInsnNode, Frame<BasicValue>> computeFrames(
+      String owner, MethodNode methodNode) {
+    // Initial guess used for methodNode.maxStack when retrying computeFrames() below; small
+    // enough to be cheap, large enough to cover the vast majority of probe-generated methods on
+    // the first attempt.
+    final int INITIAL_MAX_STACK_GUESS = 16;
+    // Probes already applied to this method may have inserted bytecode that requires more
+    // stack than originally declared, without updating methodNode.maxStack (only maxLocals is
+    // tracked, see newVar()). The ASM analyzer sizes its Frame objects from the declared
+    // maxStack (each Frame costs maxLocals+maxStack slots), so a stale/too-small value makes
+    // the analysis fail with "Insufficient maximum stack size" even though the class itself is
+    // valid. Rather than guessing an upper bound from the instruction count (which blows up
+    // Frame memory quadratically for large methods), retry with a growing maxStack only when
+    // the Analyzer itself reports it as insufficient - this converges to close to the actual
+    // stack depth the method needs. The real maxStack is recomputed again from scratch by the
+    // ClassWriter's COMPUTE_FRAMES pass when the class is finally written.
+    Map<AbstractInsnNode, Frame<BasicValue>> frames = new IdentityHashMap<>();
+    int attemptMaxStack = Math.max(methodNode.maxStack, INITIAL_MAX_STACK_GUESS);
+    int hardLimitMaxStack = methodNode.instructions.size() * 2;
+    while (true) {
+      methodNode.maxStack = attemptMaxStack;
+      try {
+        Frame<BasicValue>[] frameArray =
+            new Analyzer<>(new BasicInterpreter()).analyze(owner, methodNode);
+        AbstractInsnNode current = methodNode.instructions.getFirst();
+        int idx = 0;
+        while (current != null) {
+          frames.put(current, frameArray[idx++]);
+          current = current.getNext();
+        }
+        break;
+      } catch (AnalyzerException ex) {
+        if (isInsufficientMaxStack(ex) && attemptMaxStack < hardLimitMaxStack) {
+          attemptMaxStack *= 2;
+          continue;
+        }
+        LOGGER.debug(
+            "Failed to analyze method[{}::{}{}] instructions",
+            owner,
+            methodNode.name,
+            methodNode.desc,
+            ex);
+        // when running tests, fails if an exception is thrown during analysis
+        // Gradle is running tests with assertions enbabled
+        assert false;
+        break;
+      }
+    }
+    return frames;
+  }
+
+  private static boolean isInsufficientMaxStack(AnalyzerException ex) {
+    return ex.getMessage() != null && ex.getMessage().contains("Insufficient maximum stack size");
   }
 
   /** Wraps ASM's {@link org.objectweb.asm.Type} with associated generic types */

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/CapturedContextInstrumenter.java
@@ -1,5 +1,6 @@
 package com.datadog.debugger.instrumentation;
 
+import static com.datadog.debugger.instrumentation.ASMHelper.computeFrames;
 import static com.datadog.debugger.instrumentation.ASMHelper.getStatic;
 import static com.datadog.debugger.instrumentation.ASMHelper.invokeConstructor;
 import static com.datadog.debugger.instrumentation.ASMHelper.invokeStatic;

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ExceptionInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/ExceptionInstrumenter.java
@@ -25,7 +25,8 @@ public class ExceptionInstrumenter extends CapturedContextInstrumenter {
     // a try/catch that create a subscobe and even level method local vars are not accessible
     // in the catch clause for capture
     hoistedLocalVars = initAndHoistLocalVars(methodNode);
-    Map<AbstractInsnNode, Frame<BasicValue>> frames = computeFrames(classNode.name, methodNode);
+    Map<AbstractInsnNode, Frame<BasicValue>> frames =
+        ASMHelper.computeFrames(classNode.name, methodNode);
     processInstructions(frames); // fill returnHandlerLabel
     addFinallyHandler(methodEnterLabel, returnHandlerLabel);
     installFinallyBlocks();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumenter.java
@@ -196,6 +196,15 @@ public abstract class Instrumenter {
   protected static Map<AbstractInsnNode, Frame<BasicValue>> computeFrames(
       String owner, MethodNode methodNode) {
     Map<AbstractInsnNode, Frame<BasicValue>> frames = new IdentityHashMap<>();
+    // Probes already applied to this method may have inserted bytecode that requires more
+    // stack than originally declared, without updating methodNode.maxStack (only maxLocals is
+    // tracked, see newVar()). The ASM analyzer sizes its Frame objects from the declared
+    // maxStack, so a stale/too-small value makes the analysis fail with
+    // "Insufficient maximum stack size" even though the class itself is valid. Widen it to a
+    // safe upper bound (no single instruction pushes more than 2 stack slots) before analyzing;
+    // this is only used for this internal frame computation, the real maxStack is recomputed
+    // by the ClassWriter's COMPUTE_FRAMES pass when the class is finally written.
+    methodNode.maxStack = Math.max(methodNode.maxStack, methodNode.instructions.size() * 2);
     try {
       Frame<BasicValue>[] frameArray =
           new Analyzer<>(new BasicInterpreter()).analyze(owner, methodNode);
@@ -212,6 +221,9 @@ public abstract class Instrumenter {
           methodNode.name,
           methodNode.desc,
           ex);
+      // when running tests, fails if an exception is thrown during analysis
+      // Gradle is running tests with assertions enbabled
+      assert false;
     }
     return frames;
   }
@@ -285,13 +297,13 @@ public abstract class Instrumenter {
   }
 
   protected int newVar(Type type) {
-    int varId = methodNode.maxLocals + 1;
+    int varId = methodNode.maxLocals;
     methodNode.maxLocals += type.getSize();
     return varId;
   }
 
   protected int newVar(int size) {
-    int varId = methodNode.maxLocals + 1;
+    int varId = methodNode.maxLocals;
     methodNode.maxLocals += size;
     return varId;
   }

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumenter.java
@@ -255,9 +255,7 @@ public abstract class Instrumenter {
   }
 
   protected int newVar(Type type) {
-    int varId = methodNode.maxLocals;
-    methodNode.maxLocals += type.getSize();
-    return varId;
+    return newVar(type.getSize());
   }
 
   protected int newVar(int size) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/Instrumenter.java
@@ -13,7 +13,6 @@ import com.datadog.debugger.util.JvmLanguage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import org.objectweb.asm.Opcodes;
@@ -29,17 +28,11 @@ import org.objectweb.asm.tree.MethodInsnNode;
 import org.objectweb.asm.tree.MethodNode;
 import org.objectweb.asm.tree.TryCatchBlockNode;
 import org.objectweb.asm.tree.TypeInsnNode;
-import org.objectweb.asm.tree.analysis.Analyzer;
-import org.objectweb.asm.tree.analysis.AnalyzerException;
-import org.objectweb.asm.tree.analysis.BasicInterpreter;
 import org.objectweb.asm.tree.analysis.BasicValue;
 import org.objectweb.asm.tree.analysis.Frame;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Common class for generating instrumentation */
 public abstract class Instrumenter {
-  private static final Logger LOGGER = LoggerFactory.getLogger(Instrumenter.class);
   protected static final String CONSTRUCTOR_NAME = "<init>";
   protected static final String PROBEID_TAG_NAME = "debugger.probeid";
 
@@ -191,41 +184,6 @@ public abstract class Instrumenter {
       result.add(new InsnNode(value.getSize() == 2 ? Opcodes.POP2 : Opcodes.POP));
     }
     return result;
-  }
-
-  protected static Map<AbstractInsnNode, Frame<BasicValue>> computeFrames(
-      String owner, MethodNode methodNode) {
-    Map<AbstractInsnNode, Frame<BasicValue>> frames = new IdentityHashMap<>();
-    // Probes already applied to this method may have inserted bytecode that requires more
-    // stack than originally declared, without updating methodNode.maxStack (only maxLocals is
-    // tracked, see newVar()). The ASM analyzer sizes its Frame objects from the declared
-    // maxStack, so a stale/too-small value makes the analysis fail with
-    // "Insufficient maximum stack size" even though the class itself is valid. Widen it to a
-    // safe upper bound (no single instruction pushes more than 2 stack slots) before analyzing;
-    // this is only used for this internal frame computation, the real maxStack is recomputed
-    // by the ClassWriter's COMPUTE_FRAMES pass when the class is finally written.
-    methodNode.maxStack = Math.max(methodNode.maxStack, methodNode.instructions.size() * 2);
-    try {
-      Frame<BasicValue>[] frameArray =
-          new Analyzer<>(new BasicInterpreter()).analyze(owner, methodNode);
-      AbstractInsnNode current = methodNode.instructions.getFirst();
-      int idx = 0;
-      while (current != null) {
-        frames.put(current, frameArray[idx++]);
-        current = current.getNext();
-      }
-    } catch (AnalyzerException ex) {
-      LOGGER.debug(
-          "Failed to analyze method[{}::{}{}] instructions",
-          owner,
-          methodNode.name,
-          methodNode.desc,
-          ex);
-      // when running tests, fails if an exception is thrown during analysis
-      // Gradle is running tests with assertions enbabled
-      assert false;
-    }
-    return frames;
   }
 
   protected AbstractInsnNode processInstruction(

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/MetricInstrumenter.java
@@ -112,7 +112,7 @@ public class MetricInstrumenter extends Instrumenter {
       case EXIT:
         {
           Map<AbstractInsnNode, Frame<BasicValue>> frames =
-              computeFrames(classNode.name, methodNode);
+              ASMHelper.computeFrames(classNode.name, methodNode);
           processInstructions(frames);
           addFinallyHandler(returnHandlerLabel);
           installFinallyBlocks();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SpanInstrumenter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/instrumentation/SpanInstrumenter.java
@@ -42,7 +42,8 @@ public class SpanInstrumenter extends Instrumenter {
       return addRangeSpan(classFileLines);
     }
     spanVar = newVar(DEBUGGER_SPAN_TYPE);
-    Map<AbstractInsnNode, Frame<BasicValue>> frames = computeFrames(classNode.name, methodNode);
+    Map<AbstractInsnNode, Frame<BasicValue>> frames =
+        ASMHelper.computeFrames(classNode.name, methodNode);
     processInstructions(frames);
     LabelNode initSpanLabel = new LabelNode();
     InsnList insnList = createSpan(initSpanLabel);

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DebuggerTransformerTest.java
@@ -55,7 +55,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 import org.mockito.ArgumentCaptor;
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.tree.VarInsnNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.TableSwitchInsnNode;
 
 public class DebuggerTransformerTest {
   private static final String LANGUAGE = "java";
@@ -350,7 +353,7 @@ public class DebuggerTransformerTest {
             .startsWith(
                 "Instrumentation failed for "
                     + CLASS_NAME
-                    + ": java.lang.ArrayIndexOutOfBoundsException:"));
+                    + ": org.objectweb.asm.MethodTooLargeException:"));
     assertTrue(
         strCaptor
             .getAllValues()
@@ -358,7 +361,7 @@ public class DebuggerTransformerTest {
             .startsWith(
                 "Instrumentation failed for "
                     + CLASS_NAME
-                    + ": java.lang.ArrayIndexOutOfBoundsException:"));
+                    + ": org.objectweb.asm.MethodTooLargeException:"));
     assertTrue(
         strCaptor
             .getAllValues()
@@ -366,7 +369,7 @@ public class DebuggerTransformerTest {
             .startsWith(
                 "Instrumentation failed for "
                     + CLASS_NAME
-                    + ": java.lang.ArrayIndexOutOfBoundsException:"));
+                    + ": org.objectweb.asm.MethodTooLargeException:"));
   }
 
   @Test
@@ -443,11 +446,19 @@ public class DebuggerTransformerTest {
     @Override
     public InstrumentationResult.Status instrument(
         MethodInfo methodInfo, List<DiagnosticMessage> diagnostics, List<Integer> probeIndices) {
-      methodInfo
-          .getMethodNode()
-          .instructions
-          .insert(
-              new VarInsnNode(Opcodes.ASTORE, methodInfo.getMethodNode().localVariables.size()));
+      // Build a single TABLESWITCH with enough case entries (4 bytes each) to push the
+      // method's bytecode past the 65535-byte limit, while keeping the ASM tree
+      // instruction *count* tiny so that dataflow analysis (computeFrames) stays cheap
+      // and succeeds; the failure should only manifest when ASM serializes the method.
+      LabelNode target = new LabelNode();
+      int high = 20_000;
+      LabelNode[] labels = new LabelNode[high + 1];
+      Arrays.fill(labels, target);
+      InsnList list = new InsnList();
+      list.add(new InsnNode(Opcodes.ICONST_0));
+      list.add(new TableSwitchInsnNode(0, high, target, labels));
+      list.add(target);
+      methodInfo.getMethodNode().instructions.insert(list);
       return InstrumentationResult.Status.INSTALLED;
     }
 

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/ASMHelperTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/instrumentation/ASMHelperTest.java
@@ -11,12 +11,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.InsnNode;
 import org.objectweb.asm.tree.LabelNode;
 import org.objectweb.asm.tree.LineNumberNode;
 import org.objectweb.asm.tree.LocalVariableNode;
 import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.analysis.BasicValue;
+import org.objectweb.asm.tree.analysis.Frame;
 
 public class ASMHelperTest {
 
@@ -186,5 +192,23 @@ public class ASMHelperTest {
     assertEquals(40, lineNumbers.get(0).intValue());
     assertEquals(2, lineNumbers.get(1).intValue());
     assertEquals(82, lineNumbers.get(2).intValue());
+  }
+
+  @Test
+  void computeFramesGrowsMaxStackWhenInsufficient() {
+    MethodNode methodNode = new MethodNode(Opcodes.ACC_STATIC, "deepLongStack", "()V", null, null);
+    methodNode.maxStack = 1; // deliberately too small for the actual stack depth needed below
+    int longCount = 20; // stack depth of 20, well above the initial guess of 16
+    for (int i = 0; i < longCount; i++) {
+      methodNode.instructions.add(new InsnNode(Opcodes.LCONST_0));
+    }
+    for (int i = 0; i < longCount; i++) {
+      methodNode.instructions.add(new InsnNode(Opcodes.POP2));
+    }
+    methodNode.instructions.add(new InsnNode(Opcodes.RETURN));
+    Map<AbstractInsnNode, Frame<BasicValue>> frames =
+        ASMHelper.computeFrames("com/datadog/debugger/FakeOwner", methodNode);
+    assertEquals(methodNode.instructions.size(), frames.size());
+    assertTrue(methodNode.maxStack >= longCount);
   }
 }


### PR DESCRIPTION
# What Does This Do
Increase method maxStack before running computeFrames analysis to avoid stack error related to previous instrumentation fromm probe on the same method.
Change the classGeneratedFailed test using large tablelookup to generate incorrect class instead of incorrect frame which is now caught by computeFrames analysis.
Fix off-by-1 the newVar id.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
