### PR TITLE
Revert: Disallow benchmarks on commit tag-triggered pipelines (#11987)

### DIFF
--- a/.gitlab/java-benchmark-configs.yml
+++ b/.gitlab/java-benchmark-configs.yml
@@ -3,7 +3,8 @@
   - if: '$POPULATE_CACHE'
     when: never
   - if: '$CI_COMMIT_TAG =~ /^v?[0-9]+\.[0-9]+\.[0-9]+$/'
-    when: never
+    when: manual
+    allow_failure: true
   - if: '$CI_COMMIT_BRANCH == "master"'
     when: on_success
     interruptible: false
@@ -22,7 +23,8 @@
   - if: '$POPULATE_CACHE'
     when: never
   - if: '$CI_COMMIT_TAG =~ /^v?[0-9]+\.[0-9]+\.[0-9]+$/'
-    when: never
+    when: manual
+    allow_failure: true
   - if: '$CI_COMMIT_BRANCH == "master"'
     when: on_success
     interruptible: false
@@ -36,18 +38,9 @@
     interruptible: true
     allow_failure: true
 
+# Ensure the tracer artifact publish finishes before the benchmark jobs start.
 linux-java-spring-petclinic-parallel:
   needs: ["publish-artifacts-to-s3"]
-  rules:
-    - if: '$CI_COMMIT_TAG =~ /^v?[0-9]+\.[0-9]+\.[0-9]+$/'
-      when: never
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
-      when: on_success
-    - if: '$CI_COMMIT_BRANCH == "master"'
-      when: on_success
-      interruptible: false
-    - when: manual
-      allow_failure: true
 
 linux-java-insecure-bank-load-parallel:
   needs: ["publish-artifacts-to-s3"]


### PR DESCRIPTION
## Summary
Tag pipelines currently fail to be created, with errors like:

```
java-spring-petclinic-parallel-generate-slos: needs 'linux-java-spring-petclinic-parallel' job, but 'linux-java-spring-petclinic-parallel' does not exist in the pipeline
```

Same pattern for `check-slo-breaches`, `upload-to-bp-api`, and `notify-slo-breaches`, across all four Java parallel benchmark suites (spring-petclinic, insecure-bank/spring-petclinic startup, load, dacapo).

### Root cause
#11987 (`7694abb879`, merged 2026-07-17) changed the tag-pipeline rule for `linux-java-*-parallel` benchmark jobs from `when: manual` / `allow_failure: true` to `when: never`. `when: never` removes the job from the pipeline graph entirely, which breaks the hard `needs:` references that downstream SLO/upload/notify jobs declare on it — those jobs require the referenced job to exist somewhere in the pipeline, and pipeline creation fails outright when it doesn't. No tag pipeline ran between the rule change and this investigation, so the break went unnoticed until now.

### Fix
Revert the rule change: restore `when: manual` (the job stays in the pipeline graph, just requires a manual trigger, so downstream `needs:` references still resolve) and undo the follow-up `linux-java-spring-petclinic-parallel` rules override from the same commit. This restores the pre-#11987 behavior of allowing (rather than disallowing) manual benchmark runs on tag pipelines, and unblocks tag pipeline creation.

## Test plan
- [ ] Confirm a tag pipeline (e.g. simulate a `v1.x.x` push) creates successfully with `linux-java-*-parallel` back to `when: manual`
- [ ] Confirm downstream SLO/check/upload/notify jobs resolve `needs:` correctly again on tag pipelines