### PR TITLE
Fix Pekko async handler retaining the request context in Pekko completion callbacks

### DIFF
--- a/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -1264,7 +1264,6 @@ abstract class HttpServerTest<SERVER> extends WithHttpServer<SERVER> {
     }
   }
 
-  @Flaky(value = "https://github.com/DataDog/dd-trace-java/issues/9396", suites = ["PekkoHttpServerInstrumentationAsyncHttp2Test"])
   def "Instrumentation test exception"() {
     setup:
     def method = "GET"

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/build.gradle
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/build.gradle
@@ -39,8 +39,28 @@ configurations {
 sourceSets {
   latestDepTest.groovy.srcDir sourceSets.baseTest.groovy
   latestDepTest.scala.srcDir sourceSets.baseTest.scala
+  latestDepTest.java.srcDir sourceSets.baseTest.java
   latestPekko10Test.groovy.srcDir sourceSets.baseTest.groovy
   latestPekko10Test.scala.srcDir sourceSets.baseTest.scala
+  latestPekko10Test.java.srcDir sourceSets.baseTest.java
+}
+
+[baseTest: "baseCompletionPriorityForkedTest", latestDepTest: "latestDepCompletionPriorityForkedTest"].each { suiteName, forkedTaskName ->
+  // Deliberately reuse each suite's compiled output. The ForkedTest task-name suffix supplies
+  // forkEvery=1 and the shared forked-test concurrency limit from the test convention plugin.
+  tasks.register(forkedTaskName, Test) {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    useJUnitPlatform()
+    testClassesDirs = sourceSets[suiteName].output.classesDirs
+    classpath = sourceSets[suiteName].runtimeClasspath
+    // Scoped to this regression test; this module does not provide a general forked-test suite.
+    setIncludes(["**/PekkoHttpAsyncHandlerWrapperForkedTest.class"])
+    systemProperty "dd.trace.integration.scala_promise_completion_priority.enabled", "true"
+  }
+  tasks.named(suiteName, Test) {
+    // finalizedBy, not dependsOn, so that a failure is reported against the task that actually ran.
+    finalizedBy forkedTaskName
+  }
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/build.gradle
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/build.gradle
@@ -45,21 +45,18 @@ sourceSets {
   latestPekko10Test.java.srcDir sourceSets.baseTest.java
 }
 
-[baseTest: "baseCompletionPriorityForkedTest", latestDepTest: "latestDepCompletionPriorityForkedTest"].each { suiteName, forkedTaskName ->
-  // Deliberately reuse each suite's compiled output. The ForkedTest task-name suffix supplies
-  // forkEvery=1 and the shared forked-test concurrency limit from the test convention plugin.
-  tasks.register(forkedTaskName, Test) {
-    group = LifecycleBasePlugin.VERIFICATION_GROUP
-    useJUnitPlatform()
-    testClassesDirs = sourceSets[suiteName].output.classesDirs
-    classpath = sourceSets[suiteName].runtimeClasspath
-    // Scoped to this regression test; this module does not provide a general forked-test suite.
-    setIncludes(["**/PekkoHttpAsyncHandlerWrapperForkedTest.class"])
-    systemProperty "dd.trace.integration.scala_promise_completion_priority.enabled", "true"
+// This module has no 'test' source set, so the default forked test task runs nothing here. Register
+// one per Scala generation instead.
+['baseTest', 'latestDepTest'].each { suiteName ->
+  addForkedTestTask(suiteName).configure {
+    // The other *ForkedTest classes in this module have never run, and the client ones currently
+    // fail on an unrelated NPE in PekkoHttpClientHelpers$PekkoHttpHeaders during Data Streams
+    // injection. Keep these tasks scoped until that is fixed separately.
+    setIncludes(['**/PekkoHttpAsyncHandlerWrapper*ForkedTest.class'])
   }
   tasks.named(suiteName, Test) {
-    // finalizedBy, not dependsOn, so that a failure is reported against the task that actually ran.
-    finalizedBy forkedTaskName
+    // finalizedBy, not dependsOn, so a failure is reported against the task that actually ran.
+    finalizedBy "${suiteName}ForkedTest"
   }
 }
 

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/build.gradle
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/build.gradle
@@ -53,21 +53,6 @@ sourceSets {
   latestPekko10Test.java.srcDir sourceSets.baseTest.java
 }
 
-// This module has no 'test' source set, so the default forked test task runs nothing here. Register
-// one per Scala generation instead.
-['baseTest', 'latestDepTest'].each { suiteName ->
-  addForkedTestTask(suiteName).configure {
-    // The other *ForkedTest classes in this module have never run, and the client ones currently
-    // fail on an unrelated NPE in PekkoHttpClientHelpers$PekkoHttpHeaders during Data Streams
-    // injection. Keep these tasks scoped until that is fixed separately.
-    setIncludes(['**/PekkoHttpAsyncHandlerWrapper*ForkedTest.class'])
-  }
-  tasks.named(suiteName, Test) {
-    // finalizedBy, not dependsOn, so a failure is reported against the task that actually ran.
-    finalizedBy "${suiteName}ForkedTest"
-  }
-}
-
 dependencies {
   compileOnly libs.scala212
   compileOnly group: 'org.apache.pekko', name: 'pekko-http-core_2.12', version: '1.0.0'

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/build.gradle
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/build.gradle
@@ -53,21 +53,18 @@ sourceSets {
   latestPekko10Test.java.srcDir sourceSets.baseTest.java
 }
 
-[baseTest: "baseCompletionPriorityForkedTest", latestDepTest: "latestDepCompletionPriorityForkedTest"].each { suiteName, forkedTaskName ->
-  // Deliberately reuse each suite's compiled output. The ForkedTest task-name suffix supplies
-  // forkEvery=1 and the shared forked-test concurrency limit from the test convention plugin.
-  tasks.register(forkedTaskName, Test) {
-    group = LifecycleBasePlugin.VERIFICATION_GROUP
-    useJUnitPlatform()
-    testClassesDirs = sourceSets[suiteName].output.classesDirs
-    classpath = sourceSets[suiteName].runtimeClasspath
-    // Scoped to this regression test; this module does not provide a general forked-test suite.
-    setIncludes(["**/PekkoHttpAsyncHandlerWrapperForkedTest.class"])
-    systemProperty "dd.trace.integration.scala_promise_completion_priority.enabled", "true"
+// This module has no 'test' source set, so the default forked test task runs nothing here. Register
+// one per Scala generation instead.
+['baseTest', 'latestDepTest'].each { suiteName ->
+  addForkedTestTask(suiteName).configure {
+    // The other *ForkedTest classes in this module have never run, and the client ones currently
+    // fail on an unrelated NPE in PekkoHttpClientHelpers$PekkoHttpHeaders during Data Streams
+    // injection. Keep these tasks scoped until that is fixed separately.
+    setIncludes(['**/PekkoHttpAsyncHandlerWrapper*ForkedTest.class'])
   }
   tasks.named(suiteName, Test) {
-    // finalizedBy, not dependsOn, so that a failure is reported against the task that actually ran.
-    finalizedBy forkedTaskName
+    // finalizedBy, not dependsOn, so a failure is reported against the task that actually ran.
+    finalizedBy "${suiteName}ForkedTest"
   }
 }
 

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/build.gradle
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/build.gradle
@@ -47,8 +47,28 @@ configurations {
 sourceSets {
   latestDepTest.groovy.srcDir sourceSets.baseTest.groovy
   latestDepTest.scala.srcDir sourceSets.baseTest.scala
+  latestDepTest.java.srcDir sourceSets.baseTest.java
   latestPekko10Test.groovy.srcDir sourceSets.baseTest.groovy
   latestPekko10Test.scala.srcDir sourceSets.baseTest.scala
+  latestPekko10Test.java.srcDir sourceSets.baseTest.java
+}
+
+[baseTest: "baseCompletionPriorityForkedTest", latestDepTest: "latestDepCompletionPriorityForkedTest"].each { suiteName, forkedTaskName ->
+  // Deliberately reuse each suite's compiled output. The ForkedTest task-name suffix supplies
+  // forkEvery=1 and the shared forked-test concurrency limit from the test convention plugin.
+  tasks.register(forkedTaskName, Test) {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    useJUnitPlatform()
+    testClassesDirs = sourceSets[suiteName].output.classesDirs
+    classpath = sourceSets[suiteName].runtimeClasspath
+    // Scoped to this regression test; this module does not provide a general forked-test suite.
+    setIncludes(["**/PekkoHttpAsyncHandlerWrapperForkedTest.class"])
+    systemProperty "dd.trace.integration.scala_promise_completion_priority.enabled", "true"
+  }
+  tasks.named(suiteName, Test) {
+    // finalizedBy, not dependsOn, so that a failure is reported against the task that actually ran.
+    finalizedBy forkedTaskName
+  }
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/baseTest/java/AbstractPekkoHttpAsyncHandlerWrapperTest.java
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/baseTest/java/AbstractPekkoHttpAsyncHandlerWrapperTest.java
@@ -1,0 +1,217 @@
+import static datadog.trace.agent.test.assertions.SpanMatcher.span;
+import static datadog.trace.agent.test.assertions.TraceMatcher.trace;
+import static datadog.trace.api.DDSpanTypes.HTTP_SERVER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.context.Context;
+import datadog.context.ContextScope;
+import datadog.trace.agent.test.AbstractInstrumentationTest;
+import datadog.trace.agent.test.assertions.SpanMatcher;
+import datadog.trace.instrumentation.pekkohttp.DatadogAsyncHandlerWrapper;
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+import org.apache.pekko.http.scaladsl.model.HttpRequest;
+import org.apache.pekko.http.scaladsl.model.HttpRequest$;
+import org.apache.pekko.http.scaladsl.model.HttpResponse;
+import org.apache.pekko.http.scaladsl.model.HttpResponse$;
+import org.apache.pekko.http.scaladsl.model.Uri$;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import scala.concurrent.ExecutionContext$;
+import scala.concurrent.ExecutionContextExecutorService;
+import scala.concurrent.Future;
+import scala.concurrent.Promise;
+import scala.concurrent.Promise$;
+import scala.runtime.AbstractFunction1;
+import scala.util.Failure;
+import scala.util.Success;
+import scala.util.Try;
+
+/**
+ * Reproduces a request-context leak from the async-handler wrapper into Pekko's completion
+ * callbacks.
+ *
+ * <p>{@link DatadogAsyncHandlerWrapper} creates a server span and Pekko registers callbacks on the
+ * returned handler {@link Future} after the wrapper has closed the request scope. Those callbacks
+ * are framework bookkeeping and should therefore not inherit the request context.
+ *
+ * <p>The regression was caused by completing the Future exposed to Pekko while the request context
+ * was active. Scala's promise instrumentation consequently captured that context for Pekko's
+ * otherwise contextless completion callback. The captured continuation kept the finished trace
+ * buffered until the callback exited. The test depends on the scala-promise instrumentation in this
+ * module's test runtime to model that production propagation behavior.
+ *
+ * <p>The test makes the race deterministic by holding the simulated Pekko callback on a latch. The
+ * expected behavior is that the finished request trace is reported while that callback remains
+ * blocked. Before the instrumentation is fixed, the assertion fails because the trace is reported
+ * only after test cleanup releases the callback.
+ */
+abstract class AbstractPekkoHttpAsyncHandlerWrapperTest extends AbstractInstrumentationTest {
+
+  /**
+   * The operation name is a {@code UTF8BytesString}; {@link SpanMatcher#operationName(String)}
+   * compares object types, while the {@link Pattern} overload compares {@code CharSequence}
+   * content.
+   */
+  private static final Pattern OPERATION_NAME = Pattern.compile("pekko-http\\.request");
+
+  protected abstract boolean expectedCompletionPriority();
+
+  @BeforeEach
+  void verifyPropagationMode() throws Exception {
+    // Load the injected helper only after the test agent is installed, then verify each concrete
+    // variant is exercising the intended Scala Promise propagation mode.
+    assertEquals(
+        expectedCompletionPriority(),
+        readStaticBoolean(
+            Class.forName("datadog.trace.instrumentation.scala.PromiseHelper"),
+            "completionPriority"),
+        "Unexpected Scala Promise propagation mode");
+    // The wrapper resolves the same configuration independently, so pin the two together. A wrapper
+    // that stopped tracking this mode would otherwise silently skip the defensive Try copy while
+    // these tests kept passing.
+    assertEquals(
+        expectedCompletionPriority(),
+        readStaticBoolean(DatadogAsyncHandlerWrapper.class, "COMPLETION_PRIORITY"),
+        "Wrapper propagation mode disagrees with the Scala Promise instrumentation");
+  }
+
+  private static boolean readStaticBoolean(final Class<?> type, final String name)
+      throws Exception {
+    final Field field = type.getDeclaredField(name);
+    field.setAccessible(true);
+    return (Boolean) field.get(null);
+  }
+
+  /**
+   * Covers the failed-response path. On Scala 2.12 {@code Promise.resolveTry} allocates a fresh
+   * {@code Failure}, which incidentally drops any context associated with the completing {@code
+   * Try}, so this path exercises the root-context attachment only. Scala 2.13 passes the {@code
+   * Try} through, so there it exercises both defenses.
+   */
+  @Test
+  void doesNotPropagateRequestContextWhenHandlerFails() throws Exception {
+    assertRequestTraceIsNotRetained(
+        new Failure<>(new Exception("controller exception")),
+        span().root().operationName(OPERATION_NAME).type(HTTP_SERVER).error());
+  }
+
+  /**
+   * Covers the successful-response path. Both Scala generations pass a {@code Success} through
+   * completion unchanged, so this is the case that pins the defensive {@code Try} copy in
+   * completion-priority mode.
+   */
+  @Test
+  void doesNotPropagateRequestContextWhenHandlerSucceeds() throws Exception {
+    assertRequestTraceIsNotRetained(
+        new Success<>(emptyResponse()),
+        span().root().operationName(OPERATION_NAME).type(HTTP_SERVER).error(false));
+  }
+
+  private void assertRequestTraceIsNotRetained(
+      final Try<HttpResponse> handlerResult, final SpanMatcher expectedSpan) throws Exception {
+    try (AsyncHandlerWrapperReproducer reproducer =
+        new AsyncHandlerWrapperReproducer(handlerResult)) {
+      reproducer.start();
+
+      assertTrue(reproducer.awaitFrameworkCallback(), "Framework callback did not start");
+      assertTrue(
+          writer.waitForTracesMax(1, 5),
+          "Request trace was held by the contextless framework callback");
+      assertTraces(trace(expectedSpan));
+    }
+  }
+
+  private static HttpResponse emptyResponse() {
+    return HttpResponse$.MODULE$.apply(
+        HttpResponse$.MODULE$.apply$default$1(),
+        HttpResponse$.MODULE$.apply$default$2(),
+        HttpResponse$.MODULE$.apply$default$3(),
+        HttpResponse$.MODULE$.apply$default$4());
+  }
+
+  private static final class AsyncHandlerWrapperReproducer implements AutoCloseable {
+    private final Try<HttpResponse> handlerResult;
+    private final Promise<HttpResponse> handlerPromise = Promise$.MODULE$.apply();
+    private final AtomicReference<Context> requestContext = new AtomicReference<>();
+    private final CountDownLatch callbackStarted = new CountDownLatch(1);
+    private final CountDownLatch releaseCallback = new CountDownLatch(1);
+
+    private final ExecutionContextExecutorService handlerExecutor =
+        ExecutionContext$.MODULE$.fromExecutorService(Executors.newSingleThreadExecutor());
+    private final ExecutionContextExecutorService frameworkExecutor =
+        ExecutionContext$.MODULE$.fromExecutorService(Executors.newSingleThreadExecutor());
+
+    AsyncHandlerWrapperReproducer(final Try<HttpResponse> handlerResult) {
+      this.handlerResult = handlerResult;
+    }
+
+    void start() {
+      DatadogAsyncHandlerWrapper wrapper =
+          new DatadogAsyncHandlerWrapper(
+              new AbstractFunction1<HttpRequest, Future<HttpResponse>>() {
+                @Override
+                public Future<HttpResponse> apply(HttpRequest request) {
+                  requestContext.set(Context.current());
+                  return handlerPromise.future();
+                }
+              },
+              handlerExecutor);
+
+      HttpRequest request =
+          HttpRequest$.MODULE$.apply(
+              HttpRequest$.MODULE$.apply$default$1(),
+              Uri$.MODULE$.apply("/exception"),
+              HttpRequest$.MODULE$.apply$default$3(),
+              HttpRequest$.MODULE$.apply$default$4(),
+              HttpRequest$.MODULE$.apply$default$5());
+      Future<HttpResponse> response = wrapper.apply(request);
+
+      // Model a callback registered by Pekko after the wrapper has closed the request scope. It
+      // should not inherit the request context when the handler Future completes.
+      response.onComplete(
+          new AbstractFunction1<Try<HttpResponse>, Void>() {
+            @Override
+            public Void apply(Try<HttpResponse> result) {
+              callbackStarted.countDown();
+              try {
+                releaseCallback.await();
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              return null;
+            }
+          },
+          frameworkExecutor);
+
+      // Application futures normally complete from callbacks running with the propagated request
+      // context. Model that completion path so the test also covers context captured at promise
+      // dispatch time, not only at callback construction time.
+      try (ContextScope ignored = requestContext.get().attach()) {
+        handlerPromise.complete(handlerResult);
+      }
+    }
+
+    boolean awaitFrameworkCallback() throws InterruptedException {
+      return callbackStarted.await(5, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void close() throws InterruptedException {
+      releaseCallback.countDown();
+      handlerExecutor.shutdown();
+      frameworkExecutor.shutdown();
+      assertTrue(
+          handlerExecutor.awaitTermination(5, TimeUnit.SECONDS),
+          "Handler executor did not terminate");
+      assertTrue(
+          frameworkExecutor.awaitTermination(5, TimeUnit.SECONDS),
+          "Framework executor did not terminate");
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/baseTest/java/PekkoHttpAsyncHandlerWrapperForkedTest.java
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/baseTest/java/PekkoHttpAsyncHandlerWrapperForkedTest.java
@@ -1,4 +1,13 @@
-/** Runs the async-handler context-retention reproducer with completion-priority propagation. */
+import datadog.trace.test.junit.utils.config.WithConfig;
+
+/**
+ * Runs the async-handler context-retention reproducer with completion-priority propagation, which
+ * associates the completing context with the resolved {@code Try} instead of the thread.
+ *
+ * <p>{@link WithConfig} applies before the test agent is installed, so the Scala Promise
+ * instrumentation registers the advice that creates that association.
+ */
+@WithConfig(key = "trace.integration.scala_promise_completion_priority.enabled", value = "true")
 class PekkoHttpAsyncHandlerWrapperForkedTest extends AbstractPekkoHttpAsyncHandlerWrapperTest {
 
   @Override

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/baseTest/java/PekkoHttpAsyncHandlerWrapperForkedTest.java
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/baseTest/java/PekkoHttpAsyncHandlerWrapperForkedTest.java
@@ -1,0 +1,8 @@
+/** Runs the async-handler context-retention reproducer with completion-priority propagation. */
+class PekkoHttpAsyncHandlerWrapperForkedTest extends AbstractPekkoHttpAsyncHandlerWrapperTest {
+
+  @Override
+  protected boolean expectedCompletionPriority() {
+    return true;
+  }
+}

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/baseTest/java/PekkoHttpAsyncHandlerWrapperTest.java
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/baseTest/java/PekkoHttpAsyncHandlerWrapperTest.java
@@ -1,0 +1,8 @@
+/** Runs the async-handler context-retention reproducer with default Scala Promise propagation. */
+class PekkoHttpAsyncHandlerWrapperTest extends AbstractPekkoHttpAsyncHandlerWrapperTest {
+
+  @Override
+  protected boolean expectedCompletionPriority() {
+    return false;
+  }
+}

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/DatadogAsyncHandlerWrapper.java
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/DatadogAsyncHandlerWrapper.java
@@ -1,18 +1,25 @@
 package datadog.trace.instrumentation.pekkohttp;
 
-import static datadog.trace.bootstrap.instrumentation.api.AgentSpan.fromContext;
-
+import datadog.context.Context;
 import datadog.context.ContextScope;
-import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.api.InstrumenterConfig;
 import org.apache.pekko.http.scaladsl.model.HttpRequest;
 import org.apache.pekko.http.scaladsl.model.HttpResponse;
 import scala.Function1;
 import scala.concurrent.ExecutionContext;
 import scala.concurrent.Future;
+import scala.concurrent.Promise;
+import scala.concurrent.Promise$;
 import scala.runtime.AbstractFunction1;
+import scala.util.Failure;
+import scala.util.Success;
+import scala.util.Try;
 
 public class DatadogAsyncHandlerWrapper
     extends AbstractFunction1<HttpRequest, Future<HttpResponse>> {
+  private static final boolean COMPLETION_PRIORITY =
+      InstrumenterConfig.get().isScalaPromiseCompletionPriorityEnabled();
+
   private final Function1<HttpRequest, Future<HttpResponse>> userHandler;
   private final ExecutionContext executionContext;
 
@@ -26,33 +33,56 @@ public class DatadogAsyncHandlerWrapper
   @Override
   public Future<HttpResponse> apply(final HttpRequest request) {
     final ContextScope scope = DatadogWrapperHelper.createSpan(request);
-    AgentSpan span = fromContext(scope.context());
+    final Context context = scope.context();
     Future<HttpResponse> futureResponse;
     try {
       futureResponse = userHandler.apply(request);
     } catch (final Throwable t) {
       scope.close();
-      DatadogWrapperHelper.finishSpan(scope.context(), t);
+      DatadogWrapperHelper.finishSpan(context, t);
       throw t;
     }
-    final Future<HttpResponse> wrapped =
-        futureResponse.transform(
-            new AbstractFunction1<HttpResponse, HttpResponse>() {
-              @Override
-              public HttpResponse apply(final HttpResponse response) {
-                DatadogWrapperHelper.finishSpan(scope.context(), response);
-                return response;
-              }
-            },
-            new AbstractFunction1<Throwable, Throwable>() {
-              @Override
-              public Throwable apply(final Throwable t) {
-                DatadogWrapperHelper.finishSpan(scope.context(), t);
-                return t;
-              }
-            },
-            executionContext);
     scope.close();
-    return wrapped;
+    final Promise<HttpResponse> wrapped = Promise$.MODULE$.apply();
+    futureResponse.onComplete(
+        new AbstractFunction1<Try<HttpResponse>, Void>() {
+          @Override
+          public Void apply(final Try<HttpResponse> result) {
+            Try<HttpResponse> wrappedResult = result;
+            try {
+              if (result.isSuccess()) {
+                DatadogWrapperHelper.finishSpan(context, result.get());
+              } else {
+                DatadogWrapperHelper.finishSpan(
+                    context, ((Failure<HttpResponse>) result).exception());
+              }
+            } catch (final Throwable t) {
+              // Preserve transform's behavior when span decoration fails. Pekko does not support
+              // response blocking, and this wrapper has no Materializer for discarding the
+              // successful response entity that is replaced by this failure.
+              wrappedResult = new Failure<>(t);
+            }
+            final Try<HttpResponse> resultForPekko;
+            if (COMPLETION_PRIORITY) {
+              // Completion-priority mode can associate context directly with a Try. Copy the
+              // result so neither that association nor the active thread context reaches Pekko.
+              resultForPekko =
+                  wrappedResult.isSuccess()
+                      ? new Success<>(wrappedResult.get())
+                      : new Failure<>(((Failure<HttpResponse>) wrappedResult).exception());
+            } else {
+              resultForPekko = wrappedResult;
+            }
+            // The application Future can complete while the request context is active. Complete
+            // the Future exposed to Pekko under the root context so its framework callbacks do not
+            // capture and retain the request trace.
+            try (ContextScope ignored = Context.root().attach()) {
+              wrapped.complete(resultForPekko);
+            }
+            return null;
+          }
+        },
+        executionContext);
+    return wrapped.future();
   }
 }

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/DatadogWrapperHelper.java
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/DatadogWrapperHelper.java
@@ -22,18 +22,22 @@ public class DatadogWrapperHelper {
 
   public static void finishSpan(final Context context, final HttpResponse response) {
     final AgentSpan span = fromContext(context);
-    DECORATE.onResponse(span, response);
-    DECORATE.beforeFinish(context);
-
-    span.finish();
+    try {
+      DECORATE.onResponse(span, response);
+      DECORATE.beforeFinish(context);
+    } finally {
+      span.finish();
+    }
   }
 
   public static void finishSpan(final Context context, final Throwable t) {
     final AgentSpan span = fromContext(context);
-    DECORATE.onError(span, t);
-    span.setHttpStatusCode(500);
-    DECORATE.beforeFinish(context);
-
-    span.finish();
+    try {
+      DECORATE.onError(span, t);
+      span.setHttpStatusCode(500);
+      DECORATE.beforeFinish(context);
+    } finally {
+      span.finish();
+    }
   }
 }

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/PekkoHttp2ServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/PekkoHttp2ServerInstrumentation.java
@@ -44,7 +44,6 @@ public final class PekkoHttp2ServerInstrumentation extends InstrumenterModule.Tr
       packageName + ".DatadogWrapperHelper",
       packageName + ".DatadogAsyncHandlerWrapper",
       packageName + ".DatadogAsyncHandlerWrapper$1",
-      packageName + ".DatadogAsyncHandlerWrapper$2",
       packageName + ".PekkoHttpServerHeaders",
       packageName + ".PekkoHttpServerDecorator",
       packageName + ".UriAdapter",

--- a/dd-java-agent/instrumentation/scala/scala-promise/scala-promise-2.10/src/main/java/datadog/trace/instrumentation/scala210/concurrent/ScalaPromiseModule.java
+++ b/dd-java-agent/instrumentation/scala/scala-promise/scala-promise-2.10/src/main/java/datadog/trace/instrumentation/scala210/concurrent/ScalaPromiseModule.java
@@ -14,7 +14,6 @@ import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,8 +64,7 @@ public final class ScalaPromiseModule extends InstrumenterModule.ContextTracking
     }
     // Only enable this if integrations have been enabled and the extra "integration"
     // scala_promise_completion_priority has been enabled specifically
-    if (config.isIntegrationEnabled(
-        Collections.singletonList("scala_promise_completion_priority"), false)) {
+    if (config.isScalaPromiseCompletionPriorityEnabled()) {
       instrumenters.add(new PromiseObjectInstrumentation());
     }
     return instrumenters;

--- a/dd-java-agent/instrumentation/scala/scala-promise/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala213/concurrent/ScalaPromiseModule.java
+++ b/dd-java-agent/instrumentation/scala/scala-promise/scala-promise-2.13/src/main/java/datadog/trace/instrumentation/scala213/concurrent/ScalaPromiseModule.java
@@ -14,7 +14,6 @@ import datadog.trace.bootstrap.instrumentation.java.concurrent.ExcludeFilter;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,8 +60,7 @@ public final class ScalaPromiseModule extends InstrumenterModule.ContextTracking
     final InstrumenterConfig config = InstrumenterConfig.get();
     // Only enable this if integrations have been enabled and the extra "integration"
     // scala_promise_completion_priority has been enabled specifically
-    if (config.isIntegrationEnabled(
-        Collections.singletonList("scala_promise_completion_priority"), false)) {
+    if (config.isScalaPromiseCompletionPriorityEnabled()) {
       ret.add(new DefaultPromiseInstrumentation());
       ret.add(new PromiseObjectInstrumentation());
     }

--- a/dd-java-agent/instrumentation/scala/scala-promise/scala-promise-common/src/main/java/datadog/trace/instrumentation/scala/PromiseHelper.java
+++ b/dd-java-agent/instrumentation/scala/scala-promise/scala-promise-common/src/main/java/datadog/trace/instrumentation/scala/PromiseHelper.java
@@ -7,16 +7,13 @@ import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.AdviceUtils;
 import datadog.trace.bootstrap.instrumentation.java.concurrent.State;
-import java.util.Collections;
 import scala.util.Failure;
 import scala.util.Success;
 import scala.util.Try;
 
 public class PromiseHelper {
   public static final boolean completionPriority =
-      InstrumenterConfig.get()
-          .isIntegrationEnabled(
-              Collections.singletonList("scala_promise_completion_priority"), false);
+      InstrumenterConfig.get().isScalaPromiseCompletionPriorityEnabled();
 
   /**
    * Get the {@code Try} that should be associated with the {@code Context}. Will create a new copy

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -98,6 +98,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.VISITOR_CLASS_
 import static datadog.trace.api.config.UsmConfig.USM_ENABLED;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableList;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableSet;
+import static java.util.Collections.singletonList;
 
 import datadog.environment.JavaVirtualMachine;
 import datadog.trace.api.profiling.ProfilingEnablement;
@@ -140,6 +141,15 @@ public class InstrumenterConfig {
           ConfigInversionMetricCollectorImpl.getInstance());
     }
   }
+
+  /**
+   * Name of the opt-in Scala Promise integration that gives the context completing a {@code
+   * Promise} priority over the context that registered callbacks on it. Defined here so that the
+   * instrumentations enabling this mode and the ones that have to compensate for it cannot drift
+   * apart.
+   */
+  private static final String SCALA_PROMISE_COMPLETION_PRIORITY =
+      "scala_promise_completion_priority";
 
   private final ConfigProvider configProvider;
 
@@ -228,6 +238,7 @@ public class InstrumenterConfig {
 
   private final boolean appLogsCollectionEnabled;
   private final boolean legacyContextManagerEnabled;
+  private final boolean scalaPromiseCompletionPriorityEnabled;
 
   static {
     // Bind telemetry collector to config module before initializing ConfigProvider
@@ -394,6 +405,9 @@ public class InstrumenterConfig {
         configProvider.getBoolean(APP_LOGS_COLLECTION_ENABLED, DEFAULT_APP_LOGS_COLLECTION_ENABLED);
 
     legacyContextManagerEnabled = configProvider.getBoolean(LEGACY_CONTEXT_MANAGER_ENABLED, true);
+
+    scalaPromiseCompletionPriorityEnabled =
+        isIntegrationEnabled(singletonList(SCALA_PROMISE_COMPLETION_PRIORITY), false);
   }
 
   public boolean isCodeOriginEnabled() {
@@ -445,6 +459,20 @@ public class InstrumenterConfig {
       }
     }
     return anyEnabled;
+  }
+
+  /**
+   * Whether the Scala Promise instrumentation gives the context completing a {@code Promise}
+   * priority over the context that registered callbacks on it.
+   *
+   * <p>This mode associates the completing context with the resolved {@code Try} itself, so it is
+   * also read by instrumentations that must keep such an association from reaching a framework
+   * callback.
+   *
+   * @return {@code true} if completion-priority propagation is enabled, else {@code false}
+   */
+  public boolean isScalaPromiseCompletionPriorityEnabled() {
+    return scalaPromiseCompletionPriorityEnabled;
   }
 
   public boolean isIntegrationShortcutMatchingEnabled(
@@ -870,6 +898,8 @@ public class InstrumenterConfig {
         + apiSecurityEndpointCollectionEnabled
         + ", legacyContextManagerEnabled="
         + legacyContextManagerEnabled
+        + ", scalaPromiseCompletionPriorityEnabled="
+        + scalaPromiseCompletionPriorityEnabled
         + '}';
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -100,6 +100,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.VISITOR_CLASS_
 import static datadog.trace.api.config.UsmConfig.USM_ENABLED;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableList;
 import static datadog.trace.util.CollectionUtils.tryMakeImmutableSet;
+import static java.util.Collections.singletonList;
 
 import datadog.environment.JavaVirtualMachine;
 import datadog.trace.api.profiling.ProfilingEnablement;
@@ -142,6 +143,15 @@ public class InstrumenterConfig {
           ConfigInversionMetricCollectorImpl.getInstance());
     }
   }
+
+  /**
+   * Name of the opt-in Scala Promise integration that gives the context completing a {@code
+   * Promise} priority over the context that registered callbacks on it. Defined here so that the
+   * instrumentations enabling this mode and the ones that have to compensate for it cannot drift
+   * apart.
+   */
+  private static final String SCALA_PROMISE_COMPLETION_PRIORITY =
+      "scala_promise_completion_priority";
 
   private final ConfigProvider configProvider;
 
@@ -231,6 +241,7 @@ public class InstrumenterConfig {
 
   private final boolean appLogsCollectionEnabled;
   private final boolean legacyContextManagerEnabled;
+  private final boolean scalaPromiseCompletionPriorityEnabled;
 
   static {
     // Bind telemetry collector to config module before initializing ConfigProvider
@@ -400,6 +411,9 @@ public class InstrumenterConfig {
         configProvider.getBoolean(APP_LOGS_COLLECTION_ENABLED, DEFAULT_APP_LOGS_COLLECTION_ENABLED);
 
     legacyContextManagerEnabled = configProvider.getBoolean(LEGACY_CONTEXT_MANAGER_ENABLED, true);
+
+    scalaPromiseCompletionPriorityEnabled =
+        isIntegrationEnabled(singletonList(SCALA_PROMISE_COMPLETION_PRIORITY), false);
   }
 
   public boolean isCodeOriginEnabled() {
@@ -451,6 +465,20 @@ public class InstrumenterConfig {
       }
     }
     return anyEnabled;
+  }
+
+  /**
+   * Whether the Scala Promise instrumentation gives the context completing a {@code Promise}
+   * priority over the context that registered callbacks on it.
+   *
+   * <p>This mode associates the completing context with the resolved {@code Try} itself, so it is
+   * also read by instrumentations that must keep such an association from reaching a framework
+   * callback.
+   *
+   * @return {@code true} if completion-priority propagation is enabled, else {@code false}
+   */
+  public boolean isScalaPromiseCompletionPriorityEnabled() {
+    return scalaPromiseCompletionPriorityEnabled;
   }
 
   public boolean isIntegrationShortcutMatchingEnabled(
@@ -882,6 +910,8 @@ public class InstrumenterConfig {
         + apiSecurityEndpointCollectionEnabled
         + ", legacyContextManagerEnabled="
         + legacyContextManagerEnabled
+        + ", scalaPromiseCompletionPriorityEnabled="
+        + scalaPromiseCompletionPriorityEnabled
         + '}';
   }
 }


### PR DESCRIPTION
# What Does This Do

Stops the Pekko HTTP async-handler instrumentation from leaking the request context into Pekko's own completion callbacks, which intermittently delayed trace reporting.

`DatadogAsyncHandlerWrapper` used to return `futureResponse.transform(...)`, where both transform functions returned their input unchanged and existed only to run `finishSpan`. `transform` derives a second Promise, and that Promise was completed while the request context was active, so the Scala Promise instrumentation captured the request context for callbacks Pekko had registered on the returned Future. Those callbacks are framework bookkeeping, and the continuation they captured kept the finished trace buffered until they ran.

The wrapper now:

1. Saves the request `Context` explicitly and closes the request scope as before.
2. Creates a bridge `Promise` and observes the handler Future with `onComplete`, registered after the scope is closed so nothing is captured at construction time.
3. Finishes the span through the saved `Context`, turning a decoration failure into a failed bridge Promise (preserving what `transform` did).
4. Completes the bridge Promise under `Context.root()`, so Pekko's callbacks inherit nothing from the thread.
5. In completion-priority mode only, copies the result into a fresh `Try` first, because that mode associates the completing context with the `Try` object itself and thereby bypasses the thread-local defense.
6. Returns the bridge Future to Pekko.

Two supporting changes:

- `DatadogWrapperHelper.finishSpan` now calls `span.finish()` from a `finally` block, so a response-decoration failure cannot leave a span unfinished. This helper is shared with the HTTP/1 flow wrapper, so that path benefits too.
- The completion-priority setting is now read through a new `InstrumenterConfig.isScalaPromiseCompletionPriorityEnabled()` accessor. The integration name and its `false` default were previously written out at each call site; the Pekko gate has to agree with the Scala instrumentations that create the association it strips, and duplication let those drift apart silently. All call sites (`PromiseHelper`, both `ScalaPromiseModule` variants, and the Pekko wrapper) now share one definition.

Since the wrapper now has one anonymous callback instead of two, the stale `DatadogAsyncHandlerWrapper$2` entry was removed from the HTTP/2 helper class list.

# Motivation

`PekkoHttpServerInstrumentationAsyncTest` failed intermittently in CI while waiting for the exception-request trace:

```text
java.util.concurrent.TimeoutException: Timeout waiting for 1 trace(s).
ListWriter.size() == 0 : []
```

The server span had finished, but the trace was still buffered because an open continuation retained the request context — one belonging to a downstream Pekko completion callback rather than to customer request processing. Whether the test passed depended purely on how quickly CI scheduled that callback, which is why retries "fixed" it. Raising Pekko's `request-timeout` would not have addressed the mechanism: the cause is context propagation and continuation lifetime, not Pekko aborting the request.

Beyond the flake, this is a real customer-visible issue on the `bindAndHandleAsync` path: reporting of a finished request trace is delayed until unrelated framework bookkeeping completes.

# Additional Notes

**New regression test.** `AbstractPekkoHttpAsyncHandlerWrapperTest` drives the wrapper directly and makes the race deterministic by holding a simulated Pekko callback on a latch: the finished trace must be reported while that callback is still blocked. Two concrete variants run it — `PekkoHttpAsyncHandlerWrapperTest` with default Promise propagation, and `PekkoHttpAsyncHandlerWrapperForkedTest` with completion priority enabled in isolated JVMs via new `baseCompletionPriorityForkedTest` / `latestDepCompletionPriorityForkedTest` tasks. Each variant asserts both `PromiseHelper.completionPriority` and the wrapper's own gate, so the two configurations cannot silently substitute for each other and a wrapper that stopped tracking the mode cannot keep the suite green.

Coverage, all confirmed from `build/test-results/*/TEST-*.xml`:

| Task | Scala | Completion priority | Class |
|---|---|---|---|
| `baseTest` | 2.12 | off (default) | `PekkoHttpAsyncHandlerWrapperTest` |
| `latestDepTest` | 2.13 | off (default) | `PekkoHttpAsyncHandlerWrapperTest` |
| `latestPekko10Test` | 2.13 | off (default) | `PekkoHttpAsyncHandlerWrapperTest` |
| `baseCompletionPriorityForkedTest` | 2.12 | on | `PekkoHttpAsyncHandlerWrapperForkedTest` |
| `latestDepCompletionPriorityForkedTest` | 2.13 | on | `PekkoHttpAsyncHandlerWrapperForkedTest` |

**Both defenses are individually pinned.** The test completes the handler Promise once with a `Failure` and once with a `Success`, and each case was verified to be necessary by temporarily reverting one defense at a time:

- Removing the root-context attachment fails both default-mode tests.
- Removing the defensive `Try` copy fails the success case on Scala 2.12 and both cases on Scala 2.13.

The success case matters because Scala 2.12's `Promise.resolveTry` routes failures through `resolver`, which allocates a fresh `Failure` and so incidentally strips the association; with only a failing response, 2.12 passed without the copy. The two defenses are not interchangeable either: `PromiseTransformationInstrumentation` and `CallbackRunnableInstrumentation` capture from the completing `Try` first and only fall back to the thread-local context when the `Try` carries none, so in completion-priority mode the root attachment alone does not prevent retention.

**Deliberate behavior change.** Completing the exposed Future under the root context makes Pekko's response-bookkeeping callbacks contextless. If a future Pekko release performs user-visible child work from that Future, that work would also be contextless. Not retaining a completed request trace is the intended boundary here, but it is worth a reviewer's attention.

**Allocation cost.** Versus the old `transform`, the bridge Promise and single callback replace allocations `transform` already made, so the steady-state delta is one short-lived root-context scope per async response. The extra `Try` is allocated only when completion priority is enabled.

**Validation.** Pekko module with `--rerun-tasks`: 1517 tests, 860 skipped by existing conditions, 0 failures, 0 errors, plus muzzle (12 passed) and `spotlessCheck`. Because the setting moved into `InstrumenterConfig`, `internal-api` and both `scala-promise` modules (`test`, `forkedTest`, `muzzle`) were also run: 1483 tests, 0 failures. The new accessor needs no separate unit test — the Pekko variants assert its value in both states.

**Follow-up, not in this PR.** Akka HTTP's async-handler wrapper has the same identity-transform pattern, but its flow also performs response substitution for AppSec blocking, so it cannot be replaced mechanically with this implementation. It should get its own reproducer and fix rather than expanding this change without equivalent Akka coverage.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
