### PR TITLE
Increase agent jar size to 33.5 MiB

### DIFF
--- a/metadata/agent-jar-checks.properties
+++ b/metadata/agent-jar-checks.properties
@@ -1,7 +1,7 @@
 # Agent jar structural invariants — edit intentionally, commit with the change that justified it.
 
-# Max agent jar size in bytes. Raise only when the size growth is intentional (~33.02 MiB).
-jar.size.budget = 34619392
+# Max agent jar size in bytes. Raise only when the size growth is intentional (~33.5 MiB).
+jar.size.budget = 35127296
 
 # Minimum combined class + classdata count in the assembled agent jar.
 # Set to ~98% of the actual count at the time of the last intentional change.


### PR DESCRIPTION
# What Does This Do

Increase the agent jar size limit to ~33.5 MiB

# Motivation

Due to recent changes such as profiling upgrades, instrumentation additions, replacing JCTools queues, etc. our agent jar size has increased. Keep the increase relatively low so that we catch any large unexpected jar additions

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
