### PR TITLE
Replace ThreadPoolExecutor context-store with ClassValue cache

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFil
 import datadog.context.ContextScope;
 import datadog.trace.api.GenericClassValue;
 import datadog.trace.api.InstrumenterConfig;
+import datadog.trace.api.Platform;
 import datadog.trace.bootstrap.ContextStore;
 import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -51,25 +52,15 @@ public final class TPEHelper {
     return useWrapping || task instanceof Wrapper || (task != null && WRAP.get(task.getClass()));
   }
 
-  public static void setPropagate(
-      ContextStore<ThreadPoolExecutor, Boolean> contextStore, ThreadPoolExecutor executor) {
-    if (executor == null || contextStore == null || contextStore.get(executor) != null) {
-      return;
-    }
-    String executorType = executor.getClass().getName();
-    if (excludedClasses.contains(executorType)) {
-      contextStore.put(executor, Boolean.FALSE);
-    } else {
-      contextStore.put(executor, Boolean.TRUE);
-    }
-  }
+  private static final ClassValue<Boolean> PROPAGATE =
+      GenericClassValue.of(input -> !excludedClasses.contains(input.getName()));
 
-  public static boolean shouldPropagate(
-      ContextStore<ThreadPoolExecutor, Boolean> contextStore, ThreadPoolExecutor executor) {
-    if (executor == null || contextStore == null) {
-      return false;
-    }
-    return Boolean.TRUE.equals(contextStore.get(executor));
+  public static boolean shouldPropagate(ThreadPoolExecutor executor) {
+    // avoid tracking threads when building native images as it confuses the scanner
+    // (we still want instrumentation applied, so tracking works in the built image)
+    return !Platform.isNativeImageBuilder()
+        && executor != null
+        && PROPAGATE.get(executor.getClass());
   }
 
   public static void capture(ContextStore<Runnable, State> contextStore, Runnable task) {

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/executor/ExecutorModule.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/executor/ExecutorModule.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.java.concurrent.executor;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.EXECUTOR;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static datadog.trace.instrumentation.java.concurrent.ConcurrentInstrumentationNames.EXECUTOR_INSTRUMENTATION_NAME;
-import static datadog.trace.instrumentation.java.concurrent.executor.ThreadPoolExecutorInstrumentation.TPE;
 import static java.util.Collections.singleton;
 
 import com.google.auto.service.AutoService;
@@ -41,7 +40,6 @@ public class ExecutorModule extends InstrumenterModule.ContextTracking
     contextStore.put("java.util.concurrent.RunnableFuture", State.class.getName());
     // TODO get rid of this
     contextStore.put("java.lang.Runnable", State.class.getName());
-    contextStore.put(TPE, Boolean.class.getName());
     return Collections.unmodifiableMap(contextStore);
   }
 

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/executor/ThreadPoolExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/executor/ThreadPoolExecutorInstrumentation.java
@@ -7,7 +7,6 @@ import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFil
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.ExcludeType.RUNNABLE_FUTURE;
 import static datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter.exclude;
-import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -16,7 +15,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import datadog.context.ContextScope;
 import datadog.trace.agent.tooling.Instrumenter;
-import datadog.trace.api.Platform;
 import datadog.trace.bootstrap.InstrumentationContext;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.QueueTimerHelper;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
@@ -57,7 +55,6 @@ public final class ThreadPoolExecutorInstrumentation
     implements Instrumenter.ForBootstrap,
         Instrumenter.ForTypeHierarchy,
         Instrumenter.HasMethodAdvice {
-  static final String TPE = "java.util.concurrent.ThreadPoolExecutor";
 
   // executors which do their own wrapping before calling super,
   // leading to double wrapping, once at the child level and once
@@ -75,12 +72,11 @@ public final class ThreadPoolExecutorInstrumentation
   @Override
   public ElementMatcher<TypeDescription> hierarchyMatcher() {
     return not(named("java.util.concurrent.ScheduledThreadPoolExecutor"))
-        .and(extendsClass(named(TPE)));
+        .and(extendsClass(named("java.util.concurrent.ThreadPoolExecutor")));
   }
 
   @Override
   public void methodAdvice(MethodTransformer transformer) {
-    transformer.applyAdvice(isConstructor(), getClass().getName() + "$Init");
     transformer.applyAdvice(
         named("execute")
             .and(isMethod())
@@ -102,25 +98,12 @@ public final class ThreadPoolExecutorInstrumentation
         getClass().getName() + "$Remove");
   }
 
-  public static final class Init {
-    @Advice.OnMethodExit(suppress = Throwable.class)
-    public static void decideWrapping(@Advice.This final ThreadPoolExecutor zis) {
-      // avoid tracking threads when building native images as it confuses the scanner
-      // (we still want instrumentation applied, so tracking works in the built image)
-      if (!Platform.isNativeImageBuilder()) {
-        TPEHelper.setPropagate(
-            InstrumentationContext.get(ThreadPoolExecutor.class, Boolean.class), zis);
-      }
-    }
-  }
-
   public static final class Execute {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void capture(
         @Advice.This final ThreadPoolExecutor tpe,
         @Advice.Argument(readOnly = false, value = 0) Runnable task) {
-      if (TPEHelper.shouldPropagate(
-          InstrumentationContext.get(ThreadPoolExecutor.class, Boolean.class), tpe)) {
+      if (TPEHelper.shouldPropagate(tpe)) {
         if (TPEHelper.useWrapping(task)) {
           task = Wrapper.wrap(task);
         } else {
@@ -155,10 +138,9 @@ public final class ThreadPoolExecutorInstrumentation
   public static final class BeforeExecute {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static ContextScope beforeExecuteEnter(
-        @Advice.This final ThreadPoolExecutor zis,
+        @Advice.This final ThreadPoolExecutor tpe,
         @Advice.Argument(readOnly = false, value = 1) Runnable task) {
-      if (TPEHelper.shouldPropagate(
-          InstrumentationContext.get(ThreadPoolExecutor.class, Boolean.class), zis)) {
+      if (TPEHelper.shouldPropagate(tpe)) {
         if (TPEHelper.useWrapping(task)) {
           task = Wrapper.unwrap(task);
         } else {
@@ -181,10 +163,9 @@ public final class ThreadPoolExecutorInstrumentation
   public static final class AfterExecute {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static ContextScope afterExecuteEnter(
-        @Advice.This final ThreadPoolExecutor zis,
+        @Advice.This final ThreadPoolExecutor tpe,
         @Advice.Argument(readOnly = false, value = 0) Runnable task) {
-      if (TPEHelper.shouldPropagate(
-          InstrumentationContext.get(ThreadPoolExecutor.class, Boolean.class), zis)) {
+      if (TPEHelper.shouldPropagate(tpe)) {
         if (TPEHelper.useWrapping(task)) {
           task = Wrapper.unwrap(task);
         } else {
@@ -206,10 +187,9 @@ public final class ThreadPoolExecutorInstrumentation
   public static final class Remove {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void remove(
-        @Advice.This final ThreadPoolExecutor zis,
+        @Advice.This final ThreadPoolExecutor tpe,
         @Advice.Return(readOnly = false) Runnable removed) {
-      if (TPEHelper.shouldPropagate(
-          InstrumentationContext.get(ThreadPoolExecutor.class, Boolean.class), zis)) {
+      if (TPEHelper.shouldPropagate(tpe)) {
         if (TPEHelper.useWrapping(removed)) {
           if (removed instanceof Wrapper) {
             Wrapper<?> wrapper = ((Wrapper<?>) removed);


### PR DESCRIPTION
# Motivation

The flag being stored in the TPE context-store is constant, based on whether the class is listed in the 'excludedClasses' set provided via static config. This is better suited to being stored as a ClassValue, especially for AOT scenarios where context-stores are more likely to use the global weak-map.

# Additional Notes

Found while looking into https://github.com/DataDog/dd-trace-java/issues/10479 

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
