### PR TITLE
Avoid calling synchronized wrappers when capturing

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
@@ -205,6 +205,8 @@ public class WellKnownClasses {
           "org.agrona.collections." // Agrona
           );
 
+  private static final String SYNCHRONIZED_WRAPPER_PREFIX = "java.util.Collections$Synchronized";
+
   /**
    * @return true if type is a final class and toString implementation is well known and side effect
    *     free
@@ -223,24 +225,25 @@ public class WellKnownClasses {
   }
 
   /**
-   * @return true if collection implementation is safe to call (only in-memory)
+   * @return true if collection implementation is safe to call (only in-memory and lock free)
    */
   public static boolean isSafe(Collection<?> collection) {
-    String className = collection.getClass().getTypeName();
-    for (String safePackage : SAFE_COLLECTION_PACKAGES) {
-      if (className.startsWith(safePackage)) {
-        return true;
-      }
-    }
-    return false;
+    return isSafe(collection.getClass().getTypeName(), SAFE_COLLECTION_PACKAGES);
   }
 
   /**
-   * @return true if map implementation is safe to call (only in-memory)
+   * @return true if map implementation is safe to call (only in-memory and lock free)
    */
   public static boolean isSafe(Map<?, ?> map) {
-    String className = map.getClass().getTypeName();
-    for (String safePackage : SAFE_MAP_PACKAGES) {
+    return isSafe(map.getClass().getTypeName(), SAFE_MAP_PACKAGES);
+  }
+
+  private static boolean isSafe(String className, List<String> safePackages) {
+    // synchronized wrappers lock on their mutex: calling them can deadlock the instrumented thread
+    if (className.startsWith(SYNCHRONIZED_WRAPPER_PREFIX)) {
+      return false;
+    }
+    for (String safePackage : safePackages) {
       if (className.startsWith(safePackage)) {
         return true;
       }

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/util/WellKnownClassesTest.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/util/WellKnownClassesTest.java
@@ -1,0 +1,40 @@
+package datadog.trace.bootstrap.debugger.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.Test;
+
+class WellKnownClassesTest {
+
+  @Test
+  public void synchronizedWrappersAreNotSafe() {
+    assertFalse(WellKnownClasses.isSafe(Collections.synchronizedCollection(new ArrayList<>())));
+    assertFalse(WellKnownClasses.isSafe(Collections.synchronizedList(new ArrayList<>())));
+    assertFalse(WellKnownClasses.isSafe(Collections.synchronizedList(new LinkedList<>())));
+    assertFalse(WellKnownClasses.isSafe(Collections.synchronizedSet(new HashSet<>())));
+    assertFalse(WellKnownClasses.isSafe(Collections.synchronizedSortedSet(new TreeSet<>())));
+    assertFalse(WellKnownClasses.isSafe(Collections.synchronizedNavigableSet(new TreeSet<>())));
+    assertFalse(WellKnownClasses.isSafe(Collections.synchronizedMap(new HashMap<>())));
+    assertFalse(WellKnownClasses.isSafe(Collections.synchronizedSortedMap(new TreeMap<>())));
+    assertFalse(WellKnownClasses.isSafe(Collections.synchronizedNavigableMap(new TreeMap<>())));
+  }
+
+  @Test
+  public void plainCollectionsAreSafe() {
+    assertTrue(WellKnownClasses.isSafe(new ArrayList<>()));
+    assertTrue(WellKnownClasses.isSafe(new HashSet<>()));
+    assertTrue(WellKnownClasses.isSafe(new HashMap<>()));
+    assertTrue(WellKnownClasses.isSafe(new ConcurrentHashMap<>()));
+    assertTrue(WellKnownClasses.isSafe(Collections.emptyList()));
+    assertTrue(WellKnownClasses.isSafe(Collections.unmodifiableMap(new HashMap<>())));
+  }
+}

--- a/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/values/ListValue.java
@@ -60,7 +60,11 @@ public class ListValue implements CollectionValue<Object>, ValueExpression<ListV
 
   public boolean isEmpty() {
     if (listHolder instanceof Collection) {
-      return ((Collection<?>) listHolder).isEmpty();
+      if (WellKnownClasses.isSafe((Collection<?>) listHolder)) {
+        return ((Collection<?>) listHolder).isEmpty();
+      }
+      throw new UnsupportedOperationException(
+          "Unsupported Collection class: " + listHolder.getClass().getTypeName());
     } else if (listHolder instanceof Value) {
       Value<?> val = (Value<?>) listHolder;
       return val.isNull() || val.isUndefined();

--- a/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IsEmptyExpressionTest.java
+++ b/dd-java-agent/agent-debugger/debugger-el/src/test/java/com/datadog/debugger/el/expressions/IsEmptyExpressionTest.java
@@ -15,8 +15,10 @@ import com.datadog.debugger.el.values.MapValue;
 import com.datadog.debugger.el.values.NumericValue;
 import com.datadog.debugger.el.values.StringValue;
 import datadog.trace.bootstrap.debugger.el.Values;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 
@@ -136,6 +138,24 @@ class IsEmptyExpressionTest {
     assertEquals("isEmpty(Set)", print(isEmpty5));
     assertTrue(isEmpty6.evaluate(evalContext));
     assertEquals("isEmpty(Set)", print(isEmpty6));
+  }
+
+  @Test
+  void testSynchronizedCollection() {
+    // calling isEmpty() on those wrappers takes the wrapper mutex and can deadlock the application
+    IsEmptyExpression syncList =
+        new IsEmptyExpression(new ListValue(Collections.synchronizedList(new ArrayList<>())));
+    UnsupportedOperationException exception =
+        assertThrows(UnsupportedOperationException.class, () -> syncList.evaluate(evalContext));
+    assertEquals(
+        "Unsupported Collection class: java.util.Collections$SynchronizedRandomAccessList",
+        exception.getMessage());
+    IsEmptyExpression syncMap =
+        new IsEmptyExpression(new MapValue(Collections.synchronizedMap(new HashMap<>())));
+    exception =
+        assertThrows(UnsupportedOperationException.class, () -> syncMap.evaluate(evalContext));
+    assertEquals(
+        "Unsupported Map class: java.util.Collections$SynchronizedMap", exception.getMessage());
   }
 
   @Test

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -55,6 +55,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -66,6 +67,8 @@ import java.util.OptionalLong;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
 import org.junit.jupiter.api.Assertions;
@@ -753,6 +756,47 @@ public class SnapshotSerializationTest {
         locals, "strMap", "foo0", "bar0", "foo1", "bar1", "foo2", "bar2", "foo3", "bar3", "foo4",
         "bar4", "foo5", "bar5", "foo6", "bar6", "foo7", "bar7", "foo8", "bar8", "foo9", "bar9");
     assertSize(locals, "strMap", "10");
+  }
+
+  @Test
+  public void synchronizedMapLockedByAnotherThread() throws Exception {
+    Map<String, String> syncMap = Collections.synchronizedMap(new HashMap<>());
+    syncMap.put("foo", "bar");
+    CountDownLatch locked = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    Thread holder =
+        new Thread(
+            () -> {
+              synchronized (syncMap) {
+                locked.countDown();
+                try {
+                  release.await();
+                } catch (InterruptedException ignored) {
+                }
+              }
+            },
+            "mutex-holder");
+    holder.start();
+    assertTrue(locked.await(30, TimeUnit.SECONDS));
+    try {
+      JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
+      Snapshot snapshot = createSnapshot();
+      CapturedContext context = new CapturedContext();
+      context.addLocals(
+          new CapturedContext.CapturedValue[] {
+            capturedValueDepth("syncMap", syncMap.getClass().getTypeName(), syncMap, 1)
+          });
+      snapshot.setExit(context);
+      String buffer =
+          CompletableFuture.supplyAsync(() -> adapter.toJson(snapshot)).get(30, TimeUnit.SECONDS);
+      Map<String, Object> local = (Map<String, Object>) getLocalsFromJson(buffer).get("syncMap");
+      assertNull(local.get(ENTRIES));
+      assertNull(local.get(SIZE));
+      Assertions.assertNotNull(local.get(FIELDS));
+    } finally {
+      release.countDown();
+      holder.join();
+    }
   }
 
   private Map<String, Object> doMapSize(int maxColSize) throws IOException {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/SnapshotSerializationTest.java
@@ -776,9 +776,11 @@ public class SnapshotSerializationTest {
               }
             },
             "mutex-holder");
+    // daemon: a failed await below would otherwise leave the mutex held and block the test JVM
+    holder.setDaemon(true);
     holder.start();
-    assertTrue(locked.await(30, TimeUnit.SECONDS));
     try {
+      assertTrue(locked.await(5, TimeUnit.SECONDS));
       JsonAdapter<Snapshot> adapter = createSnapshotAdapter();
       Snapshot snapshot = createSnapshot();
       CapturedContext context = new CapturedContext();
@@ -792,7 +794,10 @@ public class SnapshotSerializationTest {
       Map<String, Object> local = (Map<String, Object>) getLocalsFromJson(buffer).get("syncMap");
       assertNull(local.get(ENTRIES));
       assertNull(local.get(SIZE));
-      Assertions.assertNotNull(local.get(FIELDS));
+      Map<String, Object> fields = (Map<String, Object>) local.get(FIELDS);
+      Assertions.assertNotNull(fields);
+      // serialized through the object path: the backing map is a field, not entries
+      assertTrue(fields.containsKey("m"));
     } finally {
       release.countDown();
       holder.join();


### PR DESCRIPTION
# What Does This Do

Treats `java.util.Collections$Synchronized*` wrappers as unsafe to call during snapshot capture, so they are serialized as plain objects instead of through `size()` / `entrySet()` / `iterator()`.

Fixes DYNIS-64

# Motivation

Snapshot capture runs on the instrumented thread, and every method on a synchronized wrapper acquires the wrapper's mutex. Capture therefore makes the application thread take an application lock, in an order the application itself never uses. A customer hit a three-thread deadlock this way and had to disable Exception Replay to recover.

Monitor entry is untimed and uninterruptible, so neither the eval timeout nor the existing exception handling can unwind a thread that is already blocked. Not calling into the wrapper at all is the only reliable fix.

# Additional Notes

- Trade-off: synchronized collections no longer show their contents in snapshots. On JDK 9+ the object fallback cannot read the wrapper's private fields either, because `java.base` does not open `java.util` to the agent, so these values are captured without contents. Improving that rendering is a follow-up.
- Probe conditions and log templates over a synchronized collection now report `Unsupported Collection class: ...` instead of evaluating, since the expression language shares the same safety check. `ListValue.isEmpty()` was missing that check and is guarded here too, so an `isEmpty()` condition can no longer take the mutex.
- Out of scope: `Vector`, `Stack`, `Hashtable` and `Properties` lock on the instance, `Collections.unmodifiableMap(synchronizedMap(...))` delegates through to the wrapper, and Guava's `Synchronized$*` wrappers carry the same hazard. Left for a follow-up, which should land after the rendering fix above.

# Testing

- `WellKnownClassesTest` covers the nine JDK synchronized wrapper types plus the collections that must stay safe.
- `IsEmptyExpressionTest` covers the guarded `isEmpty()` path for a synchronized list and map.
- `SnapshotSerializationTest.synchronizedMapLockedByAnotherThread` serializes a synchronized map while another thread holds its mutex. It blocks until the timeout before the fix and completes after it.

# Contributor Checklist

- [x] Format the pull request title to follow [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Assign `type:` and `comp:` labels
- [x] Update public documentation if needed
