### PR TITLE
Remove AgentTracer.noopScope() sentinel

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -2,7 +2,6 @@ package datadog.trace.core.scopemanager;
 
 import static datadog.trace.api.ConfigDefaults.DEFAULT_ASYNC_PROPAGATING;
 import static datadog.trace.api.telemetry.LogCollector.SEND_TELEMETRY;
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
 import static datadog.trace.core.scopemanager.ContinuableScope.CONTEXT;
 import static datadog.trace.core.scopemanager.ContinuableScope.INSTRUMENTATION;
@@ -25,6 +24,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTraceCollector;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.NoopContinuation;
+import datadog.trace.bootstrap.instrumentation.api.NoopScope;
 import datadog.trace.bootstrap.instrumentation.api.ProfilerContext;
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
 import datadog.trace.core.monitor.HealthMetrics;
@@ -52,6 +52,7 @@ public final class ContinuableScopeManager {
   static final RatelimitedLogger ratelimitedLog = new RatelimitedLogger(log, 1, MINUTES);
 
   private static final NoopContinuation ROOT_CONTINUATION = NoopContinuation.INSTANCE;
+  private static final NoopScope INVALID_SCOPE = NoopScope.INSTANCE;
 
   static final long iterationKeepAlive =
       SECONDS.toMillis(Config.get().getScopeIterationKeepAlive());
@@ -150,7 +151,7 @@ public final class ContinuableScopeManager {
       if (depthLimit <= currentDepth) {
         healthMetrics.onScopeStackOverflow();
         log.debug("Scope depth limit exceeded ({}).  Returning NoopScope.", currentDepth);
-        return noopScope();
+        return INVALID_SCOPE;
       }
     }
 
@@ -187,7 +188,7 @@ public final class ContinuableScopeManager {
       if (depthLimit <= currentDepth) {
         healthMetrics.onScopeStackOverflow();
         log.debug("Scope depth limit exceeded ({}).  Returning NoopScope.", currentDepth);
-        return noopScope();
+        return INVALID_SCOPE;
       }
     }
 
@@ -280,7 +281,7 @@ public final class ContinuableScopeManager {
     if (hasDepthLimit && depthLimit <= currentDepth) {
       healthMetrics.onScopeStackOverflow();
       log.debug("Scope depth limit exceeded ({}).  Returning NoopScope.", currentDepth);
-      return noopScope();
+      return INVALID_SCOPE;
     }
 
     assert span != null;

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeContinuation.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ScopeContinuation.java
@@ -1,11 +1,10 @@
 package datadog.trace.core.scopemanager;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope;
-
 import datadog.context.Context;
 import datadog.context.ContextScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentTraceCollector;
+import datadog.trace.bootstrap.instrumentation.api.NoopScope;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 /**
@@ -83,7 +82,7 @@ final class ScopeContinuation implements AgentScope.Continuation {
     } else {
       // continuation cancelled or too many activations; rollback count
       COUNT.decrementAndGet(this);
-      return noopScope();
+      return NoopScope.INSTANCE;
     }
   }
 

--- a/dd-trace-core/src/test/java/datadog/trace/core/scopemanager/ScopeManagerDepthTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/scopemanager/ScopeManagerDepthTest.java
@@ -1,15 +1,13 @@
 package datadog.trace.core.scopemanager;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopScope;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertSame;
 
 import datadog.trace.api.config.TracerConfig;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.NoopScope;
 import datadog.trace.common.writer.ListWriter;
 import datadog.trace.core.CoreTracer;
 import datadog.trace.core.DDCoreJavaSpecification;
@@ -43,13 +41,13 @@ class ScopeManagerDepthTest extends DDCoreJavaSpecification {
     scope = tracer.activateSpan(span);
 
     // a noop instance is returned
-    assertSame(noopScope(), scope);
+    assertInstanceOf(NoopScope.class, scope);
 
     // activate a noop scope over the limit
     scope = scopeManager.activateManualSpan(noopSpan());
 
     // still have a noop instance
-    assertSame(noopScope(), scope);
+    assertInstanceOf(NoopScope.class, scope);
 
     // scope stack not effected
     assertEquals(depth, scopeManager.scopeStack().depth());
@@ -83,14 +81,14 @@ class ScopeManagerDepthTest extends DDCoreJavaSpecification {
     scope = tracer.activateSpan(span);
 
     // a real scope is returned
-    assertNotSame(noopScope(), scope);
+    assertInstanceOf(ContinuableScope.class, scope);
     assertEquals(defaultLimit + 1, scopeManager.scopeStack().depth());
 
     // activate a noop span
     scope = scopeManager.activateManualSpan(noopSpan());
 
     // a real instance is still returned
-    assertNotSame(noopScope(), scope);
+    assertInstanceOf(ContinuableScope.class, scope);
 
     // scope stack not effected
     assertEquals(defaultLimit + 2, scopeManager.scopeStack().depth());

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -224,18 +224,6 @@ public class AgentTracer {
     return NoopSpanContext.INSTANCE;
   }
 
-  /**
-   * Returns the noop scope instance.
-   *
-   * <p>This instance will always be the same, and can be safely tested using object identity (ie
-   * {@code ==}).
-   *
-   * @return the noop scope instance.
-   */
-  public static AgentScope noopScope() {
-    return NoopScope.INSTANCE;
-  }
-
   public static final TracerAPI NOOP_TRACER = new NoopTracerAPI();
 
   private static volatile TracerAPI provider = NOOP_TRACER;

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/NoopScope.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/NoopScope.java
@@ -2,8 +2,8 @@ package datadog.trace.bootstrap.instrumentation.api;
 
 import datadog.trace.context.TraceScope;
 
-final class NoopScope implements AgentScope {
-  static final NoopScope INSTANCE = new NoopScope();
+public final class NoopScope implements AgentScope {
+  public static final NoopScope INSTANCE = new NoopScope();
 
   private NoopScope() {}
 


### PR DESCRIPTION
# Motivation

This helps with switching between the two context manager approaches, since the checks now don't assume a particular implementation.

# Additional Notes

To be merged in once https://github.com/DataDog/dd-trace-java/pull/12008 is merged

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
