### PR TITLE
Sign exploration tests image

### DIFF
--- a/.gitlab/exploration-tests.yml
+++ b/.gitlab/exploration-tests.yml
@@ -7,8 +7,19 @@ build-exploration-tests-image:
   needs: []
   tags: [ "arch:amd64" ]
   image: $REGISTRY/docker:27.3.1
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
   script:
-    - docker buildx build --tag $EXPLORATION_TESTS_IMAGE -f dd-java-agent/agent-debugger/exploration-tests/Dockerfile.exploration-tests --push dd-java-agent/agent-debugger/exploration-tests
+    - METADATA_FILE=$(mktemp)
+    - >
+      docker buildx build 
+      --tag $EXPLORATION_TESTS_IMAGE 
+      --file dd-java-agent/agent-debugger/exploration-tests/Dockerfile.exploration-tests 
+      --push 
+      --metadata-file ${METADATA_FILE}
+      dd-java-agent/agent-debugger/exploration-tests
+    - ddsign $EXPLORATION_TESTS_IMAGE --docker-metadata-file ${METADATA_FILE}
 
 .common-exploration-tests: &common-exploration-tests
   rules:

--- a/.gitlab/exploration-tests.yml
+++ b/.gitlab/exploration-tests.yml
@@ -19,7 +19,7 @@ build-exploration-tests-image:
       --push 
       --metadata-file ${METADATA_FILE}
       dd-java-agent/agent-debugger/exploration-tests
-    - ddsign $EXPLORATION_TESTS_IMAGE --docker-metadata-file ${METADATA_FILE}
+    - ddsign sign $EXPLORATION_TESTS_IMAGE --docker-metadata-file ${METADATA_FILE}
 
 .common-exploration-tests: &common-exploration-tests
   rules:


### PR DESCRIPTION
# What Does This Do
Use `ddsign` to sign the exploration tests image.

# Motivation
Image signature enforcement is being applied to Gitlab CI

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
