### PR TITLE
Added `2.1-1-osgi` to the list of bad versions.

### DIFF
--- a/dd-java-agent/instrumentation/ws/jax-ws/jax-ws-annotations-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/ws/jax-ws/jax-ws-annotations-2.0/build.gradle
@@ -3,7 +3,7 @@ muzzle {
     group = "javax.xml.ws"
     module = "jaxws-api"
     versions = "[2.0,)"
-    skipVersions += ["2.1EA2", "2.1-1"] // bad releases
+    skipVersions += ["2.1EA2", "2.1-1", "2.1-1-osgi"] // bad releases
   }
 }
 


### PR DESCRIPTION
# What Does This Do

Skips the broken `jaxws-api:2.1-1-osgi` Muzzle version.

# Motivation

Prevent nondeterministic Muzzle CI failures.

# Additional Notes

MagicMirror contains `2.1-1-osgi`, although Maven Central does not. Like the already skipped `2.1-1`, its POM references the unavailable transitive dependency `javax.jws:jsr181:1.0`.


# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
