### PR TITLE
Improve codeowners lookup performance

### DIFF
--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/CodeownersImpl.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/CodeownersImpl.java
@@ -4,11 +4,9 @@ import datadog.trace.civisibility.codeowners.matcher.CharacterMatcher;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Deque;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -20,9 +18,9 @@ import javax.annotation.Nullable;
 
 public class CodeownersImpl implements Codeowners {
 
-  private final Collection<Section> sections;
+  private final List<Section> sections;
 
-  private CodeownersImpl(Collection<Section> sections) {
+  private CodeownersImpl(List<Section> sections) {
     this.sections = sections;
   }
 
@@ -32,17 +30,25 @@ public class CodeownersImpl implements Codeowners {
    */
   @Override
   public @Nullable Collection<String> getOwners(@Nonnull String path) {
-    char[] pathCharacters = path.toCharArray();
+    if (sections.size() == 1) {
+      Section section = sections.get(0);
+      if (section.isExcluded(path)) {
+        return new ArrayList<>();
+      }
+      Entry entry = section.findMatchingEntry(path);
+      return entry != null ? new ArrayList<>(entry.getOwners()) : null;
+    }
+
     Set<String> owners = null;
     for (Section section : sections) {
-      if (section.isExcluded(pathCharacters)) {
+      if (section.isExcluded(path)) {
         if (owners == null) {
           owners = new LinkedHashSet<>();
         }
         continue;
       }
 
-      Entry entry = section.findMatchingEntry(pathCharacters);
+      Entry entry = section.findMatchingEntry(path);
       if (entry != null) {
         if (owners == null) {
           owners = new LinkedHashSet<>();
@@ -89,37 +95,5 @@ public class CodeownersImpl implements Codeowners {
     sections.add(defaultSection);
     sections.addAll(namedSections.values());
     return new CodeownersImpl(sections);
-  }
-
-  private static final class Section {
-
-    private final Deque<Entry> entries = new ArrayDeque<>();
-    private final Collection<Entry> exclusions = new ArrayList<>();
-
-    private void add(Entry entry) {
-      if (entry.isExclusion()) {
-        exclusions.add(entry);
-      } else {
-        entries.offerFirst(entry);
-      }
-    }
-
-    private boolean isExcluded(char[] path) {
-      for (Entry exclusion : exclusions) {
-        if (exclusion.getMatcher().consume(path, 0) >= 0) {
-          return true;
-        }
-      }
-      return false;
-    }
-
-    private @Nullable Entry findMatchingEntry(char[] path) {
-      for (Entry entry : entries) {
-        if (entry.getMatcher().consume(path, 0) >= 0) {
-          return entry;
-        }
-      }
-      return null;
-    }
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/Entry.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/Entry.java
@@ -1,18 +1,24 @@
 package datadog.trace.civisibility.codeowners;
 
 import datadog.trace.civisibility.codeowners.matcher.Matcher;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashSet;
+import javax.annotation.Nullable;
 
 public class Entry {
 
   private final Matcher matcher;
   private final Collection<String> owners;
   private final boolean exclusion;
+  private final @Nullable String indexKey;
 
-  public Entry(Matcher matcher, Collection<String> owners, boolean exclusion) {
+  public Entry(
+      Matcher matcher, Collection<String> owners, boolean exclusion, @Nullable String indexKey) {
     this.matcher = matcher;
-    this.owners = owners;
+    this.owners = owners.size() > 1 ? new ArrayList<>(new LinkedHashSet<>(owners)) : owners;
     this.exclusion = exclusion;
+    this.indexKey = indexKey;
   }
 
   public Matcher getMatcher() {
@@ -25,5 +31,9 @@ public class Entry {
 
   public boolean isExclusion() {
     return exclusion;
+  }
+
+  public @Nullable String getIndexKey() {
+    return indexKey;
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/EntryBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/EntryBuilder.java
@@ -73,12 +73,13 @@ public class EntryBuilder {
         offset++;
       }
 
+      String indexKey = parseIndexKey();
       Matcher matcher = parseMatcher();
       Collection<String> owners = exclusion ? Collections.emptyList() : parseOwners();
       if (!exclusion && owners.isEmpty()) {
         owners = sectionDefaultOwners;
       }
-      return new Entry(matcher, owners, exclusion);
+      return new Entry(matcher, owners, exclusion, indexKey);
 
     } catch (Exception e) {
       log.warn("Skipping malformed CODEOWNERS entry: {}", new String(c), e);
@@ -222,6 +223,38 @@ public class EntryBuilder {
     }
 
     return new CompositeMatcher(characterMatchers.toArray(new Matcher[0]));
+  }
+
+  private @Nullable String parseIndexKey() {
+    // Index by the first two fixed path segments; patterns without a safe prefix stay linear.
+    int position = offset;
+    boolean patternContainsSlashes = c[position] == '/';
+    if (patternContainsSlashes) {
+      position++;
+    }
+    int prefixStart = position;
+    int firstSeparator = -1;
+    for (; position < c.length && !isPatternTerminator(c[position]); position++) {
+      char character = c[position];
+      if (character == '*' || character == '?' || character == '[') {
+        return null;
+      }
+      if (character == '\\') {
+        return null;
+      }
+      if (character == '/') {
+        patternContainsSlashes = true;
+        if (firstSeparator >= 0) {
+          return new String(c, prefixStart, position - prefixStart);
+        }
+        firstSeparator = position;
+      }
+    }
+
+    if (!patternContainsSlashes || firstSeparator < 0 || firstSeparator == position - 1) {
+      return null;
+    }
+    return new String(c, prefixStart, position - prefixStart);
   }
 
   private boolean consumeDoubleAsterisk() {

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/EntryBuilder.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/EntryBuilder.java
@@ -228,6 +228,14 @@ public class EntryBuilder {
   private @Nullable String parseIndexKey() {
     // Index by the first two fixed path segments; patterns without a safe prefix stay linear.
     int position = offset;
+    int patternEnd = position;
+    while (patternEnd < c.length && !isPatternTerminator(c[patternEnd])) {
+      patternEnd++;
+    }
+    // Trailing-slash matchers can match beyond a segment boundary, making their prefix unsafe.
+    if (patternEnd > position && c[patternEnd - 1] == '/') {
+      return null;
+    }
     boolean patternContainsSlashes = c[position] == '/';
     if (patternContainsSlashes) {
       position++;

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/EntryIndex.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/EntryIndex.java
@@ -1,0 +1,105 @@
+package datadog.trace.civisibility.codeowners;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Resolves entries by rule priority, switching large rule sets from linear scans to fixed-prefix
+ * buckets while retaining a fallback for patterns that cannot be indexed.
+ */
+final class EntryIndex {
+
+  private static final int MIN_INDEX_SIZE = 512;
+
+  private List<IndexedEntry> entries = new ArrayList<>();
+  private Map<String, List<IndexedEntry>> entriesByKey;
+  private List<IndexedEntry> unindexedEntries;
+  private int indexableEntryCount;
+
+  void add(Entry entry, int order) {
+    IndexedEntry indexedEntry = new IndexedEntry(entry, order);
+    if (entriesByKey != null) {
+      index(indexedEntry);
+    } else {
+      entries.add(indexedEntry);
+      if (entry.getIndexKey() != null) {
+        indexableEntryCount++;
+      }
+      if (entries.size() >= MIN_INDEX_SIZE && indexableEntryCount * 2 >= entries.size()) {
+        entriesByKey = new HashMap<>();
+        unindexedEntries = new ArrayList<>();
+        for (IndexedEntry existingEntry : entries) {
+          index(existingEntry);
+        }
+        entries = Collections.emptyList();
+      }
+    }
+  }
+
+  @Nullable
+  Entry find(String path) {
+    IndexedEntry entry = findIndexedEntry(path);
+    return entry != null ? entry.entry : null;
+  }
+
+  private @Nullable IndexedEntry findIndexedEntry(String path) {
+    if (entriesByKey == null) {
+      return findFirstMatch(entries, path);
+    }
+    IndexedEntry unindexedMatch = findFirstMatch(unindexedEntries, path);
+
+    int firstSeparator = path.indexOf('/');
+    if (firstSeparator < 0) {
+      return unindexedMatch;
+    }
+    int secondSeparator = path.indexOf('/', firstSeparator + 1);
+    int keyEnd = secondSeparator >= 0 ? secondSeparator : path.length();
+    List<IndexedEntry> indexedEntries = entriesByKey.get(path.substring(0, keyEnd));
+    IndexedEntry indexedMatch = findFirstMatch(indexedEntries, path);
+
+    if (unindexedMatch == null) {
+      return indexedMatch;
+    }
+    if (indexedMatch == null) {
+      return unindexedMatch;
+    }
+    return indexedMatch.order > unindexedMatch.order ? indexedMatch : unindexedMatch;
+  }
+
+  private void index(IndexedEntry indexedEntry) {
+    String indexKey = indexedEntry.entry.getIndexKey();
+    if (indexKey != null) {
+      entriesByKey.computeIfAbsent(indexKey, key -> new ArrayList<>()).add(indexedEntry);
+    } else {
+      unindexedEntries.add(indexedEntry);
+    }
+  }
+
+  private static @Nullable IndexedEntry findFirstMatch(
+      @Nullable List<IndexedEntry> entries, String path) {
+    if (entries != null) {
+      for (int i = entries.size() - 1; i >= 0; i--) {
+        IndexedEntry entry = entries.get(i);
+        if (entry.entry.getMatcher().consume(path, 0) >= 0) {
+          return entry;
+        }
+      }
+    }
+    return null;
+  }
+
+  private static final class IndexedEntry {
+
+    private final Entry entry;
+    private final int order;
+
+    private IndexedEntry(Entry entry, int order) {
+      this.entry = entry;
+      this.order = order;
+    }
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/Section.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/Section.java
@@ -1,0 +1,28 @@
+package datadog.trace.civisibility.codeowners;
+
+import javax.annotation.Nullable;
+
+/** Groups ownership and exclusion rules for a CODEOWNERS section while preserving rule order. */
+final class Section {
+
+  private final EntryIndex entries = new EntryIndex();
+  private final EntryIndex exclusions = new EntryIndex();
+  private int entryOrder;
+
+  void add(Entry entry) {
+    if (entry.isExclusion()) {
+      exclusions.add(entry, entryOrder++);
+    } else {
+      entries.add(entry, entryOrder++);
+    }
+  }
+
+  boolean isExcluded(String path) {
+    return exclusions.find(path) != null;
+  }
+
+  @Nullable
+  Entry findMatchingEntry(String path) {
+    return entries.find(path);
+  }
+}

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/AsteriskMatcher.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/AsteriskMatcher.java
@@ -7,8 +7,8 @@ public class AsteriskMatcher implements Matcher {
   private AsteriskMatcher() {}
 
   @Override
-  public int consume(char[] line, int offset) {
-    return offset < line.length && line[offset] != '/' ? 1 : -1;
+  public int consume(String line, int offset) {
+    return offset < line.length() && line.charAt(offset) != '/' ? 1 : -1;
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/CharacterMatcher.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/CharacterMatcher.java
@@ -12,8 +12,8 @@ public class CharacterMatcher implements Matcher {
   }
 
   @Override
-  public int consume(char[] line, int offset) {
-    return offset < line.length && line[offset] == character ? 1 : -1;
+  public int consume(String line, int offset) {
+    return offset < line.length() && line.charAt(offset) == character ? 1 : -1;
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/CompositeMatcher.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/CompositeMatcher.java
@@ -9,11 +9,11 @@ public class CompositeMatcher implements Matcher {
   }
 
   @Override
-  public int consume(char[] line, int offset) {
+  public int consume(String line, int offset) {
     return consume(line, offset, 0);
   }
 
-  private int consume(char[] line, int offset, int matcherOffset) {
+  private int consume(String line, int offset, int matcherOffset) {
     int position = offset;
     while (matcherOffset < delegates.length) {
       Matcher delegate = delegates[matcherOffset];

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/DoubleAsteriskMatcher.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/DoubleAsteriskMatcher.java
@@ -7,13 +7,13 @@ public class DoubleAsteriskMatcher implements Matcher {
   private DoubleAsteriskMatcher() {}
 
   @Override
-  public int consume(char[] line, int offset) {
-    if (offset == line.length) {
+  public int consume(String line, int offset) {
+    if (offset == line.length()) {
       return -1;
     }
 
     int position = offset;
-    while (position < line.length && line[position++] != '/') {}
+    while (position < line.length() && line.charAt(position++) != '/') {}
     return position - offset;
   }
 

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/EndOfLineMatcher.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/EndOfLineMatcher.java
@@ -5,8 +5,8 @@ public class EndOfLineMatcher implements Matcher {
   public static final Matcher INSTANCE = new EndOfLineMatcher();
 
   @Override
-  public int consume(char[] line, int offset) {
-    return offset == line.length ? 0 : -1;
+  public int consume(String line, int offset) {
+    return offset == line.length() ? 0 : -1;
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/EndOfSegmentMatcher.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/EndOfSegmentMatcher.java
@@ -5,8 +5,8 @@ public class EndOfSegmentMatcher implements Matcher {
   public static final Matcher INSTANCE = new EndOfSegmentMatcher();
 
   @Override
-  public int consume(char[] line, int offset) {
-    return offset == line.length || line[offset] == '/' ? 0 : -1;
+  public int consume(String line, int offset) {
+    return offset == line.length() || line.charAt(offset) == '/' ? 0 : -1;
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/Matcher.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/Matcher.java
@@ -6,7 +6,7 @@ public interface Matcher {
    * @return the number of characters matched from the line starting with the offset. Negative value
    *     means matching failed
    */
-  int consume(char[] line, int offset);
+  int consume(String line, int offset);
 
   /**
    * @return {@code true} if this matcher can be used [0..*] times. {@code false} if the matcher

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/QuestionMarkMatcher.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/QuestionMarkMatcher.java
@@ -7,8 +7,8 @@ public class QuestionMarkMatcher implements Matcher {
   private QuestionMarkMatcher() {}
 
   @Override
-  public int consume(char[] line, int offset) {
-    return offset < line.length && line[offset] != '/' ? 1 : -1;
+  public int consume(String line, int offset) {
+    return offset < line.length() && line.charAt(offset) != '/' ? 1 : -1;
   }
 
   @Override

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/RangeMatcher.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/codeowners/matcher/RangeMatcher.java
@@ -26,10 +26,10 @@ public class RangeMatcher implements Matcher {
   }
 
   @Override
-  public int consume(char[] line, int offset) {
-    if (offset < line.length) {
+  public int consume(String line, int offset) {
+    if (offset < line.length()) {
       for (Range range : ranges) {
-        if (range.matches(line[offset])) {
+        if (range.matches(line.charAt(offset))) {
           return 1;
         }
       }

--- a/dd-java-agent/agent-ci-visibility/src/test/java/datadog/trace/civisibility/codeowners/CodeownersTest.java
+++ b/dd-java-agent/agent-ci-visibility/src/test/java/datadog/trace/civisibility/codeowners/CodeownersTest.java
@@ -11,8 +11,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.StringReader;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -28,6 +31,34 @@ class CodeownersTest {
       throws IOException {
     Codeowners codeowners = parse(resource);
     assertEquals(expectedOwners, codeowners.getOwners(path));
+  }
+
+  @Test
+  void testIndexedAndFallbackEntriesPreservePriority() throws IOException {
+    StringBuilder content = new StringBuilder();
+    for (int i = 0; i < 510; i++) {
+      content.append("/dummy").append(i).append("/file @dummy\n");
+    }
+    content.append("/service/target @indexed-before\n");
+    content.append("/**/target @fallback-after\n");
+    content.append("/other/* @fallback-before\n");
+    content.append("/other/target @indexed-after\n");
+
+    Codeowners codeowners = CodeownersImpl.parse(new StringReader(content.toString()));
+
+    assertEquals(singletonList("@fallback-after"), codeowners.getOwners("service/target"));
+    assertEquals(singletonList("@indexed-after"), codeowners.getOwners("other/target"));
+  }
+
+  @Test
+  void testSingleSectionOwnersAreNormalizedAndIndependent() throws IOException {
+    Codeowners codeowners = CodeownersImpl.parse(new StringReader("* @team @team"));
+
+    Collection<String> owners = codeowners.getOwners("source/File.java");
+    assertEquals(singletonList("@team"), owners);
+    owners.add("@other-team");
+
+    assertEquals(singletonList("@team"), codeowners.getOwners("source/File.java"));
   }
 
   static Stream<Arguments> testCodeownersMatchingArguments() {

--- a/dd-java-agent/agent-ci-visibility/src/test/java/datadog/trace/civisibility/codeowners/CodeownersTest.java
+++ b/dd-java-agent/agent-ci-visibility/src/test/java/datadog/trace/civisibility/codeowners/CodeownersTest.java
@@ -31,6 +31,8 @@ class CodeownersTest {
       throws IOException {
     Codeowners codeowners = parse(resource);
     assertEquals(expectedOwners, codeowners.getOwners(path));
+    Codeowners indexedCodeowners = parseWithActivatedIndexes(resource);
+    assertEquals(expectedOwners, indexedCodeowners.getOwners(path));
   }
 
   @Test
@@ -73,6 +75,7 @@ class CodeownersTest {
         arguments(GITHUB_SAMPLE, "scripts/inner/script.js", asList("@doctocat", "@octocat")),
         arguments(GITHUB_SAMPLE, "build/logs/current.log", singletonList("@doctocat")),
         arguments(GITHUB_SAMPLE, "build/logs/inner/current.log", singletonList("@doctocat")),
+        arguments(GITHUB_SAMPLE, "build/logs-v2/current.log", singletonList("@doctocat")),
         arguments(GITHUB_SAMPLE, "module/build/logs/current.log", globalOwners),
         arguments(GITHUB_SAMPLE, "apps/app1.exe", singletonList("@octocat")),
         arguments(GITHUB_SAMPLE, "apps/inner/app2.exe", singletonList("@octocat")),
@@ -129,14 +132,40 @@ class CodeownersTest {
             asList("@global-owner", "@other-generated-files-team")),
         arguments(
             GITLAB_SAMPLE,
+            "generated-assets/excluded-v2/output.txt",
+            asList("@global-owner", "@other-generated-files-team")),
+        arguments(
+            GITLAB_SAMPLE,
             "generated-assets/excluded/special.txt",
             asList("@global-owner", "@other-generated-files-team")));
   }
 
   private static Codeowners parse(String resource) throws IOException {
+    return CodeownersImpl.parse(new StringReader(read(resource)));
+  }
+
+  private static Codeowners parseWithActivatedIndexes(String resource) throws IOException {
+    StringBuilder content = new StringBuilder(read(resource));
+    if (GITLAB_SAMPLE.equals(resource)) {
+      content.append("\n[Generated Files]\n");
+    }
+    for (int i = 0; i < 512; i++) {
+      content.append("/__owned").append(i).append("/file @dummy\n");
+      content.append("!/__excluded").append(i).append("/file\n");
+    }
+    return CodeownersImpl.parse(new StringReader(content.toString()));
+  }
+
+  private static String read(String resource) throws IOException {
     try (InputStream stream = CodeownersTest.class.getClassLoader().getResourceAsStream(resource);
         Reader reader = new InputStreamReader(stream, UTF_8)) {
-      return CodeownersImpl.parse(reader);
+      StringBuilder content = new StringBuilder();
+      char[] buffer = new char[1024];
+      int read;
+      while ((read = reader.read(buffer)) >= 0) {
+        content.append(buffer, 0, read);
+      }
+      return content.toString();
     }
   }
 }

--- a/dd-java-agent/agent-ci-visibility/src/test/java/datadog/trace/civisibility/codeowners/EntryBuilderTest.java
+++ b/dd-java-agent/agent-ci-visibility/src/test/java/datadog/trace/civisibility/codeowners/EntryBuilderTest.java
@@ -28,8 +28,8 @@ class EntryBuilderTest {
     Entry exclusionEntry =
         new EntryBuilder(matcherFactory, "!" + pattern + " " + ownersToString(owners)).parse();
 
-    boolean result = entry.getMatcher().consume(path.toCharArray(), 0) >= 0;
-    boolean exclusionResult = exclusionEntry.getMatcher().consume(path.toCharArray(), 0) >= 0;
+    boolean result = entry.getMatcher().consume(path, 0) >= 0;
+    boolean exclusionResult = exclusionEntry.getMatcher().consume(path, 0) >= 0;
 
     assertEquals(owners, entry.getOwners());
     assertFalse(entry.isExclusion());


### PR DESCRIPTION
# What Does This Do

Improves CODEOWNERS lookup performance in Test Optimization.

The change removes several per-lookup allocations and adds adaptive indexing for large CODEOWNERS sections:

- Matchers consume the original path `String` instead of creating a `char[]`
- Owners are deduplicated once during parsing instead of during every lookup
- Each lookup still returns a fresh mutable owner list
- Ownership and exclusion rules are managed independently
- Large rule sets are indexed by their first two fixed path segments
- Patterns without a safe fixed prefix remain in a linear fallback
- Rule order still determines precedence across indexed and fallback matches

The index activates only when a rule set contains at least 512 entries and at least half can be indexed. Smaller rule sets retain the linear lookup path. When the index activates, already parsed entries are moved into their buckets using index keys computed during parsing. Patterns are not reparsed.

# Motivation

CODEOWNERS parsing happens once during repository initialization, but ownership lookup runs for every test and test suite. Large CODEOWNERS files can therefore consume measurable CPU and allocate hundreds of bytes per lookup.

The first implementation indexed every file. Benchmarks across Java projects showed that indexing small rule sets could add latency. The final implementation uses an adaptive gate so only large, indexable rule sets pay the indexing cost. 

# Additional Notes

The original benchmarking was performed against an input which contained 6,679 lines and 5,596 entries. Lookups were sampled up to 30,000 tracked paths.

| Measurement | Linear | Optimized | Change |
| --- | ---: | ---: | ---: |
| Average lookup time | 58.290 us/lookup | 12.631 us/lookup | 78.3% lower |
| p50 lookup time | 60.672 us | 10.624 us | 82.5% lower |
| p95 lookup time | 102.144 us | 30.272 us | 70.4% lower |
| p99 lookup time | 112.640 us | 37.376 us | 66.8% lower |
| Lookup allocation | 483.144 B/lookup | 108.914 B/lookup | 77.5% lower |
| Time to parse the whole file | 3.832 ms | 3.950 ms | 3.1% higher |
| Allocation while parsing | 7.97 MiB | 8.13 MiB | 2.0% higher |

Given the nature of the repository (multi-language monorepo), other projects were also benchmarked to account for specific patterns in codeowners definition for Java-centric repositories:

| Project profile | Entries (fixed / fallback) | Index active | Linear time | Optimized time | Linear allocation | Optimized allocation |
| --- | ---: | --- | ---: | ---: | ---: | ---: |
| Large polyglot monorepo | 5,596 (5,346 / 250) | Yes | 58.290 us/lookup | 12.631 us/lookup (↓78.3%) | 483.144 B/lookup | 108.914 B/lookup (↓77.5%) |
| Large Java service monorepo | 1,228 (1,177 / 51) | Yes | 19.661 us/lookup | 11.269 us/lookup (↓42.7%) | 559.060 B/lookup | 111.873 B/lookup (↓80.0%) |
| Java build-tool project | 95 (86 / 9) | No | 1.626 us/lookup | 1.604 us/lookup (↓1.4%) | 494.806 B/lookup | 48.063 B/lookup (↓90.3%) |
| Java multi-module project | 165 (130 / 35) | No | 15.272 us/lookup | 15.181 us/lookup (↓0.6%) | 474.052 B/lookup | 48.045 B/lookup (↓89.9%) |
| Small Java service | 12 (9 / 3) | No | 1.327 us/lookup | 1.206 us/lookup (↓9.1%) | 410.820 B/lookup | 48.004 B/lookup (↓88.3%) |
| Small test project | 28 (27 / 1) | No | 0.794 us/lookup | 0.761 us/lookup (↓4.2%) | 437.652 B/lookup | 51.904 B/lookup (↓88.1%) |
| Small Android project | 3 (0 / 3) | No | 2.143 us/lookup | 2.152 us/lookup (↑0.4%) | 515.021 B/lookup | 48.006 B/lookup (↓90.7%) |


test-environment-trigger: skip

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
