### PR TITLE
Avoid null collection on decoded spans

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1115,7 +1115,7 @@ test_debugger_arm64:
     - !reference [.test_job_arm64, script]
 
 test_smoke:
-  extends: .test_job
+  extends: .test_job_with_test_agent
   # needs:parallel:matrix limits this job to a specific build_tests combination.
   # Keep matrix vars exact and in build_tests declaration order:
   # https://docs.gitlab.com/ci/yaml/#needsparallelmatrix
@@ -1135,7 +1135,7 @@ test_smoke:
     matrix: *test_matrix_8
 
 test_smoke_arm64:
-  extends: .test_job_arm64
+  extends: .test_job_arm64_with_test_agent
   variables:
     <<: *tier_l_variables
     GRADLE_TARGET: "stageMainDist :smokeTest"

--- a/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
+++ b/communication/src/main/java/datadog/communication/ddagent/SharedCommunicationObjects.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
 public class SharedCommunicationObjects {
   private static final Logger log = LoggerFactory.getLogger(SharedCommunicationObjects.class);
 
+  private static final String X_DATADOG_TEST_SESSION_TOKEN = "X-Datadog-Test-Session-Token";
+
   private final List<Runnable> pausedComponents = new ArrayList<>();
   private volatile boolean paused;
 
@@ -90,7 +92,25 @@ public class SharedCommunicationObjects {
       agentHttpClient =
           OkHttpUtils.buildHttpClient(
               OkHttpUtils.isPlainHttp(agentUrl), unixDomainSocket, namedPipe, httpClientTimeout);
+      String testSessionToken = config.getTestAgentSessionToken();
+      if (testSessionToken != null) {
+        agentHttpClient = injectTestAgentSessionHeaderInterceptor(testSessionToken);
+      }
     }
+  }
+
+  private OkHttpClient injectTestAgentSessionHeaderInterceptor(String testSessionToken) {
+    return agentHttpClient
+        .newBuilder()
+        .addInterceptor(
+            chain ->
+                chain.proceed(
+                    chain
+                        .request()
+                        .newBuilder()
+                        .header(X_DATADOG_TEST_SESSION_TOKEN, testSessionToken)
+                        .build()))
+        .build();
   }
 
   /** Registers a callback to be called when remote communications resume. */

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/ExtendedDataCollectionSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/ExtendedDataCollectionSmokeTest.groovy
@@ -303,7 +303,7 @@ class ExtendedDataCollectionSmokeTest extends AbstractAppSecServerSmokeTest {
     }
     assert trigger != null, 'test trigger not found'
 
-    rootSpan.span.metaStruct != null
+    !rootSpan.span.metaStruct.isEmpty()
     def requestBody = rootSpan.span.metaStruct.get('http.request.body')
     assert requestBody != null, 'request body is not set'
     !rootSpan.meta.containsKey('_dd.appsec.request_body_size.exceeded')
@@ -343,7 +343,7 @@ class ExtendedDataCollectionSmokeTest extends AbstractAppSecServerSmokeTest {
     }
     assert trigger != null, 'test trigger not found'
 
-    rootSpan.span.metaStruct != null
+    !rootSpan.span.metaStruct.isEmpty()
     def requestBody = rootSpan.span.metaStruct.get('http.request.body')
     assert requestBody != null, 'request body is not set'
     !rootSpan.meta.containsKey('_dd.appsec.request_body_size.exceeded')
@@ -383,7 +383,7 @@ class ExtendedDataCollectionSmokeTest extends AbstractAppSecServerSmokeTest {
     }
     assert trigger != null, 'test trigger not found'
 
-    rootSpan.span.metaStruct != null
+    !rootSpan.span.metaStruct.isEmpty()
     def requestBody = rootSpan.span.metaStruct.get('http.request.body')
     assert requestBody != null, 'request body is not set'
     rootSpan.meta.containsKey('_dd.appsec.request_body_size.exceeded')
@@ -421,7 +421,7 @@ class ExtendedDataCollectionSmokeTest extends AbstractAppSecServerSmokeTest {
     }
     assert trigger == null, 'test trigger found'
 
-    rootSpan.span.metaStruct == null
+    rootSpan.span.metaStruct.isEmpty()
   }
 
   void 'test request body collection if WAF event with default-config'(){
@@ -457,7 +457,7 @@ class ExtendedDataCollectionSmokeTest extends AbstractAppSecServerSmokeTest {
     }
     assert trigger != null, 'test trigger not found'
 
-    rootSpan.span.metaStruct != null
+    !rootSpan.span.metaStruct.isEmpty()
     def requestBody = rootSpan.span.metaStruct.get('http.request.body')
     assert requestBody != null, 'request body is not set'
     !rootSpan.meta.containsKey('_dd.appsec.request_body_size.exceeded')

--- a/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
+++ b/dd-smoke-tests/appsec/springboot/src/test/groovy/datadog/smoketest/appsec/SpringBootSmokeTest.groovy
@@ -699,7 +699,7 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
       }
     }
     assert trigger != null, 'test trigger not found'
-    rootSpan.span.metaStruct != null
+    !rootSpan.span.metaStruct.isEmpty()
     def stack = rootSpan.span.metaStruct.get('_dd.stack')
     assert stack != null, 'stack is not set'
     def exploit = stack.get('exploit')
@@ -774,7 +774,7 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
       }
     }
     assert trigger != null, 'test trigger not found'
-    rootSpan.span.metaStruct == null
+    rootSpan.span.metaStruct.isEmpty()
 
     where:
     variant               | _
@@ -814,7 +814,7 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
       }
     }
     assert trigger != null, 'test trigger not found'
-    rootSpan.span.metaStruct == null
+    rootSpan.span.metaStruct.isEmpty()
 
     where:
     variant | _
@@ -853,7 +853,7 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
       }
     }
     assert trigger != null, 'test trigger not found'
-    rootSpan.span.metaStruct == null
+    rootSpan.span.metaStruct.isEmpty()
   }
 
   def findFirstMatchingSpan(String resource) {
@@ -939,7 +939,7 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
       }
     }
     assert trigger != null, 'test trigger not found'
-    rootSpan.span.metaStruct == null
+    rootSpan.span.metaStruct.isEmpty()
 
     where:
     endpoint                    | cmd                              | params
@@ -990,7 +990,7 @@ class SpringBootSmokeTest extends AbstractAppSecServerSmokeTest {
       }
     }
     assert trigger != null, 'test trigger not found'
-    rootSpan.span.metaStruct == null
+    rootSpan.span.metaStruct.isEmpty()
 
     where:
     endpoint           | cmd                                  | params

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -32,6 +32,7 @@ public final class TracerConfig {
   public static final String PROXY_NO_PROXY = "proxy.no_proxy";
   public static final String TRACE_AGENT_PATH = "trace.agent.path";
   public static final String TRACE_AGENT_ARGS = "trace.agent.args";
+  public static final String TEST_AGENT_SESSION_TOKEN = "test.agent.session.token";
   public static final String PRIORITY_SAMPLING = "priority.sampling";
   public static final String PRIORITY_SAMPLING_FORCE = "priority.sampling.force";
   @Deprecated public static final String TRACE_RESOLVER_ENABLED = "trace.resolver.enabled";

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -674,6 +674,7 @@ import static datadog.trace.api.config.TracerConfig.SPAN_SAMPLING_RULES;
 import static datadog.trace.api.config.TracerConfig.SPAN_SAMPLING_RULES_FILE;
 import static datadog.trace.api.config.TracerConfig.SPAN_TAGS;
 import static datadog.trace.api.config.TracerConfig.SPLIT_BY_TAGS;
+import static datadog.trace.api.config.TracerConfig.TEST_AGENT_SESSION_TOKEN;
 import static datadog.trace.api.config.TracerConfig.TRACE_128_BIT_TRACEID_GENERATION_ENABLED;
 import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_ARGS;
 import static datadog.trace.api.config.TracerConfig.TRACE_AGENT_PATH;
@@ -1389,6 +1390,7 @@ public class Config {
   private final boolean azureFunctions;
   private final boolean awsServerless;
   private final String traceAgentPath;
+  private final String testAgentSessionToken;
   private final List<String> traceAgentArgs;
   private final String dogStatsDPath;
   private final List<String> dogStatsDArgs;
@@ -3199,6 +3201,7 @@ public class Config {
 
     azureAppServices = configProvider.getBoolean(AZURE_APP_SERVICES, false);
     traceAgentPath = configProvider.getString(TRACE_AGENT_PATH);
+    testAgentSessionToken = configProvider.getString(TEST_AGENT_SESSION_TOKEN);
     String traceAgentArgsString = configProvider.getString(TRACE_AGENT_ARGS);
     if (traceAgentArgsString == null) {
       traceAgentArgs = Collections.emptyList();
@@ -5184,6 +5187,10 @@ public class Config {
 
   public String getTraceAgentPath() {
     return traceAgentPath;
+  }
+
+  public String getTestAgentSessionToken() {
+    return testAgentSessionToken;
   }
 
   public List<String> getTraceAgentArgs() {

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -4121,6 +4121,14 @@
         "aliases": []
       }
     ],
+    "DD_TEST_AGENT_SESSION_TOKEN": [
+      {
+        "version": "A",
+        "type": "string",
+        "default": null,
+        "aliases": []
+      }
+    ],
     "DD_TEST_FAILED_TEST_REPLAY_ENABLED": [
       {
         "version": "A",

--- a/utils/config-utils/src/main/java/datadog/trace/api/ConfigSetting.java
+++ b/utils/config-utils/src/main/java/datadog/trace/api/ConfigSetting.java
@@ -25,7 +25,13 @@ public final class ConfigSetting {
 
   private static final Set<String> CONFIG_FILTER_LIST =
       new HashSet<>(
-          Arrays.asList("DD_API_KEY", "dd.api-key", "dd.profiling.api-key", "dd.profiling.apikey"));
+          Arrays.asList(
+              "DD_API_KEY",
+              "dd.api-key",
+              "dd.profiling.api-key",
+              "dd.profiling.apikey",
+              "test.agent.session.token",
+              "DD_TEST_AGENT_SESSION_TOKEN"));
 
   public static ConfigSetting of(String key, Object value, ConfigOrigin origin) {
     return new ConfigSetting(key, value, origin, ABSENT_SEQ_ID, null);

--- a/utils/config-utils/src/test/java/datadog/trace/api/ConfigSettingTest.java
+++ b/utils/config-utils/src/test/java/datadog/trace/api/ConfigSettingTest.java
@@ -44,12 +44,14 @@ public class ConfigSettingTest {
   }
 
   @TableTest({
-    "scenario             | key                  | value     | filteredValue",
-    "DD_API_KEY           | DD_API_KEY           | somevalue | <hidden>     ",
-    "dd.api-key           | dd.api-key           | somevalue | <hidden>     ",
-    "dd.profiling.api-key | dd.profiling.api-key | somevalue | <hidden>     ",
-    "dd.profiling.apikey  | dd.profiling.apikey  | somevalue | <hidden>     ",
-    "some.other.key       | some.other.key       | somevalue | somevalue    "
+    "scenario             | key                         | value     | filteredValue",
+    "DD_API_KEY           | DD_API_KEY                  | somevalue | <hidden>     ",
+    "dd.api-key           | dd.api-key                  | somevalue | <hidden>     ",
+    "dd.profiling.api-key | dd.profiling.api-key        | somevalue | <hidden>     ",
+    "dd.profiling.apikey  | dd.profiling.apikey         | somevalue | <hidden>     ",
+    "session token prop   | test.agent.session.token    | somevalue | <hidden>     ",
+    "session token env    | DD_TEST_AGENT_SESSION_TOKEN | somevalue | <hidden>     ",
+    "some.other.key       | some.other.key              | somevalue | somevalue    "
   })
   void filtersKeyValues(String key, String value, String filteredValue) {
     assertEquals(filteredValue, ConfigSetting.of(key, value, ConfigOrigin.DEFAULT).stringValue());

--- a/utils/test-agent-utils/decoder/src/main/java/datadog/trace/test/agent/decoder/v04/raw/SpanV04.java
+++ b/utils/test-agent-utils/decoder/src/main/java/datadog/trace/test/agent/decoder/v04/raw/SpanV04.java
@@ -1,9 +1,11 @@
 package datadog.trace.test.agent.decoder.v04.raw;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
+
 import datadog.trace.test.agent.decoder.DecodedSpan;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -265,9 +267,9 @@ public class SpanV04 implements DecodedSpan {
     this.start = start;
     this.duration = duration;
     this.error = error;
-    this.meta = Collections.unmodifiableMap(meta);
-    this.metaStruct = metaStruct == null ? null : Collections.unmodifiableMap(metaStruct);
-    this.metrics = Collections.unmodifiableMap(metrics);
+    this.meta = unmodifiableMap(meta);
+    this.metaStruct = metaStruct == null ? emptyMap() : unmodifiableMap(metaStruct);
+    this.metrics = unmodifiableMap(metrics);
     this.type = type;
   }
 

--- a/utils/test-agent-utils/decoder/src/main/java/datadog/trace/test/agent/decoder/v05/raw/SpanV05.java
+++ b/utils/test-agent-utils/decoder/src/main/java/datadog/trace/test/agent/decoder/v05/raw/SpanV05.java
@@ -1,5 +1,7 @@
 package datadog.trace.test.agent.decoder.v05.raw;
 
+import static java.util.Collections.emptyMap;
+
 import datadog.trace.test.agent.decoder.DecodedSpan;
 import java.io.IOException;
 import java.util.Collections;
@@ -190,7 +192,7 @@ public class SpanV05 implements DecodedSpan {
 
   public Map<String, Object> getMetaStruct() {
     // XXX: meta_struct is not supported in v0.5.
-    return null;
+    return emptyMap();
   }
 
   public Map<String, Number> getMetrics() {

--- a/utils/test-agent-utils/decoder/src/main/java/datadog/trace/test/agent/decoder/v1/raw/SpanV1.java
+++ b/utils/test-agent-utils/decoder/src/main/java/datadog/trace/test/agent/decoder/v1/raw/SpanV1.java
@@ -1,9 +1,11 @@
 package datadog.trace.test.agent.decoder.v1.raw;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
+
 import datadog.trace.test.agent.decoder.DecodedSpan;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -492,9 +494,9 @@ public class SpanV1 implements DecodedSpan {
     this.start = start;
     this.duration = duration;
     this.error = error;
-    this.meta = Collections.unmodifiableMap(meta);
-    this.metaStruct = metaStruct == null ? null : Collections.unmodifiableMap(metaStruct);
-    this.metrics = Collections.unmodifiableMap(metrics);
+    this.meta = unmodifiableMap(meta);
+    this.metaStruct = metaStruct == null ? emptyMap() : unmodifiableMap(metaStruct);
+    this.metrics = unmodifiableMap(metrics);
     this.type = type;
   }
 


### PR DESCRIPTION
# What Does This Do

This PR updates the decoded spans to avoid null collections.

# Motivation

This changes will help asserting the trace / span structure and values with the upcoming rules and matchers.

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [APMLP-1247]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMLP-1247]: https://datadoghq.atlassian.net/browse/APMLP-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ