### PR TITLE
Fix race condition with reliability env deploy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1287,6 +1287,9 @@ deploy_to_di_backend:manual:
     UPSTREAM_COMMIT_AUTHOR: $CI_COMMIT_AUTHOR
     UPSTREAM_COMMIT_SHORT_SHA: $CI_COMMIT_SHORT_SHA
 
+deploy_to_reliability_env:
+  needs: [ build ]
+
 # If the deploy_to_maven_central job is re-run, re-trigger the deploy_artifacts_to_github job as well so that the artifacts match.
 deploy_to_maven_central:
   extends: .gradle_build


### PR DESCRIPTION
# What Does This Do
There's a race condition with the reliability env deploy introduced with one-pipeline 1.1.0 . `deploy_to_reliability_env` has `needs: []` which means it no longer waits for previous stages to finish. For `dd-trace-java`, this means the deploy job runs before the `build` job is finished causing a failure.

This PR adds `needs: [ build ]` to have the trigger wait for the build to finish

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
