### PR TITLE
Telemetry for OTLP traces/metrics/logs

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpPayloadDispatcher.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpPayloadDispatcher.java
@@ -1,6 +1,7 @@
 package datadog.trace.common.writer;
 
 import datadog.trace.core.CoreSpan;
+import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.core.otlp.common.OtlpPayload;
 import datadog.trace.core.otlp.common.OtlpSender;
 import datadog.trace.core.otlp.trace.OtlpTraceCollector;
@@ -17,10 +18,17 @@ final class OtlpPayloadDispatcher implements PayloadDispatcher {
 
   private final OtlpTraceCollector collector;
   private final OtlpSender sender;
+  private final HealthMetrics healthMetrics;
 
   OtlpPayloadDispatcher(OtlpSender sender, OtlpTraceCollector collector) {
+    this(sender, collector, HealthMetrics.NO_OP);
+  }
+
+  OtlpPayloadDispatcher(
+      OtlpSender sender, OtlpTraceCollector collector, HealthMetrics healthMetrics) {
     this.sender = sender;
     this.collector = collector;
+    this.healthMetrics = healthMetrics;
   }
 
   @Override
@@ -36,8 +44,16 @@ final class OtlpPayloadDispatcher implements PayloadDispatcher {
   public void flush() {
     try {
       OtlpPayload payload = collector.collectTraces();
+      int traceCount = collector.getTraceCount();
       if (payload != OtlpPayload.EMPTY) {
-        sender.send(payload);
+        int sizeInBytes = payload.getContentLength();
+        healthMetrics.onSerialize(sizeInBytes);
+        RemoteApi.Response response = sender.send(payload);
+        if (response.success()) {
+          healthMetrics.onSend(traceCount, sizeInBytes, response);
+        } else {
+          healthMetrics.onFailedSend(traceCount, sizeInBytes, response);
+        }
       }
     } catch (RuntimeException e) { // don't catch severe Errors
       log.debug("Failed to send OTLP payload", e);
@@ -46,7 +62,7 @@ final class OtlpPayloadDispatcher implements PayloadDispatcher {
 
   @Override
   public void onDroppedTrace(int spanCount) {
-    // TODO: surface drop counts via HealthMetrics
+    // RemoteWriter already updated healthMetrics, no further action required
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpPayloadDispatcher.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpPayloadDispatcher.java
@@ -40,11 +40,7 @@ final class OtlpPayloadDispatcher implements PayloadDispatcher {
       if (payload != OtlpPayload.EMPTY) {
         OtlpTelemetry.getInstance().onTracesExportAttempt();
         RemoteApi.Response response = sender.send(payload);
-        if (response.success()) {
-          OtlpTelemetry.getInstance().onTracesExportSuccess();
-        } else {
-          OtlpTelemetry.getInstance().onTracesExportFailure();
-        }
+        OtlpTelemetry.getInstance().onTracesExportComplete(response.success());
       }
     } catch (RuntimeException e) { // don't catch severe Errors
       log.debug("Failed to send OTLP payload", e);

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpPayloadDispatcher.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpPayloadDispatcher.java
@@ -1,7 +1,7 @@
 package datadog.trace.common.writer;
 
+import datadog.trace.api.telemetry.OtlpTelemetry;
 import datadog.trace.core.CoreSpan;
-import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.core.otlp.common.OtlpPayload;
 import datadog.trace.core.otlp.common.OtlpSender;
 import datadog.trace.core.otlp.trace.OtlpTraceCollector;
@@ -18,17 +18,10 @@ final class OtlpPayloadDispatcher implements PayloadDispatcher {
 
   private final OtlpTraceCollector collector;
   private final OtlpSender sender;
-  private final HealthMetrics healthMetrics;
 
   OtlpPayloadDispatcher(OtlpSender sender, OtlpTraceCollector collector) {
-    this(sender, collector, HealthMetrics.NO_OP);
-  }
-
-  OtlpPayloadDispatcher(
-      OtlpSender sender, OtlpTraceCollector collector, HealthMetrics healthMetrics) {
     this.sender = sender;
     this.collector = collector;
-    this.healthMetrics = healthMetrics;
   }
 
   @Override
@@ -44,15 +37,13 @@ final class OtlpPayloadDispatcher implements PayloadDispatcher {
   public void flush() {
     try {
       OtlpPayload payload = collector.collectTraces();
-      int traceCount = collector.getTraceCount();
       if (payload != OtlpPayload.EMPTY) {
-        int sizeInBytes = payload.getContentLength();
-        healthMetrics.onSerialize(sizeInBytes);
+        OtlpTelemetry.getInstance().onTracesExportAttempt();
         RemoteApi.Response response = sender.send(payload);
         if (response.success()) {
-          healthMetrics.onSend(traceCount, sizeInBytes, response);
+          OtlpTelemetry.getInstance().onTracesExportSuccess();
         } else {
-          healthMetrics.onFailedSend(traceCount, sizeInBytes, response);
+          OtlpTelemetry.getInstance().onTracesExportFailure();
         }
       }
     } catch (RuntimeException e) { // don't catch severe Errors
@@ -62,7 +53,7 @@ final class OtlpPayloadDispatcher implements PayloadDispatcher {
 
   @Override
   public void onDroppedTrace(int spanCount) {
-    // RemoteWriter already updated healthMetrics, no further action required
+    // no telemetry currently tracked for dropped traces
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpWriter.java
@@ -38,11 +38,10 @@ public class OtlpWriter extends RemoteWriter {
       TraceProcessingWorker worker,
       PayloadDispatcher dispatcher,
       OtlpSender sender,
-      HealthMetrics healthMetrics,
       int flushTimeout,
       TimeUnit flushTimeoutUnit,
       boolean alwaysFlush) {
-    super(worker, dispatcher, healthMetrics, flushTimeout, flushTimeoutUnit, alwaysFlush);
+    super(worker, dispatcher, HealthMetrics.NO_OP, flushTimeout, flushTimeoutUnit, alwaysFlush);
     this.sender = sender;
   }
 
@@ -64,7 +63,6 @@ public class OtlpWriter extends RemoteWriter {
     private OtlpConfig.Protocol protocol = OtlpConfig.Protocol.HTTP_PROTOBUF;
     private OtlpConfig.Compression compression = OtlpConfig.Compression.NONE;
     private int traceBufferSize = BUFFER_SIZE;
-    private HealthMetrics healthMetrics = HealthMetrics.NO_OP;
     private int flushIntervalMilliseconds = 1000;
     private int flushTimeout = 1;
     private TimeUnit flushTimeoutUnit = TimeUnit.SECONDS;
@@ -99,11 +97,6 @@ public class OtlpWriter extends RemoteWriter {
 
     public OtlpWriterBuilder traceBufferSize(int traceBufferSize) {
       this.traceBufferSize = traceBufferSize;
-      return this;
-    }
-
-    public OtlpWriterBuilder healthMetrics(HealthMetrics healthMetrics) {
-      this.healthMetrics = healthMetrics;
       return this;
     }
 
@@ -147,12 +140,11 @@ public class OtlpWriter extends RemoteWriter {
           protocol == OtlpConfig.Protocol.HTTP_JSON
               ? new OtlpTraceJsonCollector()
               : new OtlpTraceProtoCollector();
-      final OtlpPayloadDispatcher dispatcher =
-          new OtlpPayloadDispatcher(sender, collector, healthMetrics);
+      final OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender, collector);
       final TraceProcessingWorker worker =
           new TraceProcessingWorker(
               traceBufferSize,
-              healthMetrics,
+              HealthMetrics.NO_OP,
               dispatcher,
               DroppingPolicy.DISABLED,
               Prioritization.FAST_LANE,
@@ -161,7 +153,7 @@ public class OtlpWriter extends RemoteWriter {
               singleSpanSampler);
 
       return new OtlpWriter(
-          worker, dispatcher, sender, healthMetrics, flushTimeout, flushTimeoutUnit, alwaysFlush);
+          worker, dispatcher, sender, flushTimeout, flushTimeoutUnit, alwaysFlush);
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/OtlpWriter.java
@@ -147,7 +147,8 @@ public class OtlpWriter extends RemoteWriter {
           protocol == OtlpConfig.Protocol.HTTP_JSON
               ? new OtlpTraceJsonCollector()
               : new OtlpTraceProtoCollector();
-      final OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender, collector);
+      final OtlpPayloadDispatcher dispatcher =
+          new OtlpPayloadDispatcher(sender, collector, healthMetrics);
       final TraceProcessingWorker worker =
           new TraceProcessingWorker(
               traceBufferSize,

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -76,7 +76,6 @@ public class WriterFactory {
           .protocol(config.getOtlpTracesProtocol())
           .compression(config.getOtlpTracesCompression())
           .timeoutMillis(config.getOtlpTracesTimeout())
-          .healthMetrics(healthMetrics)
           .spanSamplingRules(singleSpanSampler)
           .flushIntervalMilliseconds(flushIntervalMilliseconds)
           .build();

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpGrpcSender.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpGrpcSender.java
@@ -2,18 +2,16 @@ package datadog.trace.core.otlp.common;
 
 import static datadog.communication.http.OkHttpUtils.buildHttp2Client;
 import static datadog.communication.http.OkHttpUtils.isPlainHttp;
-import static datadog.communication.http.OkHttpUtils.sendWithRetries;
 
 import datadog.communication.http.HttpRetryPolicy;
 import datadog.logging.RatelimitedLogger;
 import datadog.trace.api.config.OtlpConfig.Compression;
-import java.io.IOException;
+import datadog.trace.common.writer.RemoteApi;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,20 +53,8 @@ public final class OtlpGrpcSender implements OtlpSender {
   }
 
   @Override
-  public void send(OtlpPayload payload) {
-    Request request = makeRequest(payload);
-    try (Response response = sendWithRetries(client, retryPolicy, request)) {
-      if (!response.isSuccessful()) {
-        RATELIMITED_LOGGER.warn(
-            "OTLP export to {} failed with status {}: {}",
-            request.url(),
-            response.code(),
-            response.message());
-      }
-    } catch (IOException e) {
-      RATELIMITED_LOGGER.warn(
-          "OTLP export to {} failed with exception: {}", request.url(), e.toString());
-    }
+  public RemoteApi.Response send(OtlpPayload payload) {
+    return OtlpSenderSupport.send(client, retryPolicy, makeRequest(payload), RATELIMITED_LOGGER);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpHttpSender.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpHttpSender.java
@@ -2,18 +2,16 @@ package datadog.trace.core.otlp.common;
 
 import static datadog.communication.http.OkHttpUtils.buildHttpClient;
 import static datadog.communication.http.OkHttpUtils.isPlainHttp;
-import static datadog.communication.http.OkHttpUtils.sendWithRetries;
 
 import datadog.communication.http.HttpRetryPolicy;
 import datadog.logging.RatelimitedLogger;
 import datadog.trace.api.config.OtlpConfig.Compression;
-import java.io.IOException;
+import datadog.trace.common.writer.RemoteApi;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,20 +57,8 @@ public final class OtlpHttpSender implements OtlpSender {
   }
 
   @Override
-  public void send(OtlpPayload payload) {
-    Request request = makeRequest(payload);
-    try (Response response = sendWithRetries(client, retryPolicy, request)) {
-      if (!response.isSuccessful()) {
-        RATELIMITED_LOGGER.warn(
-            "OTLP export to {} failed with status {}: {}",
-            request.url(),
-            response.code(),
-            response.message());
-      }
-    } catch (IOException e) {
-      RATELIMITED_LOGGER.warn(
-          "OTLP export to {} failed with exception: {}", request.url(), e.toString());
-    }
+  public RemoteApi.Response send(OtlpPayload payload) {
+    return OtlpSenderSupport.send(client, retryPolicy, makeRequest(payload), RATELIMITED_LOGGER);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpSender.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpSender.java
@@ -1,8 +1,10 @@
 package datadog.trace.core.otlp.common;
 
+import datadog.trace.common.writer.RemoteApi;
+
 /** Sends chunks of OTLP data. */
 public interface OtlpSender {
-  void send(OtlpPayload payload);
+  RemoteApi.Response send(OtlpPayload payload);
 
   void shutdown();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpSenderSupport.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/common/OtlpSenderSupport.java
@@ -1,0 +1,39 @@
+package datadog.trace.core.otlp.common;
+
+import static datadog.communication.http.OkHttpUtils.sendWithRetries;
+import static datadog.trace.common.writer.RemoteApi.Response.failed;
+import static datadog.trace.common.writer.RemoteApi.Response.success;
+
+import datadog.communication.http.HttpRetryPolicy;
+import datadog.logging.RatelimitedLogger;
+import datadog.trace.common.writer.RemoteApi;
+import java.io.IOException;
+import okhttp3.OkHttpClient;
+
+/** Shared request execution and response handling for {@link OtlpSender} implementations. */
+final class OtlpSenderSupport {
+  private OtlpSenderSupport() {}
+
+  /** Executes the given request with retries, logging failures via the rate-limited logger. */
+  static RemoteApi.Response send(
+      OkHttpClient client,
+      HttpRetryPolicy.Factory retryPolicy,
+      okhttp3.Request request,
+      RatelimitedLogger ratelimitedLogger) {
+    try (okhttp3.Response response = sendWithRetries(client, retryPolicy, request)) {
+      if (response.isSuccessful()) {
+        return success(response.code());
+      }
+      ratelimitedLogger.warn(
+          "OTLP export to {} failed with status {}: {}",
+          request.url(),
+          response.code(),
+          response.message());
+      return failed(response.code());
+    } catch (IOException e) {
+      ratelimitedLogger.warn(
+          "OTLP export to {} failed with exception: {}", request.url(), e.toString());
+      return failed(e);
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsCollector.java
@@ -7,4 +7,7 @@ public abstract class OtlpLogsCollector {
 
   /** Waits for logs to be batched within the given interval. */
   public abstract OtlpPayload waitForLogs(int intervalMillis);
+
+  /** Number of log records collected. */
+  public abstract int getLogRecordCount();
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsJsonCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsJsonCollector.java
@@ -36,6 +36,7 @@ public final class OtlpLogsJsonCollector extends OtlpLogsCollector
   private JsonWriter writer;
   private boolean anyLogRecordWritten;
   private boolean logRecordStarted;
+  private int logRecordCount;
 
   private final LazyJsonArray attributesArray = new LazyJsonArray();
 
@@ -65,6 +66,8 @@ public final class OtlpLogsJsonCollector extends OtlpLogsCollector
 
   /** Prepare temporary elements to collect logs data. */
   private void start() {
+    logRecordCount = 0;
+
     writer = new JsonWriter();
     writer.beginObject();
     writer.name("resourceLogs").beginArray();
@@ -84,6 +87,11 @@ public final class OtlpLogsJsonCollector extends OtlpLogsCollector
     logRecordStarted = false;
 
     currentScope = null;
+  }
+
+  @Override
+  public int getLogRecordCount() {
+    return logRecordCount;
   }
 
   @Override
@@ -119,6 +127,7 @@ public final class OtlpLogsJsonCollector extends OtlpLogsCollector
 
     logRecordStarted = false;
     anyLogRecordWritten = true;
+    logRecordCount++;
   }
 
   // opens the log record object on first attribute or value written for it

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsProtoCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsProtoCollector.java
@@ -41,6 +41,7 @@ public final class OtlpLogsProtoCollector extends OtlpLogsCollector
   // total number of chunked bytes at different nesting levels
   private int payloadBytes;
   private int scopedBytes;
+  private int logRecordCount;
 
   private OtelInstrumentationScope currentScope;
 
@@ -68,6 +69,7 @@ public final class OtlpLogsProtoCollector extends OtlpLogsCollector
 
   /** Prepare temporary elements to collect logs data. */
   private void start() {
+    logRecordCount = 0;
 
     // remove stale entries from caches
     OtlpCommonProto.recalibrateCaches();
@@ -85,6 +87,11 @@ public final class OtlpLogsProtoCollector extends OtlpLogsCollector
   }
 
   @Override
+  public int getLogRecordCount() {
+    return logRecordCount;
+  }
+
+  @Override
   public OtlpScopedLogsVisitor visitScopedLogs(OtelInstrumentationScope scope) {
     if (currentScope != null) {
       completeScope();
@@ -96,6 +103,7 @@ public final class OtlpLogsProtoCollector extends OtlpLogsCollector
   @Override
   public void visitLogRecord(OtlpLogRecord logRecord) {
     scopedBytes += recordLogRecordMessage(buf, logRecord, protobuf);
+    logRecordCount++;
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/logs/OtlpLogsService.java
@@ -4,6 +4,8 @@ import static datadog.trace.util.AgentThreadFactory.AgentThread.OTLP_LOGS_EXPORT
 import static datadog.trace.util.AgentThreadFactory.newAgentThread;
 
 import datadog.trace.api.Config;
+import datadog.trace.api.telemetry.OtlpTelemetry;
+import datadog.trace.common.writer.RemoteApi;
 import datadog.trace.core.otlp.common.OtlpGrpcSender;
 import datadog.trace.core.otlp.common.OtlpHttpSender;
 import datadog.trace.core.otlp.common.OtlpPayload;
@@ -108,7 +110,11 @@ public final class OtlpLogsService {
       try {
         OtlpPayload payload = collector.waitForLogs(intervalMillis);
         if (payload != OtlpPayload.EMPTY) {
-          sender.send(payload);
+          int logRecordCount = collector.getLogRecordCount();
+          RemoteApi.Response response = sender.send(payload);
+          if (response.success()) {
+            OtlpTelemetry.getInstance().onLogRecordsSubmitted(logRecordCount);
+          }
         }
       } catch (RuntimeException e) {
         LOGGER.debug("Uncaught exception exporting logs", e);

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsService.java
@@ -4,7 +4,9 @@ import static datadog.trace.util.AgentThreadFactory.AgentThread.OTLP_METRICS_EXP
 
 import datadog.trace.api.Config;
 import datadog.trace.api.config.OtlpConfig;
+import datadog.trace.api.telemetry.OtlpTelemetry;
 import datadog.trace.api.time.SystemTimeSource;
+import datadog.trace.common.writer.RemoteApi;
 import datadog.trace.core.otlp.common.OtlpPayload;
 import datadog.trace.core.otlp.common.OtlpSender;
 import datadog.trace.util.AgentTaskScheduler;
@@ -29,7 +31,6 @@ public final class OtlpMetricsService {
 
   OtlpMetricsService(Config config) {
     this.scheduler = new AgentTaskScheduler(OTLP_METRICS_EXPORTER);
-
     this.sender = OtlpMetricsSenderFactory.create(config);
     if (this.sender == null) {
       LOGGER.debug("Unsupported OTLP metrics protocol: {}", config.getOtlpMetricsProtocol());
@@ -91,7 +92,13 @@ public final class OtlpMetricsService {
   private void export() {
     OtlpPayload payload = collector.collectMetrics();
     if (payload != OtlpPayload.EMPTY) {
-      sender.send(payload);
+      OtlpTelemetry.getInstance().onMetricsExportAttempt();
+      RemoteApi.Response response = sender.send(payload);
+      if (response.success()) {
+        OtlpTelemetry.getInstance().onMetricsExportSuccess();
+      } else {
+        OtlpTelemetry.getInstance().onMetricsExportFailure();
+      }
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsService.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpMetricsService.java
@@ -94,11 +94,7 @@ public final class OtlpMetricsService {
     if (payload != OtlpPayload.EMPTY) {
       OtlpTelemetry.getInstance().onMetricsExportAttempt();
       RemoteApi.Response response = sender.send(payload);
-      if (response.success()) {
-        OtlpTelemetry.getInstance().onMetricsExportSuccess();
-      } else {
-        OtlpTelemetry.getInstance().onMetricsExportFailure();
-      }
+      OtlpTelemetry.getInstance().onMetricsExportComplete(response.success());
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpStatsMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpStatsMetricWriter.java
@@ -7,6 +7,7 @@ import static datadog.trace.bootstrap.otlp.common.OtlpAttributeVisitor.STRING_AT
 import datadog.metrics.api.Histogram;
 import datadog.trace.api.Config;
 import datadog.trace.api.config.OtlpConfig;
+import datadog.trace.api.telemetry.OtlpTelemetry;
 import datadog.trace.api.time.SystemTimeSource;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.otel.common.OtelInstrumentationScope;
@@ -16,6 +17,7 @@ import datadog.trace.bootstrap.otlp.metrics.OtlpMetricVisitor;
 import datadog.trace.bootstrap.otlp.metrics.OtlpMetricsVisitor;
 import datadog.trace.common.metrics.AggregateEntry;
 import datadog.trace.common.metrics.MetricWriter;
+import datadog.trace.common.writer.RemoteApi;
 import datadog.trace.core.otlp.common.OtlpPayload;
 import datadog.trace.core.otlp.common.OtlpResourceJson;
 import datadog.trace.core.otlp.common.OtlpResourceProto;
@@ -167,7 +169,13 @@ public final class OtlpStatsMetricWriter implements MetricWriter {
       }
       OtlpPayload payload = collector.collectMetrics(this::emit, startNanos, endNanos);
       if (payload != OtlpPayload.EMPTY) {
-        sender.send(payload);
+        OtlpTelemetry.getInstance().onMetricsExportAttempt();
+        RemoteApi.Response response = sender.send(payload);
+        if (response.success()) {
+          OtlpTelemetry.getInstance().onMetricsExportSuccess();
+        } else {
+          OtlpTelemetry.getInstance().onMetricsExportFailure();
+        }
       }
     } finally {
       pending.clear();

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpStatsMetricWriter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/metrics/OtlpStatsMetricWriter.java
@@ -171,11 +171,7 @@ public final class OtlpStatsMetricWriter implements MetricWriter {
       if (payload != OtlpPayload.EMPTY) {
         OtlpTelemetry.getInstance().onMetricsExportAttempt();
         RemoteApi.Response response = sender.send(payload);
-        if (response.success()) {
-          OtlpTelemetry.getInstance().onMetricsExportSuccess();
-        } else {
-          OtlpTelemetry.getInstance().onMetricsExportFailure();
-        }
+        OtlpTelemetry.getInstance().onMetricsExportComplete(response.success());
       }
     } finally {
       pending.clear();

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceCollector.java
@@ -18,6 +18,9 @@ public abstract class OtlpTraceCollector {
   /** Returns the number of bytes buffered since the last collection. */
   public abstract int sizeInBytes();
 
+  /** Number of traces collected since the last collection. */
+  public abstract int getTraceCount();
+
   protected final boolean shouldExport(CoreSpan<?> span) {
     return span.samplingPriority() > 0 // trace-level sampling priority
         || span.getTag(SPAN_SAMPLING_MECHANISM_TAG) != null; // span-level sampling priority

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceCollector.java
@@ -18,9 +18,6 @@ public abstract class OtlpTraceCollector {
   /** Returns the number of bytes buffered since the last collection. */
   public abstract int sizeInBytes();
 
-  /** Number of traces collected since the last collection. */
-  public abstract int getTraceCount();
-
   protected final boolean shouldExport(CoreSpan<?> span) {
     return span.samplingPriority() > 0 // trace-level sampling priority
         || span.getTag(SPAN_SAMPLING_MECHANISM_TAG) != null; // span-level sampling priority

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollector.java
@@ -42,6 +42,7 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
   private boolean payloadStarted;
   private boolean anySpanWritten;
   private boolean firstSpanInScope;
+  private int traceCount;
 
   private OtelInstrumentationScope currentScope;
   private DDSpan currentSpan;
@@ -56,8 +57,12 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
     }
 
     try {
+      boolean exported = false;
       for (CoreSpan<?> span : spans) {
-        visitSpan(span);
+        exported |= visitSpan(span);
+      }
+      if (exported) {
+        traceCount++;
       }
     } catch (Throwable e) {
       // reset the buffer for subsequent traces
@@ -90,6 +95,8 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
 
   /** Prepare temporary elements to collect trace data. */
   private void start() {
+    traceCount = 0;
+
     writer = new JsonWriter();
     metaWriter = new OtlpTraceJson.MetaWriter(writer);
 
@@ -116,6 +123,11 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
     currentSpanLinks = Collections.emptyList();
   }
 
+  @Override
+  public int getTraceCount() {
+    return traceCount;
+  }
+
   private void visitScopedSpans(OtelInstrumentationScope scope) {
     if (currentScope != null) {
       completeScope();
@@ -128,18 +140,20 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
     writer.name("spans").beginArray();
   }
 
-  private void visitSpan(CoreSpan<?> span) {
-    if (shouldExport(span)) {
-      if (currentSpan != null) {
-        // ensure last span written at trace boundary includes sampling tags
-        if (!span.getTraceId().equals(currentSpan.getTraceId())) {
-          metaWriter.includeSamplingTags();
-        }
-        completeSpan();
-      }
-      currentSpan = (DDSpan) span;
-      currentSpanLinks = currentSpan.getLinks();
+  private boolean visitSpan(CoreSpan<?> span) {
+    if (!shouldExport(span)) {
+      return false;
     }
+    if (currentSpan != null) {
+      // ensure last span written at trace boundary includes sampling tags
+      if (!span.getTraceId().equals(currentSpan.getTraceId())) {
+        metaWriter.includeSamplingTags();
+      }
+      completeSpan();
+    }
+    currentSpan = (DDSpan) span;
+    currentSpanLinks = currentSpan.getLinks();
+    return true;
   }
 
   // called once we've processed all scopes and span messages

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollector.java
@@ -42,7 +42,6 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
   private boolean payloadStarted;
   private boolean anySpanWritten;
   private boolean firstSpanInScope;
-  private int traceCount;
 
   private OtelInstrumentationScope currentScope;
   private DDSpan currentSpan;
@@ -57,12 +56,8 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
     }
 
     try {
-      boolean exported = false;
       for (CoreSpan<?> span : spans) {
-        exported |= visitSpan(span);
-      }
-      if (exported) {
-        traceCount++;
+        visitSpan(span);
       }
     } catch (Throwable e) {
       // reset the buffer for subsequent traces
@@ -95,8 +90,6 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
 
   /** Prepare temporary elements to collect trace data. */
   private void start() {
-    traceCount = 0;
-
     writer = new JsonWriter();
     metaWriter = new OtlpTraceJson.MetaWriter(writer);
 
@@ -123,11 +116,6 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
     currentSpanLinks = Collections.emptyList();
   }
 
-  @Override
-  public int getTraceCount() {
-    return traceCount;
-  }
-
   private void visitScopedSpans(OtelInstrumentationScope scope) {
     if (currentScope != null) {
       completeScope();
@@ -140,9 +128,9 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
     writer.name("spans").beginArray();
   }
 
-  private boolean visitSpan(CoreSpan<?> span) {
+  private void visitSpan(CoreSpan<?> span) {
     if (!shouldExport(span)) {
-      return false;
+      return;
     }
     if (currentSpan != null) {
       // ensure last span written at trace boundary includes sampling tags
@@ -153,7 +141,6 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
     }
     currentSpan = (DDSpan) span;
     currentSpanLinks = currentSpan.getLinks();
-    return true;
   }
 
   // called once we've processed all scopes and span messages

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProtoCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProtoCollector.java
@@ -44,6 +44,7 @@ public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
   private int payloadBytes;
   private int scopedBytes;
   private int spanBytes;
+  private int traceCount;
 
   private OtelInstrumentationScope currentScope;
   private DDSpan currentSpan;
@@ -57,9 +58,13 @@ public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
     }
 
     try {
+      boolean exported = false;
       // OtlpProtoBuffer collects spans in reverse
       for (int i = spans.size() - 1; i >= 0; i--) {
-        visitSpan(spans.get(i));
+        exported |= visitSpan(spans.get(i));
+      }
+      if (exported) {
+        traceCount++;
       }
     } catch (Throwable e) {
       // reset the buffer for subsequent traces
@@ -89,12 +94,18 @@ public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
 
   /** Prepare temporary elements to collect trace data. */
   private void start() {
+    traceCount = 0;
 
     // remove stale entries from caches
     OtlpCommonProto.recalibrateCaches();
 
     // for now put all spans under the default scope
     visitScopedSpans(DEFAULT_TRACE_SCOPE);
+  }
+
+  @Override
+  public int getTraceCount() {
+    return traceCount;
   }
 
   /** Cleanup elements used to collect trace data. */
@@ -119,19 +130,21 @@ public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
     currentScope = scope;
   }
 
-  private void visitSpan(CoreSpan<?> span) {
-    if (shouldExport(span)) {
-      if (currentSpan != null) {
-        // ensure last span written at trace boundary includes sampling tags
-        // payload buffer is prepending, so last span written appears first!
-        if (!span.getTraceId().equals(currentSpan.getTraceId())) {
-          metaWriter.includeSamplingTags();
-        }
-        completeSpan();
-      }
-      currentSpan = (DDSpan) span;
-      currentSpan.getLinks().forEach(this::visitSpanLink);
+  private boolean visitSpan(CoreSpan<?> span) {
+    if (!shouldExport(span)) {
+      return false;
     }
+    if (currentSpan != null) {
+      // ensure last span written at trace boundary includes sampling tags
+      // payload buffer is prepending, so last span written appears first!
+      if (!span.getTraceId().equals(currentSpan.getTraceId())) {
+        metaWriter.includeSamplingTags();
+      }
+      completeSpan();
+    }
+    currentSpan = (DDSpan) span;
+    currentSpan.getLinks().forEach(this::visitSpanLink);
+    return true;
   }
 
   private void visitSpanLink(AgentSpanLink spanLink) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProtoCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProtoCollector.java
@@ -44,7 +44,6 @@ public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
   private int payloadBytes;
   private int scopedBytes;
   private int spanBytes;
-  private int traceCount;
 
   private OtelInstrumentationScope currentScope;
   private DDSpan currentSpan;
@@ -58,13 +57,9 @@ public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
     }
 
     try {
-      boolean exported = false;
       // OtlpProtoBuffer collects spans in reverse
       for (int i = spans.size() - 1; i >= 0; i--) {
-        exported |= visitSpan(spans.get(i));
-      }
-      if (exported) {
-        traceCount++;
+        visitSpan(spans.get(i));
       }
     } catch (Throwable e) {
       // reset the buffer for subsequent traces
@@ -94,18 +89,11 @@ public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
 
   /** Prepare temporary elements to collect trace data. */
   private void start() {
-    traceCount = 0;
-
     // remove stale entries from caches
     OtlpCommonProto.recalibrateCaches();
 
     // for now put all spans under the default scope
     visitScopedSpans(DEFAULT_TRACE_SCOPE);
-  }
-
-  @Override
-  public int getTraceCount() {
-    return traceCount;
   }
 
   /** Cleanup elements used to collect trace data. */
@@ -130,9 +118,9 @@ public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
     currentScope = scope;
   }
 
-  private boolean visitSpan(CoreSpan<?> span) {
+  private void visitSpan(CoreSpan<?> span) {
     if (!shouldExport(span)) {
-      return false;
+      return;
     }
     if (currentSpan != null) {
       // ensure last span written at trace boundary includes sampling tags
@@ -144,7 +132,6 @@ public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
     }
     currentSpan = (DDSpan) span;
     currentSpan.getLinks().forEach(this::visitSpanLink);
-    return true;
   }
 
   private void visitSpanLink(AgentSpanLink spanLink) {

--- a/dd-trace-core/src/test/java/datadog/trace/common/writer/OtlpPayloadDispatcherTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/writer/OtlpPayloadDispatcherTest.java
@@ -40,6 +40,7 @@ class OtlpPayloadDispatcherTest {
   @BeforeEach
   void stubSuccessfulSend() {
     lenient().when(sender.send(any())).thenReturn(RemoteApi.Response.success(200));
+    OtlpTelemetry.getInstance().prepareMetrics();
     OtlpTelemetry.getInstance().drain();
   }
 
@@ -201,6 +202,7 @@ class OtlpPayloadDispatcherTest {
 
   private static Map<String, OtlpTelemetry.OtlpMetric> drainTracesTelemetry() {
     Map<String, OtlpTelemetry.OtlpMetric> byName = new HashMap<>();
+    OtlpTelemetry.getInstance().prepareMetrics();
     for (OtlpTelemetry.OtlpMetric metric : OtlpTelemetry.getInstance().drain()) {
       byName.put(metric.metricName, metric);
     }

--- a/dd-trace-core/src/test/java/datadog/trace/common/writer/OtlpPayloadDispatcherTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/writer/OtlpPayloadDispatcherTest.java
@@ -5,7 +5,10 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -13,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 import datadog.trace.api.sampling.PrioritySampling;
 import datadog.trace.core.CoreSpan;
+import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.core.otlp.common.OtlpPayload;
 import datadog.trace.core.otlp.common.OtlpSender;
 import datadog.trace.core.otlp.trace.OtlpTraceCollector;
@@ -20,6 +24,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -29,8 +34,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class OtlpPayloadDispatcherTest {
   @Mock OtlpSender sender;
+  @Mock HealthMetrics healthMetrics;
 
   TestCollector collector = new TestCollector();
+
+  @BeforeEach
+  void stubSuccessfulSend() {
+    lenient().when(sender.send(any())).thenReturn(RemoteApi.Response.success(200));
+  }
 
   @Test
   void sampledTraceForwardsAllSpans() {
@@ -159,6 +170,32 @@ class OtlpPayloadDispatcherTest {
   }
 
   @Test
+  void flushRecordsSerializedSizeBeforeSending() {
+    RemoteApi.Response response = RemoteApi.Response.success(200);
+    when(sender.send(any())).thenReturn(response);
+    OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender, collector, healthMetrics);
+
+    dispatcher.addTrace(Arrays.asList(sampledSpan(), sampledSpan()));
+    dispatcher.flush();
+
+    verify(healthMetrics).onSerialize(2 /*spans*/);
+    verify(healthMetrics).onSend(eq(1) /*trace*/, eq(2) /*spans*/, same(response));
+  }
+
+  @Test
+  void flushRecordsFailedSendHealthMetric() {
+    RemoteApi.Response response = RemoteApi.Response.failed(500);
+    when(sender.send(any())).thenReturn(response);
+    OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender, collector, healthMetrics);
+
+    dispatcher.addTrace(Arrays.asList(sampledSpan(), sampledSpan()));
+    dispatcher.flush();
+
+    verify(healthMetrics).onSerialize(2 /*spans*/);
+    verify(healthMetrics).onFailedSend(eq(1) /*trace*/, eq(2) /*spans*/, same(response));
+  }
+
+  @Test
   void getApisIsEmpty() {
     OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender, collector);
 
@@ -205,6 +242,7 @@ class OtlpPayloadDispatcherTest {
   /** Test collector that creates payloads whose size equals the number of exported spans. */
   private static class TestCollector extends OtlpTraceCollector {
     final List<CoreSpan<?>> spansToExport = new ArrayList<>();
+    int traceCount;
 
     // lets tests drive the proactive-flush threshold independently of spansToExport
     int fakeSizeInBytes;
@@ -214,10 +252,19 @@ class OtlpPayloadDispatcherTest {
 
     @Override
     public void addTrace(List<? extends CoreSpan<?>> spans) {
+      if (spansToExport.isEmpty()) {
+        // starting a new batch - reset the count left over from the last collection
+        traceCount = 0;
+      }
+      boolean exported = false;
       for (CoreSpan<?> span : spans) {
         if (shouldExport(span)) {
           spansToExport.add(span);
+          exported = true;
         }
+      }
+      if (exported) {
+        traceCount++;
       }
     }
 
@@ -243,6 +290,11 @@ class OtlpPayloadDispatcherTest {
     @Override
     public int sizeInBytes() {
       return fakeSizeInBytes;
+    }
+
+    @Override
+    public int getTraceCount() {
+      return traceCount;
     }
   }
 }

--- a/dd-trace-core/src/test/java/datadog/trace/common/writer/OtlpPayloadDispatcherTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/writer/OtlpPayloadDispatcherTest.java
@@ -6,8 +6,6 @@ import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -15,15 +13,17 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.api.telemetry.OtlpTelemetry;
 import datadog.trace.core.CoreSpan;
-import datadog.trace.core.monitor.HealthMetrics;
 import datadog.trace.core.otlp.common.OtlpPayload;
 import datadog.trace.core.otlp.common.OtlpSender;
 import datadog.trace.core.otlp.trace.OtlpTraceCollector;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,13 +34,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class OtlpPayloadDispatcherTest {
   @Mock OtlpSender sender;
-  @Mock HealthMetrics healthMetrics;
 
   TestCollector collector = new TestCollector();
 
   @BeforeEach
   void stubSuccessfulSend() {
     lenient().when(sender.send(any())).thenReturn(RemoteApi.Response.success(200));
+    OtlpTelemetry.getInstance().drain();
   }
 
   @Test
@@ -170,29 +170,41 @@ class OtlpPayloadDispatcherTest {
   }
 
   @Test
-  void flushRecordsSerializedSizeBeforeSending() {
+  void flushRecordsSuccessfulExportTelemetry() {
     RemoteApi.Response response = RemoteApi.Response.success(200);
     when(sender.send(any())).thenReturn(response);
-    OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender, collector, healthMetrics);
+    OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender, collector);
 
     dispatcher.addTrace(Arrays.asList(sampledSpan(), sampledSpan()));
     dispatcher.flush();
 
-    verify(healthMetrics).onSerialize(2 /*spans*/);
-    verify(healthMetrics).onSend(eq(1) /*trace*/, eq(2) /*spans*/, same(response));
+    Map<String, OtlpTelemetry.OtlpMetric> metrics = drainTracesTelemetry();
+    assertEquals(2, metrics.size());
+    assertEquals(1L, metrics.get("otel.traces_export_attempts").value);
+    assertEquals(1L, metrics.get("otel.traces_export_successes").value);
   }
 
   @Test
-  void flushRecordsFailedSendHealthMetric() {
+  void flushRecordsFailedExportTelemetry() {
     RemoteApi.Response response = RemoteApi.Response.failed(500);
     when(sender.send(any())).thenReturn(response);
-    OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender, collector, healthMetrics);
+    OtlpPayloadDispatcher dispatcher = new OtlpPayloadDispatcher(sender, collector);
 
     dispatcher.addTrace(Arrays.asList(sampledSpan(), sampledSpan()));
     dispatcher.flush();
 
-    verify(healthMetrics).onSerialize(2 /*spans*/);
-    verify(healthMetrics).onFailedSend(eq(1) /*trace*/, eq(2) /*spans*/, same(response));
+    Map<String, OtlpTelemetry.OtlpMetric> metrics = drainTracesTelemetry();
+    assertEquals(2, metrics.size());
+    assertEquals(1L, metrics.get("otel.traces_export_attempts").value);
+    assertEquals(1L, metrics.get("otel.traces_export_failures").value);
+  }
+
+  private static Map<String, OtlpTelemetry.OtlpMetric> drainTracesTelemetry() {
+    Map<String, OtlpTelemetry.OtlpMetric> byName = new HashMap<>();
+    for (OtlpTelemetry.OtlpMetric metric : OtlpTelemetry.getInstance().drain()) {
+      byName.put(metric.metricName, metric);
+    }
+    return byName;
   }
 
   @Test
@@ -242,7 +254,6 @@ class OtlpPayloadDispatcherTest {
   /** Test collector that creates payloads whose size equals the number of exported spans. */
   private static class TestCollector extends OtlpTraceCollector {
     final List<CoreSpan<?>> spansToExport = new ArrayList<>();
-    int traceCount;
 
     // lets tests drive the proactive-flush threshold independently of spansToExport
     int fakeSizeInBytes;
@@ -252,19 +263,10 @@ class OtlpPayloadDispatcherTest {
 
     @Override
     public void addTrace(List<? extends CoreSpan<?>> spans) {
-      if (spansToExport.isEmpty()) {
-        // starting a new batch - reset the count left over from the last collection
-        traceCount = 0;
-      }
-      boolean exported = false;
       for (CoreSpan<?> span : spans) {
         if (shouldExport(span)) {
           spansToExport.add(span);
-          exported = true;
         }
-      }
-      if (exported) {
-        traceCount++;
       }
     }
 
@@ -290,11 +292,6 @@ class OtlpPayloadDispatcherTest {
     @Override
     public int sizeInBytes() {
       return fakeSizeInBytes;
-    }
-
-    @Override
-    public int getTraceCount() {
-      return traceCount;
     }
   }
 }

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/common/OtlpSenderSupportTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/common/OtlpSenderSupportTest.java
@@ -1,0 +1,95 @@
+package datadog.trace.core.otlp.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import datadog.communication.http.HttpRetryPolicy;
+import datadog.communication.http.OkHttpUtils;
+import datadog.logging.RatelimitedLogger;
+import datadog.trace.common.writer.RemoteApi;
+import java.io.IOException;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+class OtlpSenderSupportTest {
+
+  private final OkHttpClient client = mock(OkHttpClient.class);
+  private final HttpRetryPolicy.Factory retryPolicy = HttpRetryPolicy.Factory.NEVER_RETRY;
+  private final Request request =
+      new Request.Builder().url("http://localhost:4318/v1/traces").build();
+  private final RatelimitedLogger ratelimitedLogger = mock(RatelimitedLogger.class);
+
+  @Test
+  void successfulResponseIsReturnedWithoutLogging() throws IOException {
+    Response response = responseWithCode(200);
+    try (MockedStatic<OkHttpUtils> okHttpUtils = mockStatic(OkHttpUtils.class)) {
+      okHttpUtils
+          .when(() -> OkHttpUtils.sendWithRetries(client, retryPolicy, request))
+          .thenReturn(response);
+
+      RemoteApi.Response result =
+          OtlpSenderSupport.send(client, retryPolicy, request, ratelimitedLogger);
+
+      assertTrue(result.success());
+      assertEquals(200, result.status().getAsInt());
+      verify(ratelimitedLogger, never()).warn(any(String.class), any());
+    }
+  }
+
+  @Test
+  void unsuccessfulResponseIsReturnedAndLogged() throws IOException {
+    Response response = responseWithCode(500);
+    try (MockedStatic<OkHttpUtils> okHttpUtils = mockStatic(OkHttpUtils.class)) {
+      okHttpUtils
+          .when(() -> OkHttpUtils.sendWithRetries(client, retryPolicy, request))
+          .thenReturn(response);
+
+      RemoteApi.Response result =
+          OtlpSenderSupport.send(client, retryPolicy, request, ratelimitedLogger);
+
+      assertFalse(result.success());
+      assertEquals(500, result.status().getAsInt());
+      verify(ratelimitedLogger).warn(any(String.class), any(), any(), any());
+    }
+  }
+
+  @Test
+  void ioExceptionIsReturnedAsFailureAndLogged() throws IOException {
+    IOException exception = new IOException("boom");
+    try (MockedStatic<OkHttpUtils> okHttpUtils = mockStatic(OkHttpUtils.class)) {
+      okHttpUtils
+          .when(() -> OkHttpUtils.sendWithRetries(client, retryPolicy, request))
+          .thenThrow(exception);
+
+      RemoteApi.Response result =
+          OtlpSenderSupport.send(client, retryPolicy, request, ratelimitedLogger);
+
+      assertFalse(result.success());
+      assertTrue(result.exception().isPresent());
+      assertEquals(exception, result.exception().get());
+      verify(ratelimitedLogger).warn(any(String.class), any(), any());
+    }
+  }
+
+  private Response responseWithCode(int code) {
+    return new Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(code)
+        .message(code == 200 ? "OK" : "Server Error")
+        .body(ResponseBody.create(MediaType.get("text/plain"), ""))
+        .build();
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/metrics/OtlpStatsMetricWriterTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/metrics/OtlpStatsMetricWriterTest.java
@@ -1,5 +1,6 @@
 package datadog.trace.core.otlp.metrics;
 
+import static datadog.trace.common.writer.RemoteApi.Response.success;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -14,6 +15,7 @@ import datadog.metrics.api.Histograms;
 import datadog.metrics.impl.DDSketchHistograms;
 import datadog.trace.common.metrics.AggregateEntry;
 import datadog.trace.common.metrics.AggregateEntryTestUtils;
+import datadog.trace.common.writer.RemoteApi;
 import datadog.trace.core.otlp.common.OtlpPayload;
 import datadog.trace.core.otlp.common.OtlpSender;
 import java.io.IOException;
@@ -64,12 +66,13 @@ class OtlpStatsMetricWriterTest {
     byte[] lastPayload;
 
     @Override
-    public void send(OtlpPayload payload) {
+    public RemoteApi.Response send(OtlpPayload payload) {
       sendCount++;
       java.nio.ByteBuffer content = payload.getContent();
       byte[] bytes = new byte[content.remaining()];
       content.get(bytes);
       lastPayload = bytes;
+      return success(200);
     }
 
     @Override

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/OtlpTelemetry.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/OtlpTelemetry.java
@@ -17,13 +17,27 @@ public class OtlpTelemetry implements MetricCollector<OtlpTelemetry.OtlpMetric> 
     return INSTANCE;
   }
 
+  private final String[] tracesTags = tagsFor(Config.get().getOtlpTracesProtocol());
   private final String[] metricsTags = tagsFor(Config.get().getOtlpMetricsProtocol());
   private final String[] logsTags = tagsFor(Config.get().getOtlpLogsProtocol());
 
+  private final ExportCounters tracesExport = new ExportCounters("traces");
   private final ExportCounters metricsExport = new ExportCounters("metrics");
   private final LongAdder logRecords = new LongAdder();
 
   private OtlpTelemetry() {}
+
+  public void onTracesExportAttempt() {
+    tracesExport.attempts.increment();
+  }
+
+  public void onTracesExportSuccess() {
+    tracesExport.successes.increment();
+  }
+
+  public void onTracesExportFailure() {
+    tracesExport.failures.increment();
+  }
 
   public void onMetricsExportAttempt() {
     metricsExport.attempts.increment();
@@ -57,6 +71,7 @@ public class OtlpTelemetry implements MetricCollector<OtlpTelemetry.OtlpMetric> 
   @Override
   public Collection<OtlpMetric> drain() {
     List<OtlpMetric> drained = new ArrayList<>();
+    tracesExport.drainInto(drained, tracesTags);
     metricsExport.drainInto(drained, metricsTags);
     long logRecordCount = logRecords.sumThenReset();
     if (logRecordCount > 0) {

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/OtlpTelemetry.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/OtlpTelemetry.java
@@ -4,7 +4,10 @@ import datadog.trace.api.Config;
 import datadog.trace.api.config.OtlpConfig;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.LongAdder;
 
 /** Collects telemetry metrics for the OTLP trace, metrics, and log exporters. */
@@ -24,6 +27,8 @@ public class OtlpTelemetry implements MetricCollector<OtlpTelemetry.OtlpMetric> 
   private final ExportCounters tracesExport = new ExportCounters("traces");
   private final ExportCounters metricsExport = new ExportCounters("metrics");
   private final LongAdder logRecords = new LongAdder();
+
+  private final BlockingQueue<OtlpMetric> telemetryQueue = new ArrayBlockingQueue<>(RAW_QUEUE_SIZE);
 
   private OtlpTelemetry() {}
 
@@ -57,18 +62,21 @@ public class OtlpTelemetry implements MetricCollector<OtlpTelemetry.OtlpMetric> 
 
   @Override
   public void prepareMetrics() {
-    // metrics are accumulated directly as they happen; nothing to prepare
+    tracesExport.stageInto(telemetryQueue, tracesTags);
+    metricsExport.stageInto(telemetryQueue, metricsTags);
+    long logRecordCount = logRecords.sumThenReset();
+    if (logRecordCount > 0) {
+      telemetryQueue.offer(new OtlpMetric("otel.log_records", logRecordCount, logsTags));
+    }
   }
 
   @Override
   public Collection<OtlpMetric> drain() {
-    List<OtlpMetric> drained = new ArrayList<>();
-    tracesExport.drainInto(drained, tracesTags);
-    metricsExport.drainInto(drained, metricsTags);
-    long logRecordCount = logRecords.sumThenReset();
-    if (logRecordCount > 0) {
-      drained.add(new OtlpMetric("otel.log_records", logRecordCount, logsTags));
+    if (telemetryQueue.isEmpty()) {
+      return Collections.emptyList();
     }
+    List<OtlpMetric> drained = new ArrayList<>(telemetryQueue.size());
+    telemetryQueue.drainTo(drained);
     return drained;
   }
 
@@ -92,17 +100,17 @@ public class OtlpTelemetry implements MetricCollector<OtlpTelemetry.OtlpMetric> 
       (success ? successes : failures).increment();
     }
 
-    void drainInto(List<OtlpMetric> out, String[] tags) {
+    void stageInto(BlockingQueue<OtlpMetric> out, String[] tags) {
       addIfNonZero(out, attemptsMetric, attempts, tags);
       addIfNonZero(out, successesMetric, successes, tags);
       addIfNonZero(out, failuresMetric, failures, tags);
     }
 
     private static void addIfNonZero(
-        List<OtlpMetric> out, String metricName, LongAdder counter, String[] tags) {
+        BlockingQueue<OtlpMetric> out, String metricName, LongAdder counter, String[] tags) {
       long value = counter.sumThenReset();
       if (value > 0) {
-        out.add(new OtlpMetric(metricName, value, tags));
+        out.offer(new OtlpMetric(metricName, value, tags));
       }
     }
   }

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/OtlpTelemetry.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/OtlpTelemetry.java
@@ -1,0 +1,104 @@
+package datadog.trace.api.telemetry;
+
+import datadog.trace.api.Config;
+import datadog.trace.api.config.OtlpConfig;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.LongAdder;
+
+/** Collects telemetry metrics for the OTLP trace, metrics, and log exporters. */
+public class OtlpTelemetry implements MetricCollector<OtlpTelemetry.OtlpMetric> {
+  private static final String NAMESPACE = "tracers";
+
+  private static final OtlpTelemetry INSTANCE = new OtlpTelemetry();
+
+  public static OtlpTelemetry getInstance() {
+    return INSTANCE;
+  }
+
+  private final String[] metricsTags = tagsFor(Config.get().getOtlpMetricsProtocol());
+  private final String[] logsTags = tagsFor(Config.get().getOtlpLogsProtocol());
+
+  private final ExportCounters metricsExport = new ExportCounters("metrics");
+  private final LongAdder logRecords = new LongAdder();
+
+  private OtlpTelemetry() {}
+
+  public void onMetricsExportAttempt() {
+    metricsExport.attempts.increment();
+  }
+
+  public void onMetricsExportSuccess() {
+    metricsExport.successes.increment();
+  }
+
+  public void onMetricsExportFailure() {
+    metricsExport.failures.increment();
+  }
+
+  public void onLogRecordsSubmitted(long count) {
+    if (count > 0) {
+      logRecords.add(count);
+    }
+  }
+
+  private static String[] tagsFor(OtlpConfig.Protocol protocol) {
+    String protocolTag = protocol == OtlpConfig.Protocol.GRPC ? "grpc" : "http";
+    String encodingTag = protocol == OtlpConfig.Protocol.HTTP_JSON ? "json" : "protobuf";
+    return new String[] {"protocol:" + protocolTag, "encoding:" + encodingTag};
+  }
+
+  @Override
+  public void prepareMetrics() {
+    // metrics are accumulated directly as they happen; nothing to prepare
+  }
+
+  @Override
+  public Collection<OtlpMetric> drain() {
+    List<OtlpMetric> drained = new ArrayList<>();
+    metricsExport.drainInto(drained, metricsTags);
+    long logRecordCount = logRecords.sumThenReset();
+    if (logRecordCount > 0) {
+      drained.add(new OtlpMetric("otel.log_records", logRecordCount, logsTags));
+    }
+    return drained;
+  }
+
+  /** Counters for a single signal's export attempts/successes/failures. */
+  private static final class ExportCounters {
+    final String attemptsMetric;
+    final String successesMetric;
+    final String failuresMetric;
+
+    final LongAdder attempts = new LongAdder();
+    final LongAdder successes = new LongAdder();
+    final LongAdder failures = new LongAdder();
+
+    ExportCounters(String signal) {
+      this.attemptsMetric = "otel." + signal + "_export_attempts";
+      this.successesMetric = "otel." + signal + "_export_successes";
+      this.failuresMetric = "otel." + signal + "_export_failures";
+    }
+
+    void drainInto(List<OtlpMetric> out, String[] tags) {
+      addIfNonZero(out, attemptsMetric, attempts, tags);
+      addIfNonZero(out, successesMetric, successes, tags);
+      addIfNonZero(out, failuresMetric, failures, tags);
+    }
+
+    private static void addIfNonZero(
+        List<OtlpMetric> out, String metricName, LongAdder counter, String[] tags) {
+      long value = counter.sumThenReset();
+      if (value > 0) {
+        out.add(new OtlpMetric(metricName, value, tags));
+      }
+    }
+  }
+
+  public static class OtlpMetric extends MetricCollector.Metric {
+    public OtlpMetric(String metricName, long value, String... tags) {
+      super(NAMESPACE, true, metricName, "count", value, tags);
+    }
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/OtlpTelemetry.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/OtlpTelemetry.java
@@ -31,24 +31,16 @@ public class OtlpTelemetry implements MetricCollector<OtlpTelemetry.OtlpMetric> 
     tracesExport.attempts.increment();
   }
 
-  public void onTracesExportSuccess() {
-    tracesExport.successes.increment();
-  }
-
-  public void onTracesExportFailure() {
-    tracesExport.failures.increment();
+  public void onTracesExportComplete(boolean success) {
+    tracesExport.complete(success);
   }
 
   public void onMetricsExportAttempt() {
     metricsExport.attempts.increment();
   }
 
-  public void onMetricsExportSuccess() {
-    metricsExport.successes.increment();
-  }
-
-  public void onMetricsExportFailure() {
-    metricsExport.failures.increment();
+  public void onMetricsExportComplete(boolean success) {
+    metricsExport.complete(success);
   }
 
   public void onLogRecordsSubmitted(long count) {
@@ -94,6 +86,10 @@ public class OtlpTelemetry implements MetricCollector<OtlpTelemetry.OtlpMetric> 
       this.attemptsMetric = "otel." + signal + "_export_attempts";
       this.successesMetric = "otel." + signal + "_export_successes";
       this.failuresMetric = "otel." + signal + "_export_failures";
+    }
+
+    void complete(boolean success) {
+      (success ? successes : failures).increment();
     }
 
     void drainInto(List<OtlpMetric> out, String[] tags) {

--- a/internal-api/src/test/java/datadog/trace/api/telemetry/OtlpTelemetryTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/telemetry/OtlpTelemetryTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -13,6 +15,38 @@ class OtlpTelemetryTest {
   @BeforeEach
   void drainStaleMetrics() {
     collector.drain();
+  }
+
+  @Test
+  void onTracesExportAttemptQueuesCountMetricWithTags() {
+    collector.onTracesExportAttempt();
+
+    Collection<OtlpTelemetry.OtlpMetric> metrics = collector.drain();
+
+    assertEquals(1, metrics.size());
+    OtlpTelemetry.OtlpMetric metric = metrics.iterator().next();
+    assertEquals("tracers", metric.namespace);
+    assertEquals("otel.traces_export_attempts", metric.metricName);
+    assertEquals("count", metric.type);
+    assertEquals(1L, metric.value);
+    assertEquals(2, metric.tags.size());
+    assertTrue(metric.tags.contains("protocol:http"));
+    assertTrue(metric.tags.contains("encoding:protobuf"));
+  }
+
+  @Test
+  void tracesExportMetricsUseExpectedNames() {
+    collector.onTracesExportAttempt();
+    collector.onTracesExportAttempt();
+    collector.onTracesExportSuccess();
+    collector.onTracesExportFailure();
+
+    Map<String, Number> valuesByName = drainToMap();
+
+    assertEquals(3, valuesByName.size());
+    assertEquals(2L, valuesByName.get("otel.traces_export_attempts"));
+    assertEquals(1L, valuesByName.get("otel.traces_export_successes"));
+    assertEquals(1L, valuesByName.get("otel.traces_export_failures"));
   }
 
   @Test
@@ -35,16 +69,16 @@ class OtlpTelemetryTest {
   @Test
   void metricsExportMetricsUseExpectedNames() {
     collector.onMetricsExportAttempt();
+    collector.onMetricsExportAttempt();
     collector.onMetricsExportSuccess();
     collector.onMetricsExportFailure();
 
-    Collection<OtlpTelemetry.OtlpMetric> metrics = collector.drain();
+    Map<String, Number> valuesByName = drainToMap();
 
-    assertEquals(3, metrics.size());
-    assertTrue(metrics.stream().anyMatch(m -> m.metricName.equals("otel.metrics_export_attempts")));
-    assertTrue(
-        metrics.stream().anyMatch(m -> m.metricName.equals("otel.metrics_export_successes")));
-    assertTrue(metrics.stream().anyMatch(m -> m.metricName.equals("otel.metrics_export_failures")));
+    assertEquals(3, valuesByName.size());
+    assertEquals(2L, valuesByName.get("otel.metrics_export_attempts"));
+    assertEquals(1L, valuesByName.get("otel.metrics_export_successes"));
+    assertEquals(1L, valuesByName.get("otel.metrics_export_failures"));
   }
 
   @Test
@@ -72,5 +106,13 @@ class OtlpTelemetryTest {
   @Test
   void drainReturnsEmptyCollectionWhenNoMetricsQueued() {
     assertTrue(collector.drain().isEmpty());
+  }
+
+  private Map<String, Number> drainToMap() {
+    Map<String, Number> valuesByName = new HashMap<>();
+    for (OtlpTelemetry.OtlpMetric metric : collector.drain()) {
+      valuesByName.put(metric.metricName, metric.value);
+    }
+    return valuesByName;
   }
 }

--- a/internal-api/src/test/java/datadog/trace/api/telemetry/OtlpTelemetryTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/telemetry/OtlpTelemetryTest.java
@@ -1,0 +1,76 @@
+package datadog.trace.api.telemetry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OtlpTelemetryTest {
+  private final OtlpTelemetry collector = OtlpTelemetry.getInstance();
+
+  @BeforeEach
+  void drainStaleMetrics() {
+    collector.drain();
+  }
+
+  @Test
+  void onMetricsExportAttemptQueuesCountMetricWithTags() {
+    collector.onMetricsExportAttempt();
+
+    Collection<OtlpTelemetry.OtlpMetric> metrics = collector.drain();
+
+    assertEquals(1, metrics.size());
+    OtlpTelemetry.OtlpMetric metric = metrics.iterator().next();
+    assertEquals("tracers", metric.namespace);
+    assertEquals("otel.metrics_export_attempts", metric.metricName);
+    assertEquals("count", metric.type);
+    assertEquals(1L, metric.value);
+    assertEquals(2, metric.tags.size());
+    assertTrue(metric.tags.contains("protocol:http"));
+    assertTrue(metric.tags.contains("encoding:protobuf"));
+  }
+
+  @Test
+  void metricsExportMetricsUseExpectedNames() {
+    collector.onMetricsExportAttempt();
+    collector.onMetricsExportSuccess();
+    collector.onMetricsExportFailure();
+
+    Collection<OtlpTelemetry.OtlpMetric> metrics = collector.drain();
+
+    assertEquals(3, metrics.size());
+    assertTrue(metrics.stream().anyMatch(m -> m.metricName.equals("otel.metrics_export_attempts")));
+    assertTrue(
+        metrics.stream().anyMatch(m -> m.metricName.equals("otel.metrics_export_successes")));
+    assertTrue(metrics.stream().anyMatch(m -> m.metricName.equals("otel.metrics_export_failures")));
+  }
+
+  @Test
+  void onLogRecordsSubmittedQueuesCountWithGivenValue() {
+    collector.onLogRecordsSubmitted(5);
+
+    Collection<OtlpTelemetry.OtlpMetric> metrics = collector.drain();
+
+    assertEquals(1, metrics.size());
+    OtlpTelemetry.OtlpMetric metric = metrics.iterator().next();
+    assertEquals("otel.log_records", metric.metricName);
+    assertEquals(5L, metric.value);
+    assertTrue(metric.tags.contains("protocol:http"));
+    assertTrue(metric.tags.contains("encoding:protobuf"));
+  }
+
+  @Test
+  void onLogRecordsSubmittedIgnoresNonPositiveCounts() {
+    collector.onLogRecordsSubmitted(0);
+    collector.onLogRecordsSubmitted(-1);
+
+    assertTrue(collector.drain().isEmpty());
+  }
+
+  @Test
+  void drainReturnsEmptyCollectionWhenNoMetricsQueued() {
+    assertTrue(collector.drain().isEmpty());
+  }
+}

--- a/internal-api/src/test/java/datadog/trace/api/telemetry/OtlpTelemetryTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/telemetry/OtlpTelemetryTest.java
@@ -14,12 +14,14 @@ class OtlpTelemetryTest {
 
   @BeforeEach
   void drainStaleMetrics() {
+    collector.prepareMetrics();
     collector.drain();
   }
 
   @Test
   void onTracesExportAttemptQueuesCountMetricWithTags() {
     collector.onTracesExportAttempt();
+    collector.prepareMetrics();
 
     Collection<OtlpTelemetry.OtlpMetric> metrics = collector.drain();
 
@@ -40,6 +42,7 @@ class OtlpTelemetryTest {
     collector.onTracesExportAttempt();
     collector.onTracesExportComplete(true);
     collector.onTracesExportComplete(false);
+    collector.prepareMetrics();
 
     Map<String, Number> valuesByName = drainToMap();
 
@@ -52,6 +55,7 @@ class OtlpTelemetryTest {
   @Test
   void onMetricsExportAttemptQueuesCountMetricWithTags() {
     collector.onMetricsExportAttempt();
+    collector.prepareMetrics();
 
     Collection<OtlpTelemetry.OtlpMetric> metrics = collector.drain();
 
@@ -72,6 +76,7 @@ class OtlpTelemetryTest {
     collector.onMetricsExportAttempt();
     collector.onMetricsExportComplete(true);
     collector.onMetricsExportComplete(false);
+    collector.prepareMetrics();
 
     Map<String, Number> valuesByName = drainToMap();
 
@@ -84,6 +89,7 @@ class OtlpTelemetryTest {
   @Test
   void onLogRecordsSubmittedQueuesCountWithGivenValue() {
     collector.onLogRecordsSubmitted(5);
+    collector.prepareMetrics();
 
     Collection<OtlpTelemetry.OtlpMetric> metrics = collector.drain();
 

--- a/internal-api/src/test/java/datadog/trace/api/telemetry/OtlpTelemetryTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/telemetry/OtlpTelemetryTest.java
@@ -38,8 +38,8 @@ class OtlpTelemetryTest {
   void tracesExportMetricsUseExpectedNames() {
     collector.onTracesExportAttempt();
     collector.onTracesExportAttempt();
-    collector.onTracesExportSuccess();
-    collector.onTracesExportFailure();
+    collector.onTracesExportComplete(true);
+    collector.onTracesExportComplete(false);
 
     Map<String, Number> valuesByName = drainToMap();
 
@@ -70,8 +70,8 @@ class OtlpTelemetryTest {
   void metricsExportMetricsUseExpectedNames() {
     collector.onMetricsExportAttempt();
     collector.onMetricsExportAttempt();
-    collector.onMetricsExportSuccess();
-    collector.onMetricsExportFailure();
+    collector.onMetricsExportComplete(true);
+    collector.onMetricsExportComplete(false);
 
     Map<String, Number> valuesByName = drainToMap();
 

--- a/telemetry/build.gradle.kts
+++ b/telemetry/build.gradle.kts
@@ -18,7 +18,8 @@ extra["excludedClassesCoverage"] = listOf(
   "datadog.telemetry.TelemetrySystem",
   "datadog.telemetry.api.*",
   "datadog.telemetry.metric.CiVisibilityMetricPeriodicAction",
-  "datadog.telemetry.metric.OtelSpiMetricPeriodicAction"
+  "datadog.telemetry.metric.OtelSpiMetricPeriodicAction",
+  "datadog.telemetry.metric.OtlpTelemetryPeriodicAction"
 )
 extra["excludedClassesBranchCoverage"] = listOf(
   "datadog.telemetry.PolymorphicAdapterFactory.1",

--- a/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
+++ b/telemetry/src/main/java/datadog/telemetry/TelemetrySystem.java
@@ -16,6 +16,7 @@ import datadog.telemetry.metric.IastMetricPeriodicAction;
 import datadog.telemetry.metric.LLMObsMetricPeriodicAction;
 import datadog.telemetry.metric.OtelEnvMetricPeriodicAction;
 import datadog.telemetry.metric.OtelSpiMetricPeriodicAction;
+import datadog.telemetry.metric.OtlpTelemetryPeriodicAction;
 import datadog.telemetry.metric.WafMetricPeriodicAction;
 import datadog.telemetry.products.ProductChangeAction;
 import datadog.telemetry.rum.RumPeriodicAction;
@@ -65,6 +66,7 @@ public class TelemetrySystem {
       actions.add(new ConfigInversionMetricPeriodicAction());
       actions.add(new IntegrationPeriodicAction());
       actions.add(new WafMetricPeriodicAction());
+      actions.add(new OtlpTelemetryPeriodicAction());
       if (Verbosity.OFF != Config.get().getIastTelemetryVerbosity()) {
         actions.add(new IastMetricPeriodicAction());
       }

--- a/telemetry/src/main/java/datadog/telemetry/metric/OtlpTelemetryPeriodicAction.java
+++ b/telemetry/src/main/java/datadog/telemetry/metric/OtlpTelemetryPeriodicAction.java
@@ -1,0 +1,14 @@
+package datadog.telemetry.metric;
+
+import datadog.trace.api.telemetry.MetricCollector;
+import datadog.trace.api.telemetry.OtlpTelemetry;
+import javax.annotation.Nonnull;
+
+public class OtlpTelemetryPeriodicAction extends MetricPeriodicAction {
+
+  @Override
+  @Nonnull
+  public MetricCollector collector() {
+    return OtlpTelemetry.getInstance();
+  }
+}


### PR DESCRIPTION
# What Does This Do

Telemetry for OTLP traces/metrics/logs:
* otel.traces_export_{attempts,successes,failures}
* otel.metrics_export_{attempts,successes,failures}
* otel.log_records

OTLP telemetry metrics are tagged by protocol and encoding (per signal)

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
