### PR TITLE
Remove check for JAVA_TOOLS_OPTIONS in verifyAgentJarIntegrations

### DIFF
--- a/dd-java-agent/build.gradle
+++ b/dd-java-agent/build.gradle
@@ -622,6 +622,10 @@ tasks.register('verifyAgentJarIntegrations', JavaExec) {
   classpath = objects.fileCollection().from(jarProvider)
   args = ['--list-integrations']
 
+  // Listing integrations only inspects classes and metadata in the assembled agent jar, so it does
+  // not need inherited JAVA_TOOL_OPTIONS.
+  environment.remove('JAVA_TOOL_OPTIONS')
+
   // Capture both stdout and stderr: InstrumenterIndex.buildModule() logs ERROR and returns null when a module
   // fails to load, while the process exits with status 0.
   def capturedOutput = new ByteArrayOutputStream()


### PR DESCRIPTION
# What Does This Do

Remove check for `JAVA_TOOLS_OPTIONS` in `verifyAgentJarIntegrations` Gradle task.

# Motivation

Recent Fabric Egress Gateway changes in CI injected proxy settings through `JAVA_TOOLS_OPTIONS` which the JVM echoes to `stderr`. Any info in `stderr` causes the verification task to fail, so this led to a broken CI. The verification task intends to confirm class and metadata info, not tool options, so we can remove the `JAVA_TOOLS_OPTIONS` check entirely.

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
