### PR TITLE
Remove vestigial TagMap.isOptimized

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -923,10 +923,7 @@ public class DDSpanContext
    * If the tag may be intercepted, then boxing is also used.
    */
   private boolean precheckIntercept(String tag) {
-    // Usually only a single instanceof TagMap will be loaded,
-    // so isOptimized is turned into a direct call and then inlines to a constant
-    // Since isOptimized just returns a constant - doesn't require synchronization
-    return !unsafeTags.isOptimized() || tagInterceptor.needsIntercept(tag);
+    return tagInterceptor.needsIntercept(tag);
   }
 
   /*

--- a/internal-api/src/main/java/datadog/trace/api/TagMap.java
+++ b/internal-api/src/main/java/datadog/trace/api/TagMap.java
@@ -1009,10 +1009,6 @@ public final class TagMap implements Map<String, Object>, Iterable<TagMap.EntryR
     this.frozen = true;
   }
 
-  public boolean isOptimized() {
-    return true;
-  }
-
   @Override
   public int size() {
     return this.size;

--- a/internal-api/src/test/java/datadog/trace/api/TagMapTest.java
+++ b/internal-api/src/test/java/datadog/trace/api/TagMapTest.java
@@ -109,17 +109,13 @@ public class TagMapTest {
     map.set(BOOL, first);
 
     TagMap.Entry firstEntry = map.getEntry(BOOL);
-    if (map.isOptimized()) {
-      assertEquals(TagMap.Entry.BOOLEAN, firstEntry.rawType);
-    }
+    assertEquals(TagMap.Entry.BOOLEAN, firstEntry.rawType);
 
     assertEquals(first, firstEntry.booleanValue());
     assertEquals(first, map.getBoolean(BOOL));
 
     TagMap.Entry priorEntry = map.getAndSet(BOOL, second);
-    if (map.isOptimized()) {
-      assertSame(priorEntry, firstEntry);
-    }
+    assertSame(priorEntry, firstEntry);
     assertEquals(first, priorEntry.booleanValue());
 
     TagMap.Entry newEntry = map.getEntry(BOOL);
@@ -250,17 +246,13 @@ public class TagMapTest {
     map.set(INT, first);
 
     TagMap.Entry firstEntry = map.getEntry("int");
-    if (map.isOptimized()) {
-      assertEquals(TagMap.Entry.INT, firstEntry.rawType);
-    }
+    assertEquals(TagMap.Entry.INT, firstEntry.rawType);
 
     assertEquals(first, firstEntry.intValue());
     assertEquals(first, map.getInt("int"));
 
     TagMap.Entry priorEntry = map.getAndSet("int", second);
-    if (map.isOptimized()) {
-      assertSame(priorEntry, firstEntry);
-    }
+    assertSame(priorEntry, firstEntry);
     assertEquals(first, priorEntry.intValue());
 
     TagMap.Entry newEntry = map.getEntry("int");
@@ -284,17 +276,13 @@ public class TagMapTest {
     map.set(LONG, first);
 
     TagMap.Entry firstEntry = map.getEntry("long");
-    if (map.isOptimized()) {
-      assertEquals(TagMap.Entry.LONG, firstEntry.rawType);
-    }
+    assertEquals(TagMap.Entry.LONG, firstEntry.rawType);
 
     assertEquals(first, firstEntry.longValue());
     assertEquals(first, map.getLong("long"));
 
     TagMap.Entry priorEntry = map.getAndSet("long", second);
-    if (map.isOptimized()) {
-      assertSame(priorEntry, firstEntry);
-    }
+    assertSame(priorEntry, firstEntry);
     assertEquals(first, priorEntry.longValue());
 
     TagMap.Entry newEntry = map.getEntry("long");
@@ -319,17 +307,13 @@ public class TagMapTest {
     map.set(FLOAT, first);
 
     TagMap.Entry firstEntry = map.getEntry(FLOAT);
-    if (map.isOptimized()) {
-      assertEquals(TagMap.Entry.FLOAT, firstEntry.rawType);
-    }
+    assertEquals(TagMap.Entry.FLOAT, firstEntry.rawType);
 
     assertEquals(first, firstEntry.floatValue());
     assertEquals(first, map.getFloat(FLOAT));
 
     TagMap.Entry priorEntry = map.getAndSet(FLOAT, second);
-    if (map.isOptimized()) {
-      assertSame(priorEntry, firstEntry);
-    }
+    assertSame(priorEntry, firstEntry);
     assertEquals(first, priorEntry.floatValue());
 
     TagMap.Entry newEntry = map.getEntry(FLOAT);
@@ -354,17 +338,13 @@ public class TagMapTest {
     map.set(DOUBLE, Math.PI);
 
     TagMap.Entry firstEntry = map.getEntry(DOUBLE);
-    if (map.isOptimized()) {
-      assertEquals(TagMap.Entry.DOUBLE, firstEntry.rawType);
-    }
+    assertEquals(TagMap.Entry.DOUBLE, firstEntry.rawType);
 
     assertEquals(first, firstEntry.doubleValue());
     assertEquals(first, map.getDouble(DOUBLE));
 
     TagMap.Entry priorEntry = map.getAndSet(DOUBLE, second);
-    if (map.isOptimized()) {
-      assertSame(priorEntry, firstEntry);
-    }
+    assertSame(priorEntry, firstEntry);
     assertEquals(first, priorEntry.doubleValue());
 
     TagMap.Entry newEntry = map.getEntry(DOUBLE);


### PR DESCRIPTION
## What Does This Do?

Removes `TagMap.isOptimized()`, which was dead surface. `TagMap` is now a single `final` class whose `isOptimized()` unconditionally returned `true`, so every use was a no-op:

- **Production** — `DDSpanContext.precheckIntercept` had `return !unsafeTags.isOptimized() || tagInterceptor.needsIntercept(tag);`. With `isOptimized()` always `true`, the `!unsafeTags.isOptimized() ||` clause is always `false`, so it collapses to `return tagInterceptor.needsIntercept(tag);`. The stale inlining comment above it (which described the old multi-impl `instanceof`/constant-fold behavior) is dropped.
- **Tests** — the 10 `if (map.isOptimized())` guards in `TagMapTest` were always taken (all `TagMapScenario` values are `OPTIMIZED_*`), so they're unwrapped to the bare assertions.

## Motivation

Leftover from when `TagMap` had a legacy + optimized implementation behind an interface. Since the fold to a single class, the method only added dead branches and a misleading comment.

## Additional Notes

None — no behavioral change. `:internal-api` + `:dd-trace-core` compile clean and `TagMapTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)