### PR TITLE
Fix initialization of samplers for probe file

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationFileLoader.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/ConfigurationFileLoader.java
@@ -1,30 +1,24 @@
 package com.datadog.debugger.agent;
 
-import com.datadog.debugger.probe.LogProbe;
-import com.datadog.debugger.probe.MetricProbe;
+import static com.datadog.debugger.probe.ProbeDefinitionDeserializer.deserializeLogProbe;
+import static com.datadog.debugger.probe.ProbeDefinitionDeserializer.deserializeMetricProbe;
+import static com.datadog.debugger.probe.ProbeDefinitionDeserializer.deserializeSpanDecorationProbe;
+import static com.datadog.debugger.probe.ProbeDefinitionDeserializer.deserializeSpanProbe;
+import static com.datadog.debugger.probe.ProbeDefinitionDeserializer.deserializeTriggerProbe;
+
 import com.datadog.debugger.probe.ProbeDefinition;
-import com.datadog.debugger.probe.SpanDecorationProbe;
-import com.datadog.debugger.probe.SpanProbe;
-import com.datadog.debugger.probe.TriggerProbe;
-import com.datadog.debugger.util.MoshiHelper;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
-import com.squareup.moshi.Moshi;
-import com.squareup.moshi.Types;
 import datadog.trace.util.SizeCheckedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import okio.Okio;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,9 +40,7 @@ public class ConfigurationFileLoader {
         }
       } while (bytesRead > -1);
       byte[] configContent = outputStream.toByteArray();
-      Moshi moshi = MoshiHelper.createMoshiConfigBuilder().add(new ProbeFileFactory()).build();
-      ParameterizedType type = Types.newParameterizedType(List.class, ProbeDefinition.class);
-      JsonAdapter<List<ProbeDefinition>> adapter = moshi.adapter(type);
+      JsonAdapter<List<ProbeDefinition>> adapter = new ProbeFileAdapter();
       List<ProbeDefinition> probeDefinitions =
           adapter.fromJson(
               JsonReader.of(Okio.buffer(Okio.source(new ByteArrayInputStream(configContent)))));
@@ -59,40 +51,7 @@ public class ConfigurationFileLoader {
     }
   }
 
-  private static class ProbeFileFactory implements JsonAdapter.Factory {
-    @Override
-    public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {
-      if (Types.equals(type, Types.newParameterizedType(List.class, ProbeDefinition.class))) {
-        return new ProbeFileAdapter(
-            moshi.adapter(LogProbe.class),
-            moshi.adapter(MetricProbe.class),
-            moshi.adapter(SpanProbe.class),
-            moshi.adapter(SpanDecorationProbe.class),
-            moshi.adapter(TriggerProbe.class));
-      }
-      return null;
-    }
-  }
-
   private static class ProbeFileAdapter extends JsonAdapter<List<ProbeDefinition>> {
-    private final JsonAdapter<LogProbe> logProbeAdapter;
-    private final JsonAdapter<MetricProbe> metricProbeAdapter;
-    private final JsonAdapter<SpanProbe> spanProbeAdapter;
-    private final JsonAdapter<SpanDecorationProbe> spanDecorationProbeAdapter;
-    private final JsonAdapter<TriggerProbe> triggerProbeAdapter;
-
-    public ProbeFileAdapter(
-        JsonAdapter<LogProbe> logProbeAdapter,
-        JsonAdapter<MetricProbe> metricProbeAdapter,
-        JsonAdapter<SpanProbe> spanProbeAdapter,
-        JsonAdapter<SpanDecorationProbe> spanDecorationProbeAdapter,
-        JsonAdapter<TriggerProbe> triggerProbeAdapter) {
-      this.logProbeAdapter = logProbeAdapter;
-      this.metricProbeAdapter = metricProbeAdapter;
-      this.spanProbeAdapter = spanProbeAdapter;
-      this.spanDecorationProbeAdapter = spanDecorationProbeAdapter;
-      this.triggerProbeAdapter = triggerProbeAdapter;
-    }
 
     @Override
     public List<ProbeDefinition> fromJson(JsonReader reader) throws IOException {
@@ -110,19 +69,19 @@ public class ConfigurationFileLoader {
             String type = jsonPeekReader.nextString();
             switch (type) {
               case "LOG_PROBE":
-                probeDefinitions.add(logProbeAdapter.fromJson(reader));
+                probeDefinitions.add(deserializeLogProbe(reader));
                 break;
               case "METRIC_PROBE":
-                probeDefinitions.add(metricProbeAdapter.fromJson(reader));
+                probeDefinitions.add(deserializeMetricProbe(reader));
                 break;
               case "SPAN_PROBE":
-                probeDefinitions.add(spanProbeAdapter.fromJson(reader));
+                probeDefinitions.add(deserializeSpanProbe(reader));
                 break;
               case "SPAN_DECORATION_PROBE":
-                probeDefinitions.add(spanDecorationProbeAdapter.fromJson(reader));
+                probeDefinitions.add(deserializeSpanDecorationProbe(reader));
                 break;
               case "TRIGGER_PROBE":
-                probeDefinitions.add(triggerProbeAdapter.fromJson(reader));
+                probeDefinitions.add(deserializeTriggerProbe(reader));
                 break;
               default:
                 throw new RuntimeException("Unknown type: " + type);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinitionDeserializer.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/ProbeDefinitionDeserializer.java
@@ -3,6 +3,7 @@ package com.datadog.debugger.probe;
 import com.datadog.debugger.agent.Configuration;
 import com.datadog.debugger.util.MoshiHelper;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import okio.Okio;
@@ -29,8 +30,18 @@ public class ProbeDefinitionDeserializer {
     return deserialize(METRIC_PROBE_JSON_ADAPTER, content);
   }
 
+  public static MetricProbe deserializeMetricProbe(JsonReader reader) throws IOException {
+    return METRIC_PROBE_JSON_ADAPTER.fromJson(reader);
+  }
+
   public static LogProbe deserializeLogProbe(byte[] content) throws IOException {
     LogProbe logProbe = deserialize(LOG_PROBE_JSON_ADAPTER, content);
+    logProbe.initSamplers();
+    return logProbe;
+  }
+
+  public static LogProbe deserializeLogProbe(JsonReader reader) throws IOException {
+    LogProbe logProbe = LOG_PROBE_JSON_ADAPTER.fromJson(reader);
     logProbe.initSamplers();
     return logProbe;
   }
@@ -39,8 +50,18 @@ public class ProbeDefinitionDeserializer {
     return deserialize(SPAN_PROBE_JSON_ADAPTER, content);
   }
 
+  public static SpanProbe deserializeSpanProbe(JsonReader reader) throws IOException {
+    return SPAN_PROBE_JSON_ADAPTER.fromJson(reader);
+  }
+
   public static TriggerProbe deserializeTriggerProbe(byte[] content) throws IOException {
     TriggerProbe triggerProbe = deserialize(TRIGGER_PROBE_JSON_ADAPTER, content);
+    triggerProbe.initSamplers();
+    return triggerProbe;
+  }
+
+  public static TriggerProbe deserializeTriggerProbe(JsonReader jsonReader) throws IOException {
+    TriggerProbe triggerProbe = TRIGGER_PROBE_JSON_ADAPTER.fromJson(jsonReader);
     triggerProbe.initSamplers();
     return triggerProbe;
   }
@@ -49,6 +70,14 @@ public class ProbeDefinitionDeserializer {
       throws IOException {
     SpanDecorationProbe spanDecorationProbe =
         deserialize(SPAN_DECORATION_PROBE_JSON_ADAPTER, content);
+    spanDecorationProbe.initSamplers();
+    return spanDecorationProbe;
+  }
+
+  public static SpanDecorationProbe deserializeSpanDecorationProbe(JsonReader jsonReader)
+      throws IOException {
+    SpanDecorationProbe spanDecorationProbe =
+        SPAN_DECORATION_PROBE_JSON_ADAPTER.fromJson(jsonReader);
     spanDecorationProbe.initSamplers();
     return spanDecorationProbe;
   }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationFileLoaderTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/ConfigurationFileLoaderTest.java
@@ -7,6 +7,7 @@ import com.datadog.debugger.probe.MetricProbe;
 import com.datadog.debugger.probe.ProbeDefinition;
 import com.datadog.debugger.probe.SpanDecorationProbe;
 import com.datadog.debugger.probe.SpanProbe;
+import com.datadog.debugger.probe.TriggerProbe;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -21,11 +22,12 @@ class ConfigurationFileLoaderTest {
     Configuration configuration = ConfigurationFileLoader.from(probeFilePath, 1024 * 1024);
     assertNotNull(configuration);
     List<ProbeDefinition> definitions = configuration.getDefinitions();
-    assertEquals(5, definitions.size());
-    assertInstanceOf(MetricProbe.class, definitions.get(0));
-    assertInstanceOf(LogProbe.class, definitions.get(1));
+    assertEquals(6, definitions.size());
+    assertInstanceOf(TriggerProbe.class, definitions.get(0));
+    assertInstanceOf(MetricProbe.class, definitions.get(1));
     assertInstanceOf(LogProbe.class, definitions.get(2));
-    assertInstanceOf(SpanProbe.class, definitions.get(3));
-    assertInstanceOf(SpanDecorationProbe.class, definitions.get(4));
+    assertInstanceOf(LogProbe.class, definitions.get(3));
+    assertInstanceOf(SpanProbe.class, definitions.get(4));
+    assertInstanceOf(SpanDecorationProbe.class, definitions.get(5));
   }
 }

--- a/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/TestApplicationHelper.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/main/java/datadog/smoketest/debugger/TestApplicationHelper.java
@@ -13,12 +13,14 @@ import java.util.function.Predicate;
 
 public class TestApplicationHelper {
   // instrumentation is done by main thread
-  private static final String INSTRUMENTATION_DONE_MAIN_THREAD =
-      "[main] DEBUG com.datadog.debugger.agent.DebuggerTransformer - Generating bytecode for class: %s";
-  private static final String INSTRUMENTATION_DONE_BCKG_THREAD =
-      "[dd-remote-config] DEBUG com.datadog.debugger.agent.DebuggerTransformer - Generating bytecode for class: %s";
-  private static final String INSTRUMENTATION_DONE_TASK_THREAD =
-      "[dd-task-scheduler] DEBUG com.datadog.debugger.agent.DebuggerTransformer - Generating bytecode for class: %s";
+  private static final String INSTRUMENTATION_DONE =
+      "[%s] DEBUG com.datadog.debugger.agent.DebuggerTransformer - Generating bytecode for class: %s";
+  private static final String THREAD_MAIN = "main";
+  private static final String THREAD_REMOTE_CONFIG = "dd-remote-config";
+  private static final String THREAD_SCHEDULER = "dd-task-scheduler";
+  private static final String THREAD_STARTUP = "dd-agent-startup-datadog-tracer";
+  private static final String[] THREAD_NAMES =
+      new String[] {THREAD_MAIN, THREAD_REMOTE_CONFIG, THREAD_SCHEDULER, THREAD_STARTUP};
   private static final String RENTRANSFORMATION_CLASS =
       "[dd-remote-config] DEBUG com.datadog.debugger.agent.ConfigurationUpdater - Re-transforming class: %s";
   private static final String RETRANSFORMATION_DONE =
@@ -52,17 +54,16 @@ public class TestApplicationHelper {
         fromLine != null ? line -> line.contains(fromLine) : null,
         line -> {
           // when instrumentation is done by main thread, we are good to go
-          if (line.contains(String.format(INSTRUMENTATION_DONE_MAIN_THREAD, className))) {
+          if (line.contains(String.format(INSTRUMENTATION_DONE, THREAD_MAIN, className))) {
             return true;
           }
           if (!generatingByteCode.get()) {
             // instrumentation is done by background thread, need to wait for end of
             // re-transformation
-            if (line.contains(String.format(INSTRUMENTATION_DONE_BCKG_THREAD, className))) {
-              generatingByteCode.set(true);
-            }
-            if (line.contains(String.format(INSTRUMENTATION_DONE_TASK_THREAD, className))) {
-              generatingByteCode.set(true);
+            for (String threadName : THREAD_NAMES) {
+              if (line.contains(String.format(INSTRUMENTATION_DONE, threadName, className))) {
+                generatingByteCode.set(true);
+              }
             }
           } else {
             return line.contains(RETRANSFORMATION_DONE);

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/BaseIntegrationTest.java
@@ -21,6 +21,7 @@ import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
 import datadog.trace.bootstrap.debugger.CapturedContext;
+import datadog.trace.bootstrap.debugger.ProbeId;
 import datadog.trace.bootstrap.debugger.ProbeRateLimiter;
 import datadog.trace.test.agent.decoder.DecodedMessage;
 import datadog.trace.test.agent.decoder.DecodedTrace;
@@ -332,23 +333,25 @@ public abstract class BaseIntegrationTest {
     probeStatusListeners.add(listener);
   }
 
-  protected AtomicBoolean registerCheckReceivedInstalledEmitting() {
+  protected AtomicBoolean registerCheckReceivedInstalledEmitting(ProbeId probeId) {
     AtomicBoolean received = new AtomicBoolean();
     AtomicBoolean installed = new AtomicBoolean();
     AtomicBoolean emitting = new AtomicBoolean();
     AtomicBoolean result = new AtomicBoolean();
     registerProbeStatusListener(
         probeStatus -> {
-          if (probeStatus.getDiagnostics().getStatus() == ProbeStatus.Status.RECEIVED) {
-            received.set(true);
+          if (probeStatus.getDiagnostics().getProbeId().equals(probeId)) {
+            if (probeStatus.getDiagnostics().getStatus() == ProbeStatus.Status.RECEIVED) {
+              received.set(true);
+            }
+            if (probeStatus.getDiagnostics().getStatus() == ProbeStatus.Status.INSTALLED) {
+              installed.set(true);
+            }
+            if (probeStatus.getDiagnostics().getStatus() == ProbeStatus.Status.EMITTING) {
+              emitting.set(true);
+            }
+            result.set(received.get() && installed.get() && emitting.get());
           }
-          if (probeStatus.getDiagnostics().getStatus() == ProbeStatus.Status.INSTALLED) {
-            installed.set(true);
-          }
-          if (probeStatus.getDiagnostics().getStatus() == ProbeStatus.Status.EMITTING) {
-            emitting.set(true);
-          }
-          result.set(received.get() && installed.get() && emitting.get());
         });
     return result;
   }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/LogProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/LogProbesIntegrationTest.java
@@ -100,7 +100,7 @@ public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
           assertNull(snapshot.getCaptures().getReturn().getCapturedThrowable());
           snapshotReceived.set(true);
         });
-    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting();
+    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting(PROBE_ID);
     processRequests(
         () -> snapshotReceived.get() && statusResult.get(),
         () ->
@@ -132,7 +132,7 @@ public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
           assertFullMethodCaptureArgs(snapshot.getCaptures().getEntry());
           snapshotReceived.set(true);
         });
-    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting();
+    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting(PROBE_ID);
     processRequests(
         () -> snapshotReceived.get() && statusResult.get(),
         () ->
@@ -166,7 +166,7 @@ public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
           assertFullMethodCaptureArgs(snapshot.getCaptures().getReturn());
           snapshotReceived.set(true);
         });
-    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting();
+    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting(PROBE_ID);
     processRequests(
         () -> snapshotReceived.get() && statusResult.get(),
         () ->
@@ -199,7 +199,7 @@ public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
               "Cannot find symbol: noarg", snapshot.getEvaluationErrors().get(0).getMessage());
           snapshotReceived.set(true);
         });
-    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting();
+    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting(PROBE_ID);
     processRequests(
         () -> snapshotReceived.get() && statusResult.get(),
         () ->
@@ -236,7 +236,7 @@ public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
           assertEquals(PROBE_ID.getId(), snapshot.getProbe().getId());
           snapshotReceived.set(true);
         });
-    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting();
+    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting(PROBE_ID);
     processRequests(
         () -> snapshotReceived.get() && correctLogMessage.get() && statusResult.get(),
         () ->
@@ -288,7 +288,7 @@ public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
           assertNull(key2Value.getNotCapturedReason());
           snapshotReceived.set(true);
         });
-    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting();
+    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting(PROBE_ID);
     processRequests(
         () -> snapshotReceived.get() && statusResult.get(),
         () ->
@@ -371,7 +371,7 @@ public class LogProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest {
           assertNull(capturedContext.getCapturedThrowable());
           snapshotReceived.set(true);
         });
-    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting();
+    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting(LINE_PROBE_ID1);
     processRequests(
         () -> snapshotReceived.get() && statusResult.get(),
         () ->

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MetricProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/MetricProbesIntegrationTest.java
@@ -112,7 +112,7 @@ public class MetricProbesIntegrationTest extends SimpleAppDebuggerIntegrationTes
     targetProcess = createProcessBuilder(logFilePath, METHOD_NAME, EXPECTED_UPLOADS).start();
     String msgExpected = String.format(expectedMsgFormat, metricName, PROBE_ID.getId());
     assertNotNull(retrieveStatsdMessage(msgExpected));
-    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting();
+    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting(PROBE_ID);
     processRequests(
         statusResult::get, () -> String.format("timeout statusResult=%s", statusResult.get()));
   }
@@ -219,7 +219,7 @@ public class MetricProbesIntegrationTest extends SimpleAppDebuggerIntegrationTes
     targetProcess = createProcessBuilder(logFilePath, METHOD_NAME, EXPECTED_UPLOADS).start();
     String msgExpected = String.format(expectedMsgFormat, metricName, PROBE_ID.getId());
     assertNotNull(retrieveStatsdMessage(msgExpected));
-    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting();
+    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting(PROBE_ID);
     processRequests(
         statusResult::get, () -> String.format("timeout statusResult=%s", statusResult.get()));
   }

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ProbeFileIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/ProbeFileIntegrationTest.java
@@ -1,0 +1,83 @@
+package datadog.smoketest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import datadog.trace.bootstrap.debugger.ProbeId;
+import datadog.trace.test.agent.decoder.DecodedSpan;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.condition.DisabledIf;
+
+public class ProbeFileIntegrationTest extends ServerAppDebuggerIntegrationTest {
+  private static final ProbeId PROBE_ID2 = new ProbeId("ad4cba6f-d476-4554-b5ed-80dd941a40d8", 0);
+  private static final ProbeId PROBE_ID3 = new ProbeId("70b55d06-f9fa-403b-a329-4f2f960aed01", 0);
+  private static final ProbeId PROBE_ID4 = new ProbeId("123356537", 0);
+
+  Path probeFilePath;
+
+  @BeforeEach
+  @Override
+  public void setup(TestInfo testInfo) throws Exception {
+    super.setup(testInfo);
+    probeFilePath =
+        Paths.get(ProbeFileIntegrationTest.class.getResource("/test_probe_file.json").toURI());
+    appUrl = startAppAndAndGetUrl();
+  }
+
+  @Override
+  protected ProcessBuilder createProcessBuilder(Path logFilePath, String... params) {
+    List<String> commandParams = getDebuggerCommandParams();
+    commandParams.add("-Ddd.trace.enabled=true"); // explicitly enable tracer
+    commandParams.add("-Ddd.dynamic.instrumentation.probe.file=" + probeFilePath.toString());
+    // increase eval timeout for decoration evaluations
+    commandParams.add("-Ddd.dynamic.instrumentation.evaluation.timeout.ms=100");
+    return ProcessBuilderHelper.createProcessBuilder(
+        commandParams, logFilePath, getAppClass(), params);
+  }
+
+  @Test
+  @DisplayName("testProbeFile")
+  @DisabledIf(
+      value = "datadog.environment.JavaVirtualMachine#isJ9",
+      disabledReason = "Flaky on J9 JVMs")
+  void testProbeFile() throws Exception {
+    waitForInstrumentation(appUrl);
+    execute(appUrl, TRACED_METHOD_NAME);
+    AtomicBoolean snapshotReceived = new AtomicBoolean();
+    AtomicBoolean traceReceived = new AtomicBoolean();
+    registerSnapshotListener(
+        snapshot -> {
+          assertEquals(PROBE_ID.getId(), snapshot.getProbe().getId());
+          assertEquals(5, snapshot.getCaptures().getReturn().getArguments().size());
+          snapshotReceived.set(true);
+        });
+    registerTraceListener(
+        decodedTrace -> {
+          for (DecodedSpan span : decodedTrace.getSpans()) {
+            if (isDynamicSpan(span)) {
+              assertEquals("foobar", span.getMeta().get("client"));
+              assertEquals(PROBE_ID2.getId(), span.getMeta().get("_dd.di.client.probe_id"));
+              traceReceived.set(true);
+            }
+          }
+        });
+    processRequests(
+        () -> snapshotReceived.get() && traceReceived.get(),
+        () ->
+            String.format(
+                "Timeout! traceReceived=%s snapshotReceived=%s", traceReceived, snapshotReceived));
+    assertFalse(logHasErrors(logFilePath, it -> it.contains(" Error ")));
+  }
+
+  protected boolean isDynamicSpan(DecodedSpan span) {
+    return span.getName().equals("dd.dynamic.span")
+        && span.getResource().equals("ServerDebuggerTestApplication.tracedMethod");
+  }
+}

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanProbesIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/SpanProbesIntegrationTest.java
@@ -34,7 +34,7 @@ public class SpanProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest 
     setCurrentConfiguration(createSpanConfig(spanProbe));
     targetProcess = createProcessBuilder(logFilePath, METHOD_NAME, EXPECTED_UPLOADS).start();
 
-    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting();
+    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting(PROBE_ID);
     AtomicBoolean traceReceived = new AtomicBoolean();
     registerTraceListener(
         decodedTrace -> {
@@ -64,7 +64,7 @@ public class SpanProbesIntegrationTest extends SimpleAppDebuggerIntegrationTest 
             .build();
     setCurrentConfiguration(createSpanConfig(spanProbe));
     targetProcess = createProcessBuilder(logFilePath, METHOD_NAME, EXPECTED_UPLOADS).start();
-    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting();
+    AtomicBoolean statusResult = registerCheckReceivedInstalledEmitting(PROBE_ID);
     AtomicBoolean traceReceived = new AtomicBoolean();
     registerTraceListener(
         decodedTrace -> {

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/TracerDebuggerIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/TracerDebuggerIntegrationTest.java
@@ -54,9 +54,6 @@ public class TracerDebuggerIntegrationTest extends SpringBasedIntegrationTest {
               PROBE_ID.getId(), intakeRequest.getDebugger().getSnapshot().getProbe().getId());
           assertTrue(Pattern.matches("[0-9a-f]+", intakeRequest.getTraceId()));
           assertTrue(Pattern.matches("\\d+", intakeRequest.getSpanId()));
-          assertFalse(
-              logHasErrors(
-                  logFilePath, it -> it.contains("TypePool$Resolution$NoSuchTypeException")));
           if (processTagsEnabled) {
             assertNotNull(intakeRequest.getProcessTags());
             assertTrue(

--- a/dd-smoke-tests/debugger-integration-tests/src/test/resources/test_probe_file.json
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/resources/test_probe_file.json
@@ -5,10 +5,11 @@
     "language": "java",
     "type": "LOG_PROBE",
     "where": {
-      "typeName": "java.lang.Object",
-      "methodName": "toString",
-      "signature": "java.lang.String ()"
-    }
+      "typeName": "ServerDebuggerTestApplication",
+      "methodName": "tracedMethod",
+      "signature": ""
+    },
+    "captureSnapshot": true
   },
   {
     "id": "100c9a5c-45ad-49dc-818b-c570d31e11d1",
@@ -31,12 +32,12 @@
     "language": "java",
     "type": "METRIC_PROBE",
     "where": {
-      "typeName": "VetController",
-      "methodName": "showVetList"
+      "typeName": "ServerDebuggerTestApplication",
+      "methodName": "tracedMethod"
     },
     "tags": ["version:v123", "env:staging"],
     "kind": "COUNT",
-    "metricName": "datadog.debugger.showVetList.calls",
+    "metricName": "datadog.debugger.fullMethod.calls",
     "value": {
       "dsl": "42",
       "json": 42
@@ -48,13 +49,13 @@
     "type": "SPAN_DECORATION_PROBE",
     "language": "java",
     "where": {
-      "typeName": "com.datadog.debugger.demomonitor.DemoRequestScheduledJob",
-      "methodName": "fireRequests",
-      "signature": "()"
+      "typeName": "ServerDebuggerTestApplication",
+      "methodName": "tracedMethod",
+      "signature": ""
     },
     "tags": [],
     "evaluateAt": "EXIT",
-    "targetSpan": "ROOT",
+    "targetSpan": "ACTIVE",
     "decorations": [
       {
         "tags": [
@@ -63,13 +64,13 @@
             "value": {
               "segments": [
                 {
-                  "dsl": "client",
+                  "dsl": "argStr",
                   "json": {
-                    "ref": "client"
+                    "ref": "argStr"
                   }
                 }
               ],
-              "template": "{client}"
+              "template": "{argStr}"
             }
           }
         ]
@@ -82,24 +83,10 @@
     "type": "SPAN_PROBE",
     "language": "java",
     "where": {
-      "typeName": "MetadataClientUtils",
-      "methodName": "listTableWithContinuation"
+      "typeName": "ServerDebuggerTestApplication",
+      "methodName": "tracedMethod"
     },
     "tags": [],
     "evaluateAt": "EXIT"
-  },
-  {
-    "id": "70b55d06-f9fa-403b-a329-4f2f960aed02",
-    "version": 0,
-    "type": "TRIGGER_PROBE",
-    "language": "java",
-    "where": {
-      "typeName": "MetadataClientUtils",
-      "methodName": "listTableWithContinuation"
-    },
-    "tags": [],
-    "evaluateAt": "EXIT",
-    "sessionId": "session",
-    "sampling": { "snapshotsPerSecond": 100 }
   }
 ]


### PR DESCRIPTION
# What Does This Do
When loading probes from file, initSamplers method is not called for deserialized probes. we centralize probe deserialization in ProbeDefinitionDeserializer class and add smoke test for this.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [DEBUG-5873]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-5873]: https://datadoghq.atlassian.net/browse/DEBUG-5873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ