### PR TITLE
Tag @Async @Scheduled spring-scheduling spans as errored on exception

### DIFF
--- a/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
+++ b/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpannedMethodInvocation.java
@@ -50,8 +50,15 @@ public class SpannedMethodInvocation implements MethodInvocation {
 
   private Object invokeWithSpan(CharSequence spanName) throws Throwable {
     AgentSpan span = startSpan("spring-scheduling", spanName);
+    DECORATE.afterStart(span);
+    DECORATE.measureIfEnabled(span);
     try (ContextScope scope = activateSpan(span)) {
-      return delegate.proceed();
+      try {
+        return delegate.proceed();
+      } catch (Throwable throwable) {
+        DECORATE.onError(span, throwable);
+        throw throwable;
+      }
     } finally {
       span.finish();
     }

--- a/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingDecorator.java
+++ b/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingDecorator.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.springscheduling;
 
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
@@ -8,6 +9,8 @@ import org.springframework.scheduling.support.ScheduledMethodRunnable;
 public class SpringSchedulingDecorator extends BaseDecorator {
   public static final CharSequence SCHEDULED_CALL = UTF8BytesString.create("scheduled.call");
   public static final SpringSchedulingDecorator DECORATE = new SpringSchedulingDecorator();
+
+  private static final boolean MEASURED = Config.get().isSpringSchedulingMeasuredEnabled();
 
   private SpringSchedulingDecorator() {}
 
@@ -24,6 +27,12 @@ public class SpringSchedulingDecorator extends BaseDecorator {
   @Override
   protected CharSequence component() {
     return "spring-scheduling";
+  }
+
+  public void measureIfEnabled(final AgentSpan span) {
+    if (MEASURED) {
+      span.setMeasured(true);
+    }
   }
 
   public void onRun(final AgentSpan span, final Runnable runnable) {

--- a/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingRunnableWrapper.java
+++ b/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/src/main/java/datadog/trace/instrumentation/springscheduling/SpringSchedulingRunnableWrapper.java
@@ -59,6 +59,7 @@ public class SpringSchedulingRunnableWrapper implements Runnable {
             ? startSpan("spring-scheduling", SCHEDULED_CALL)
             : startSpan("spring-scheduling", SCHEDULED_CALL, null);
     DECORATE.afterStart(span);
+    DECORATE.measureIfEnabled(span);
 
     try (final ContextScope scope = activateSpan(span)) {
       DECORATE.onRun(span, runnable);

--- a/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/src/test/groovy/SpringAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/src/test/groovy/SpringAsyncTest.groovy
@@ -1,9 +1,56 @@
 import datadog.trace.agent.test.InstrumentationSpecification
+import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
 class SpringAsyncTest extends InstrumentationSpecification {
+
+  boolean asyncMeasured() {
+    false
+  }
+
+  @Override
+  protected void configurePreAgent() {
+    super.configurePreAgent()
+    if (asyncMeasured()) {
+      injectSysConfig("spring-scheduling.measured.enabled", "true")
+    }
+  }
+
+  def "exception in @async method tags span as errored"() {
+    setup:
+    def context = new AnnotationConfigApplicationContext(AsyncTaskConfig)
+    AsyncTask asyncTask = context.getBean(AsyncTask)
+
+    when:
+    Throwable thrown = null
+    try {
+      asyncTask.asyncThrow().join()
+    } catch (Throwable t) {
+      thrown = t
+    }
+
+    then:
+    thrown != null
+    assertTraces(1) {
+      trace(1) {
+        span {
+          resourceName "AsyncTask.asyncThrow"
+          errored true
+          measured asyncMeasured()
+          tags {
+            "$Tags.COMPONENT" "spring-scheduling"
+            errorTags(RuntimeException, "Datadog async repro")
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    cleanup:
+    context.close()
+  }
 
   def "context propagated through @async annotation"() {
     setup:
@@ -52,5 +99,12 @@ class SpringAsyncTest extends InstrumentationSpecification {
 
     where:
     hasParent << [true, false]
+  }
+}
+
+class SpringAsyncMeasuredForkedTest extends SpringAsyncTest {
+  @Override
+  boolean asyncMeasured() {
+    true
   }
 }

--- a/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/src/test/java/AsyncTask.java
+++ b/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/src/test/java/AsyncTask.java
@@ -10,6 +10,11 @@ public class AsyncTask {
     return CompletableFuture.completedFuture(getInt());
   }
 
+  @Async
+  public CompletableFuture<Void> asyncThrow() {
+    throw new RuntimeException("Datadog async repro");
+  }
+
   @Trace
   public int getInt() {
     return ThreadLocalRandom.current().nextInt();

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -157,6 +157,9 @@ public final class TraceInstrumentationConfig {
   public static final String SPRING_DATA_REPOSITORY_INTERFACE_RESOURCE_NAME =
       "spring-data.repository.interface.resource-name";
 
+  public static final String SPRING_SCHEDULING_MEASURED_ENABLED =
+      "spring-scheduling.measured.enabled";
+
   public static final String INSTRUMENTATION_CONFIG_ID = "instrumentation_config_id";
 
   public static final String RESOLVER_CACHE_CONFIG = "resolver.cache.config";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -626,6 +626,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ROOT_C
 import static datadog.trace.api.config.TraceInstrumentationConfig.SPARK_APP_NAME_AS_SERVICE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SPARK_TASK_HISTOGRAM_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SPRING_DATA_REPOSITORY_INTERFACE_RESOURCE_NAME;
+import static datadog.trace.api.config.TraceInstrumentationConfig.SPRING_SCHEDULING_MEASURED_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SQS_BODY_PROPAGATION_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_128_BIT_TRACEID_LOGGING_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_HTTP_CLIENT_TAG_QUERY_STRING;
@@ -1292,6 +1293,8 @@ public class Config {
 
   private final boolean hystrixTagsEnabled;
   private final boolean hystrixMeasuredEnabled;
+
+  private final boolean springSchedulingMeasuredEnabled;
 
   private final boolean resilience4jMeasuredEnabled;
   private final boolean resilience4jTagMetricsEnabled;
@@ -3051,6 +3054,9 @@ public class Config {
 
     hystrixTagsEnabled = configProvider.getBoolean(HYSTRIX_TAGS_ENABLED, false);
     hystrixMeasuredEnabled = configProvider.getBoolean(HYSTRIX_MEASURED_ENABLED, false);
+
+    springSchedulingMeasuredEnabled =
+        configProvider.getBoolean(SPRING_SCHEDULING_MEASURED_ENABLED, false);
 
     resilience4jMeasuredEnabled = configProvider.getBoolean(RESILIENCE4J_MEASURED_ENABLED, false);
     resilience4jTagMetricsEnabled =
@@ -4973,6 +4979,10 @@ public class Config {
     return resilience4jMeasuredEnabled;
   }
 
+  public boolean isSpringSchedulingMeasuredEnabled() {
+    return springSchedulingMeasuredEnabled;
+  }
+
   public boolean isResilience4jTagMetricsEnabled() {
     return resilience4jTagMetricsEnabled;
   }
@@ -6666,6 +6676,8 @@ public class Config {
         + hystrixTagsEnabled
         + ", hystrixMeasuredEnabled="
         + hystrixMeasuredEnabled
+        + ", springSchedulingMeasuredEnabled="
+        + springSchedulingMeasuredEnabled
         + ", resilience4jMeasuredEnable="
         + resilience4jMeasuredEnabled
         + ", resilience4jTagMetricsEnabled="

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -3897,6 +3897,14 @@
         "aliases": []
       }
     ],
+    "DD_SPRING_SCHEDULING_MEASURED_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "false",
+        "aliases": []
+      }
+    ],
     "DD_STACK_TRACE_LENGTH_LIMIT": [
       {
         "version": "A",


### PR DESCRIPTION
# What Does This Do

Marks the span of a Spring `@Async` + `@Scheduled` method as **errored** when the method throws. Before, the exception was lost and the trace looked successful.

Fix: add a `catch` in `SpannedMethodInvocation` that calls `DECORATE.onError(...)` and rethrows - the same handling the synchronous path already does. It also calls `DECORATE.afterStart(...)` so the async span carries the `spring-scheduling` component/integration tags, like the sync span.

# Motivation

With `@Async` the method runs on a different thread. The parent span (`scheduled.call`) closes as soon as the task is submitted - **before the body runs** — and the exception is thrown later on the async thread, in a child span that had no error handling. So it closed clean

<img width="1210" height="369" alt="Untitled-2024-09-10-1730b" src="https://github.com/user-attachments/assets/97272db0-a31a-4801-b224-e629004419f3" />

# Additional Notes

Tests: `SpringAsyncTest` (default) + `SpringAsyncMeasuredForkedTest` (flag on)

Optional: showing these errors on the Service/Resource pages

**Optional - surfacing these errors on the Service/Resource pages.**
The errored span is a child, not top-level, so by default it doesn't feed APM trace-metrics (same as any non-top-level span). A new opt-in flag `DD_SPRING_SCHEDULING_MEASURED_ENABLED` (default **off**) marks spring-scheduling spans `measured` so their errors show up on the stats pages, at the cost of a new APM operation per `@Async` method. It's modeled on the existing `hystrix.measured.enabled` / `resilience4j.measured.enabled` flags.

Out of scope: methods that *return* an already-failing `Future` (instead of throwing) are still not tagged.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
