### PR TITLE
Restrict freemarker ObjectWrapper instrumentation to 2.3.24+

### DIFF
--- a/dd-java-agent/instrumentation/freemarker/freemarker-2.3.24/src/main/java/datadog/trace/instrumentation/freemarker24/ObjectWrapperInstrumentation.java
+++ b/dd-java-agent/instrumentation/freemarker/freemarker-2.3.24/src/main/java/datadog/trace/instrumentation/freemarker24/ObjectWrapperInstrumentation.java
@@ -1,5 +1,6 @@
 package datadog.trace.instrumentation.freemarker24;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.ClassLoaderMatchers.hasClassNamed;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
@@ -27,6 +28,14 @@ public class ObjectWrapperInstrumentation extends InstrumenterModule.Iast
 
   public ObjectWrapperInstrumentation() {
     super("freemarker");
+  }
+
+  static final ElementMatcher.Junction<ClassLoader> VERSION_POST_2_3_24 =
+      hasClassNamed("freemarker.cache.ByteArrayTemplateLoader");
+
+  @Override
+  public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
+    return VERSION_POST_2_3_24;
   }
 
   @Override


### PR DESCRIPTION
DO NOT MERGE, first need to decide how to fix correctly.


# What Does This Do

Adds a classloader version guard to `ObjectWrapperInstrumentation` (freemarker `2.3.24` module), matching what `DollarVariableInstrumentation` already does in the same package:

```java
static final ElementMatcher.Junction<ClassLoader> VERSION_POST_2_3_24 =
    hasClassNamed("freemarker.cache.ByteArrayTemplateLoader");

@Override
public ElementMatcher.Junction<ClassLoader> classLoaderMatcher() {
  return VERSION_POST_2_3_24;
}
```

# Motivation

The `freemarker-2.3.24` muzzle directive declares `versions = '[2.3.24-incubating,]'` with `assertInverse = true`, so every pre-`2.3.24` version is expected to **fail** muzzle. `ObjectWrapperInstrumentation` only references `freemarker.template.ObjectWrapper` and `freemarker.template.TemplateModel`, both of which exist since `2.3.9` — so its reference check passed on old versions and the inverse assertion blew up with:

```
MUZZLE PASSED ObjectWrapperInstrumentation BUT FAILURE WAS EXPECTED
```

`MuzzleVersionScanPlugin` folds the classloader matcher into the pass/fail verdict (`passed = mismatches.isEmpty() && classLoaderMatch`), so adding the guard makes the instrumentation fail muzzle on pre-`2.3.24` as declared. This showed up only intermittently on GitLab because muzzle samples the inverse version range randomly (`MuzzleVersionUtils.limitLargeRanges` shuffles low/high per `major.minor`).

# Additional Notes

- `freemarker.cache.ByteArrayTemplateLoader` was verified as the right version marker: absent in `2.3.9` / `2.3.20` / `2.3.23`, present in `2.3.24-incubating` / `2.3.34`.
- Reproduced locally by pointing `MAVEN_REPOSITORY_PROXY` at a file repo exposing `2.3.23` in its metadata (maven central's `org.freemarker:freemarker` metadata only lists `2.3.24+`, which is why the inverse range is empty on plain central): `muzzle-AssertFail-...-2.3.23` fails without this change and passes with it.
- Runtime effect is intentional: on freemarker `2.3.9`–`2.3.23` the `ObjectWrapper` taint propagation no longer applies, aligning behavior with the module's declared support range. The `2.3.9` module ships no `ObjectWrapper` instrumentation, so no tested version loses coverage.
- Tests: `freemarker-2.3.24` `test` / `latestDepTest` and `freemarker-2.3.9` `test` / `version2_3_23Test` all pass (42 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)