### PR TITLE
[DO NOT MERGE] 

### DIFF
--- a/.github/workflows/check-pull-request-labels.yaml
+++ b/.github/workflows/check-pull-request-labels.yaml
@@ -146,7 +146,8 @@ jobs:
               'mergequeue-status:',
               'team:',
               'performance:',  // To refactor to 'ci: ' in the future
-              'run-tests:'     // Unused since GitLab migration
+              'run-tests:',    // Unused since GitLab migration
+              'pr-shepherd:'   // Applied by the PR Shepherd automation
             ]
             // Exact-match labels that don't fit a category prefix (e.g. labels applied
             // by external automation tooling).


### PR DESCRIPTION
## What

Add the `pr-shepherd:` prefix to the `validCategories` allowlist in `check-pull-request-labels.yaml`.

## Why

The PR Shepherd automation applies labels such as `pr-shepherd:in_progress`. The `Validate PR Label Format` workflow only accepts labels matching a fixed set of prefixes, so these labels were flagged as invalid and the PR was blocked (a maintainer had to delete the bot comment to unblock). See e.g. https://github.com/DataDog/dd-trace-java/pull/12034#issuecomment-5065154033

## Consequence check

- `validCategories` is read in exactly one place (this filter); nothing else consumes it.
- No other workflow acts on a `pr-shepherd:` label — `check-pull-requests.yaml` requires `type:`/`comp:`/`inst:`, and `draft-release-notes-on-tag.yaml` only maps `comp:`/`inst:` (any `pr-shepherd:` label falls through to "other PRs").
- No test fixtures reference the prefix list.

The change only removes the false-positive block; no downstream side effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)