### PR TITLE
Write helpers into module bytecode directly

### DIFF
--- a/dd-java-agent/agent-installer/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
+++ b/dd-java-agent/agent-installer/src/main/java/datadog/trace/agent/tooling/CombiningTransformerBuilder.java
@@ -130,12 +130,7 @@ public final class CombiningTransformerBuilder
 
     adviceShader = AdviceShader.with(module);
 
-    String[] helperClassNames =
-        InstrumenterModule.loadStaticMuzzleHelperClassNames(
-            Utils.getExtendedClassLoader(), module.getClass().getName());
-    if (null == helperClassNames) {
-      helperClassNames = module.helperClassNames();
-    }
+    String[] helperClassNames = module.helperClassNames();
     if (module.injectHelperDependencies()) {
       helperClassNames = HelperScanner.withClassDependencies(helperClassNames);
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
@@ -113,23 +113,10 @@ public abstract class InstrumenterModule implements Instrumenter {
   }
 
   /**
-   * @return the build-time inferred and manually-declared helper class names captured by {@code
-   *     $Muzzle}, or {@code null} when none are available and fall back to {@link
-   *     #helperClassNames()}.
+   * Optional manual additions to the injected helper set. At build time {@code MuzzleGenerator}
+   * overwrites this with the fully resolved list (inferred + manual), so at runtime it returns
+   * every helper the module injects.
    */
-  public static String[] loadStaticMuzzleHelperClassNames(
-      ClassLoader classLoader, String instrumentationClass) {
-    String muzzleClass = instrumentationClass + "$Muzzle";
-    try {
-      // helper class names captured at build-time; see MuzzleGenerator
-      return (String[])
-          classLoader.loadClass(muzzleClass).getMethod("helperClassNames").invoke(null);
-    } catch (Throwable e) {
-      return null;
-    }
-  }
-
-  /** Optional manual additions to the injected helper set. */
   public String[] helperClassNames() {
     return NO_HELPERS;
   }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/InstrumenterModule.java
@@ -113,9 +113,9 @@ public abstract class InstrumenterModule implements Instrumenter {
   }
 
   /**
-   * Optional manual additions to the injected helper set. At build time {@code MuzzleGenerator}
-   * overwrites this with the fully resolved list (inferred + manual), so at runtime it returns
-   * every helper the module injects.
+   * The helper classes to inject. Override this to declare them manually; otherwise {@code
+   * MuzzleGenerator} generates it at build time from the helpers inferred from the advice, so at
+   * runtime it returns every helper the module injects.
    */
   public String[] helperClassNames() {
     return NO_HELPERS;

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGenerator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGenerator.java
@@ -77,14 +77,33 @@ public class MuzzleGenerator implements AsmVisitorWrapper {
       throw new RuntimeException(e);
     }
 
+    AdviceShader adviceShader = AdviceShader.with(module.adviceShading());
+
+    // Collect the muzzle references from every advice the module defines.
+    Set<String> adviceClasses = new HashSet<>();
+    List<Reference> allReferences = new ArrayList<>();
+    for (Instrumenter instrumenter : module.typeInstrumentations()) {
+      if (instrumenter instanceof Instrumenter.HasMethodAdvice) {
+        Collections.addAll(
+            allReferences,
+            generateReferences(
+                (Instrumenter.HasMethodAdvice) instrumenter, adviceShader, adviceClasses));
+      }
+    }
+
+    String[] orderedHelpers = computeInjectedHelpers(module, allReferences, adviceClasses);
+
     File muzzleClass = new File(targetDir, moduleDefinition.getInternalName() + "$Muzzle.class");
     try {
       muzzleClass.getParentFile().mkdirs();
-      Files.write(muzzleClass.toPath(), generateMuzzleClass(module));
+      Files.write(muzzleClass.toPath(), generateMuzzleClass(module, allReferences, orderedHelpers));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
-    return classVisitor;
+
+    // Set resolved helpers directly in the module's helperClassNames() so agent reads
+    // them directly without loading the $Muzzle class.
+    return new HelperClassNamesWriter(classVisitor, orderedHelpers);
   }
 
   private static Reference[] generateReferences(
@@ -123,23 +142,8 @@ public class MuzzleGenerator implements AsmVisitorWrapper {
   }
 
   /** This code is generated in a separate side-class. */
-  private byte[] generateMuzzleClass(InstrumenterModule module) {
-
-    AdviceShader adviceShader = AdviceShader.with(module.adviceShading());
-
-    // Collect the muzzle references from every advice the module defines.
-    Set<String> adviceClasses = new HashSet<>();
-    List<Reference> allReferences = new ArrayList<>();
-    for (Instrumenter instrumenter : module.typeInstrumentations()) {
-      if (instrumenter instanceof Instrumenter.HasMethodAdvice) {
-        Collections.addAll(
-            allReferences,
-            generateReferences(
-                (Instrumenter.HasMethodAdvice) instrumenter, adviceShader, adviceClasses));
-      }
-    }
-
-    String[] orderedHelpers = computeInjectedHelpers(module, allReferences, adviceClasses);
+  private byte[] generateMuzzleClass(
+      InstrumenterModule module, List<Reference> allReferences, String[] orderedHelpers) {
 
     // Injected helpers are our own classes, so they don't need to be asserted as library
     // references.
@@ -201,24 +205,46 @@ public class MuzzleGenerator implements AsmVisitorWrapper {
     mv.visitMaxs(0, 0);
     mv.visitEnd();
 
-    // Generate helperClassNames() with resolved helpers for the agent to read at load time;
-    // skip the method entirely when the module injects nothing.
-    if (orderedHelpers.length > 0) {
-      MethodVisitor hv =
-          cw.visitMethod(
-              Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
-              "helperClassNames",
-              "()[Ljava/lang/String;",
-              null,
-              null);
-      hv.visitCode();
-      writeStrings(hv, orderedHelpers);
-      hv.visitInsn(Opcodes.ARETURN);
-      hv.visitMaxs(0, 0);
-      hv.visitEnd();
+    return cw.toByteArray();
+  }
+
+  /**
+   * Rewrite a module's {@code helperClassNames()} to return the build-time-resolved helper list.
+   */
+  private static final class HelperClassNamesWriter extends ClassVisitor {
+    private static final String HELPER_METHOD = "helperClassNames";
+    private static final String HELPER_DESCRIPTOR = "()[Ljava/lang/String;";
+
+    private final String[] helpers;
+
+    HelperClassNamesWriter(ClassVisitor classVisitor, String[] helpers) {
+      super(Opcodes.ASM7, classVisitor);
+      this.helpers = helpers;
     }
 
-    return cw.toByteArray();
+    @Override
+    public MethodVisitor visitMethod(
+        int access, String name, String descriptor, String signature, String[] exceptions) {
+      // Drop any existing helperClassNames() - resolved version will be re-added in visitEnd.
+      if (HELPER_METHOD.equals(name) && HELPER_DESCRIPTOR.equals(descriptor)) {
+        return null;
+      }
+      return super.visitMethod(access, name, descriptor, signature, exceptions);
+    }
+
+    @Override
+    public void visitEnd() {
+      if (helpers.length > 0) {
+        MethodVisitor mv =
+            super.visitMethod(Opcodes.ACC_PUBLIC, HELPER_METHOD, HELPER_DESCRIPTOR, null, null);
+        mv.visitCode();
+        writeStrings(mv, helpers);
+        mv.visitInsn(Opcodes.ARETURN);
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
+      }
+      super.visitEnd();
+    }
   }
 
   /** Resolves the ordered set of helper classes to inject for a module. */

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGenerator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGenerator.java
@@ -101,8 +101,7 @@ public class MuzzleGenerator implements AsmVisitorWrapper {
       throw new RuntimeException(e);
     }
 
-    // Set resolved helpers directly in the module's helperClassNames() so agent reads
-    // them directly without loading the $Muzzle class.
+    // Write the resolved helpers into the module's helperClassNames() so agent reads them directly.
     return new HelperClassNamesWriter(classVisitor, orderedHelpers);
   }
 
@@ -209,13 +208,15 @@ public class MuzzleGenerator implements AsmVisitorWrapper {
   }
 
   /**
-   * Rewrite a module's {@code helperClassNames()} to return the build-time-resolved helper list.
+   * Adds a {@code helperClassNames()} returning the build-time-resolved helper list to modules that
+   * don't declare one; a module that declares its own keeps it.
    */
   private static final class HelperClassNamesWriter extends ClassVisitor {
     private static final String HELPER_METHOD = "helperClassNames";
     private static final String HELPER_DESCRIPTOR = "()[Ljava/lang/String;";
 
     private final String[] helpers;
+    private boolean declared;
 
     HelperClassNamesWriter(ClassVisitor classVisitor, String[] helpers) {
       super(Opcodes.ASM7, classVisitor);
@@ -225,16 +226,16 @@ public class MuzzleGenerator implements AsmVisitorWrapper {
     @Override
     public MethodVisitor visitMethod(
         int access, String name, String descriptor, String signature, String[] exceptions) {
-      // Drop any existing helperClassNames() - resolved version will be re-added in visitEnd.
       if (HELPER_METHOD.equals(name) && HELPER_DESCRIPTOR.equals(descriptor)) {
-        return null;
+        declared = true;
       }
       return super.visitMethod(access, name, descriptor, signature, exceptions);
     }
 
     @Override
     public void visitEnd() {
-      if (helpers.length > 0) {
+      // Only generate when the module does not declare its own manually listed helpers.
+      if (!declared && helpers.length > 0) {
         MethodVisitor mv =
             super.visitMethod(Opcodes.ACC_PUBLIC, HELPER_METHOD, HELPER_DESCRIPTOR, null, null);
         mv.visitCode();

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGenerator.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/muzzle/MuzzleGenerator.java
@@ -261,32 +261,37 @@ public class MuzzleGenerator implements AsmVisitorWrapper {
       }
     }
 
-    // Add manually defined helpers.
+    // A module with a manually declared list uses it directly; otherwise the helpers
+    // inferred from its advice are used (with their nested classes, dependency-ordered, and any
+    // build-time-only muzzle providers dropped).
     Set<String> manualHelpers = new LinkedHashSet<>(asList(module.helperClassNames()));
-    Set<String> initialHelpers = new LinkedHashSet<>(inferredHelpers);
-    initialHelpers.addAll(manualHelpers);
-    for (String helper : new ArrayList<>(initialHelpers)) {
-      if (isOwnOutput(helper)) {
-        addNestedClasses(helper, initialHelpers);
+    String[] injectedHelpers;
+    if (!manualHelpers.isEmpty()) {
+      injectedHelpers = manualHelpers.toArray(new String[0]);
+    } else {
+      Set<String> initialHelpers = new LinkedHashSet<>(inferredHelpers);
+      for (String helper : new ArrayList<>(initialHelpers)) {
+        if (isOwnOutput(helper)) {
+          addNestedClasses(helper, initialHelpers);
+        }
       }
+      ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+      String[] orderedHelpers =
+          discoverAndOrderHelpers(
+              initialHelpers, manualHelpers, helperPredicate, contextClassLoader);
+      // Drop build-time-only muzzle providers.
+      ClassFileLocator locator = ClassFileLocator.ForClassLoader.of(contextClassLoader);
+      List<String> injectableHelpers = new ArrayList<>(orderedHelpers.length);
+      for (String helper : orderedHelpers) {
+        if (!isBuildTimeOnly(helper, locator)) {
+          injectableHelpers.add(helper);
+        }
+      }
+      injectedHelpers = injectableHelpers.toArray(new String[0]);
     }
 
-    ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-    String[] orderedHelpers =
-        discoverAndOrderHelpers(initialHelpers, manualHelpers, helperPredicate, contextClassLoader);
-
-    // Drop build-time-only muzzle providers.
-    ClassFileLocator locator = ClassFileLocator.ForClassLoader.of(contextClassLoader);
-    List<String> injectableHelpers = new ArrayList<>(orderedHelpers.length);
-    for (String helper : orderedHelpers) {
-      if (!isBuildTimeOnly(helper, locator)) {
-        injectableHelpers.add(helper);
-      }
-    }
-    orderedHelpers = injectableHelpers.toArray(new String[0]);
-
-    writeInferenceReport(module, adviceClasses.isEmpty(), inferredHelpers, orderedHelpers);
-    return orderedHelpers;
+    writeInferenceReport(module, adviceClasses.isEmpty(), inferredHelpers, injectedHelpers);
+    return injectedHelpers;
   }
 
   /** {@code true} if the class was compiled from this instrumentation subproject's own output. */

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/muzzle/MuzzleGeneratorFixtures.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/muzzle/MuzzleGeneratorFixtures.java
@@ -42,11 +42,14 @@ final class MuzzleGeneratorFixtures {
     }
   }
 
-  /** Module declaring a manual helper the advice crawl cannot see. */
-  static class CombineModule extends TestInstrumentationClasses.BaseInst {
+  /** Module declaring a manual helper list. */
+  static class ManualModule extends TestInstrumentationClasses.BaseInst {
     @Override
     public String[] helperClassNames() {
       return new String[] {ManualHelperFixture.class.getName()};
     }
   }
+
+  /** Module with no declared helper list, so its helpers come from auto-detection. */
+  static class InferredModule extends TestInstrumentationClasses.BaseInst {}
 }

--- a/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/muzzle/MuzzleGeneratorTest.java
+++ b/dd-java-agent/agent-tooling/src/test/java/datadog/trace/agent/tooling/muzzle/MuzzleGeneratorTest.java
@@ -6,9 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import datadog.trace.agent.tooling.InstrumenterModule;
 import datadog.trace.agent.tooling.muzzle.MuzzleGeneratorFixtures.BuildTimeProviderFixture;
 import datadog.trace.agent.tooling.muzzle.MuzzleGeneratorFixtures.CombineAdvice;
-import datadog.trace.agent.tooling.muzzle.MuzzleGeneratorFixtures.CombineModule;
 import datadog.trace.agent.tooling.muzzle.MuzzleGeneratorFixtures.InferredHelperFixture;
+import datadog.trace.agent.tooling.muzzle.MuzzleGeneratorFixtures.InferredModule;
 import datadog.trace.agent.tooling.muzzle.MuzzleGeneratorFixtures.ManualHelperFixture;
+import datadog.trace.agent.tooling.muzzle.MuzzleGeneratorFixtures.ManualModule;
 import datadog.trace.agent.tooling.muzzle.MuzzleGeneratorFixtures.OwnerWithMuzzleFixture;
 import java.io.File;
 import java.nio.file.Files;
@@ -39,7 +40,30 @@ class MuzzleGeneratorTest {
   }
 
   @Test
-  void combinesInferredAndManualHelpersAndDropsMuzzleProviders() throws Exception {
+  void declaredHelperListIsUsedAsIsWithoutMergingInference() throws Exception {
+    List<String> injected = injectedHelpers(new ManualModule());
+
+    // A module that declares helperClassNames() gets exactly that list - nothing inferred from the
+    // advice is merged in.
+    assertTrue(injected.contains(MANUAL), "manually declared helper should be injected");
+    assertFalse(injected.contains(INFERRED), "inferred helper must not be merged into manual list");
+    assertFalse(injected.contains(OWNER), "ownOutput helper must not be merged into manual list");
+  }
+
+  @Test
+  void inferredHelpersAreUsedWhenNoListDeclaredAndMuzzleProvidersDropped() throws Exception {
+    List<String> injected = injectedHelpers(new InferredModule());
+
+    // If no declared list, the helpers inferred from the advice are injected minus the
+    // build-time-only muzzle provider and advice root.
+    assertTrue(injected.contains(INFERRED), "inferred helper should be injected");
+    assertTrue(injected.contains(OWNER), "ownOutput helper should be injected");
+    assertFalse(injected.contains(MUZZLE_HELPER), "build-time MuzzleHelper must not be injected");
+    assertFalse(injected.contains(CombineAdvice.class.getName()), "advice root is not a helper");
+    assertFalse(injected.contains(MANUAL), "helper the advice never references is not inferred");
+  }
+
+  private static List<String> injectedHelpers(InstrumenterModule module) throws Exception {
     // Point the generator's "ownOutput" at this module's compiled test classes so the fixtures
     // count as this subproject's own helpers.
     File sourceDir = classesRootOf(MuzzleGeneratorFixtures.class);
@@ -52,24 +76,9 @@ class MuzzleGeneratorTest {
     List<Reference> references = new ArrayList<>(crawled.values());
     Set<String> adviceClasses = Collections.singleton(CombineAdvice.class.getName());
 
-    List<String> injected =
-        injectedHelpers(generator, new CombineModule(), references, adviceClasses);
-
-    assertTrue(injected.contains(INFERRED), "inferred helper should be injected");
-    assertTrue(injected.contains(MANUAL), "manually declared helper should be injected");
-    assertTrue(injected.contains(OWNER), "ownOutput helper should be injected");
-    assertFalse(injected.contains(MUZZLE_HELPER), "build-time MuzzleHelper must not be injected");
-    assertFalse(injected.contains(CombineAdvice.class.getName()), "advice root is not a helper");
-  }
-
-  private static List<String> injectedHelpers(
-      MuzzleGenerator generator,
-      InstrumenterModule module,
-      List<Reference> references,
-      Set<String> adviceClasses) {
     ClassLoader previous = Thread.currentThread().getContextClassLoader();
     // computeInjectedHelpers resolves classes via the context class-loader.
-    Thread.currentThread().setContextClassLoader(MuzzleGeneratorTest.class.getClassLoader());
+    Thread.currentThread().setContextClassLoader(loader);
     try {
       return Arrays.asList(generator.computeInjectedHelpers(module, references, adviceClasses));
     } finally {

--- a/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
+++ b/dd-java-agent/instrumentation/servlet/javax-servlet/javax-servlet-common/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
@@ -42,6 +42,7 @@ public final class HttpServletResponseInstrumentation extends InstrumenterModule
   public String[] helperClassNames() {
     return new String[] {
       "datadog.trace.instrumentation.servlet.ServletRequestSetter",
+      "datadog.trace.instrumentation.servlet.http.HttpServletResponseDecorator",
     };
   }
 


### PR DESCRIPTION
# What Does This Do

Write the build-time-resolved helper list directly into each module's `helperClassNames()` bytecode. The transformer will now read helper class names directly instead of needing to load the `$Muzzle` class.

# Motivation

Without this change, the `$Muzzle` side class is loaded eagerly to get the helper class names, negatively affecting startup time. Instead we can write the helpers directly into the bytecode and avoid loading the muzzle class.

# Additional Notes

This is built off of #12059 and offers an alternative to #12116 in addressing the startup time issues. The changes here are more minimal, but we are rewriting the module bytecode in place.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
