### PR TITLE
🍒 12055 - Bump java-profiler (ddprof) to 1.47.0

### DIFF
--- a/dd-java-agent/ddprof-lib/gradle.lockfile
+++ b/dd-java-agent/ddprof-lib/gradle.lockfile
@@ -5,7 +5,7 @@
 ch.qos.logback:logback-classic:1.2.13=testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.2.13=testCompileClasspath,testRuntimeClasspath
 com.datadoghq:dd-javac-plugin-client:0.2.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.datadoghq:ddprof:1.46.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.datadoghq:ddprof:1.47.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.github.javaparser:javaparser-core:3.25.6=codenarc
 com.github.spotbugs:spotbugs-annotations:4.9.8=compileClasspath,spotbugs
 com.github.spotbugs:spotbugs:4.9.8=spotbugs

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ shadow = "9.4.2"
 spotbugs_annotations = "4.9.8"
 
 # DataDog libs and forks
-ddprof = "1.46.0"
+ddprof = "1.47.0"
 dogstatsd = "4.4.5"
 okhttp = "3.12.15" # Datadog fork to support Java 7
 

--- a/metadata/agent-jar-checks.properties
+++ b/metadata/agent-jar-checks.properties
@@ -1,7 +1,7 @@
 # Agent jar structural invariants — edit intentionally, commit with the change that justified it.
 
-# Max agent jar size in bytes. Raise only when the size growth is intentional (33 MiB = 34603008).
-jar.size.budget = 34603008
+# Max agent jar size in bytes. Raise only when the size growth is intentional (~33.02 MiB).
+jar.size.budget = 34619392
 
 # Minimum combined class + classdata count in the assembled agent jar.
 # Set to ~98% of the actual count at the time of the last intentional change.


### PR DESCRIPTION
Backport #12055 to release/v1.64.x