### PR TITLE
Allow forked test tasks for source sets other than test

### DIFF
--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -150,13 +150,8 @@ ext.testcontainersLimit = gradle.sharedServices.registerIfAbsent("testcontainers
   maxParallelUsages = project.findProperty("testcontainersMaxParallelUsages").toInteger()
 }
 
-// Task for tests that want to run forked in their own separate JVM
-tasks.register('forkedTest', Test) {
-  group = LifecycleBasePlugin.VERIFICATION_GROUP
-  useJUnitPlatform()
-  testClassesDirs = sourceSets.test.output.classesDirs
-  classpath = sourceSets.test.runtimeClasspath
-}
+// Every project gets a forked test task for its default 'test' source set.
+addForkedTestTask('test')
 
 // testRuntimeActivation is registered in individual module build files after this convention is
 // applied, so tasks.named() won't work here — use a lazy hook that intercepts it on registration.

--- a/gradle/test-suites.gradle
+++ b/gradle/test-suites.gradle
@@ -77,3 +77,29 @@ ext.addTestSuiteForDir = { testSuiteName, dirName ->
 ext.addTestSuite = { testSuiteName ->
   ext.addTestSuiteForDir(testSuiteName, testSuiteName)
 }
+
+// Registers a task that runs the '*ForkedTest' classes of a source set, each in its own JVM.
+//
+// The task name ends in 'ForkedTest', which is what makes the test convention plugin restrict it to
+// '**/*ForkedTest*', set forkEvery=1 and apply the shared forked-test concurrency limit. 'check',
+// 'allTests' and 'allLatestDepTests' pick the task up automatically, because they match Test tasks
+// by type rather than by name.
+//
+// Modules whose tests live in the default 'test' source set get 'forkedTest' registered for them by
+// java_no_deps.gradle. Modules that use their own suites instead - for example to compile the same
+// tests against several Scala versions - have no 'test' sources, so their forked tests never run
+// unless they opt in:
+//
+//   addTestSuite('baseTest')
+//   addForkedTestTask('baseTest')  // registers 'baseTestForkedTest'
+//
+// Returns the TaskProvider so callers can configure the task further.
+ext.addForkedTestTask = { String sourceSetName ->
+  def taskName = sourceSetName == 'test' ? 'forkedTest' : "${sourceSetName}ForkedTest"
+  return tasks.register(taskName, Test) {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    useJUnitPlatform()
+    testClassesDirs = sourceSets[sourceSetName].output.classesDirs
+    classpath = sourceSets[sourceSetName].runtimeClasspath
+  }
+}


### PR DESCRIPTION
# What Does This Do

Lets a module register a forked-test task for a source set other than `test`.

`gradle/java_no_deps.gradle` registered a single hardcoded `forkedTest` task bound to `sourceSets.test`. This turns that registration into a reusable helper next to its siblings in `gradle/test-suites.gradle`, and calls it with `'test'` from the same place as before:

```groovy
ext.addForkedTestTask = { String sourceSetName ->
  def taskName = sourceSetName == 'test' ? 'forkedTest' : "${sourceSetName}ForkedTest"
  return tasks.register(taskName, Test) {
    group = LifecycleBasePlugin.VERIFICATION_GROUP
    useJUnitPlatform()
    testClassesDirs = sourceSets[sourceSetName].output.classesDirs
    classpath = sourceSets[sourceSetName].runtimeClasspath
  }
}
```

A module with its own suites now opts in with one line:

```groovy
addTestSuite('baseTest')
addForkedTestTask('baseTest')  // registers 'baseTestForkedTest'
```

No behaviour changes for any existing module: `forkedTest` is still registered for every project, with the same name and the same configuration.

# Motivation

Modules that do not use the default `test` source set silently do not run their forked tests.

The convention plugin excludes `**/*ForkedTest*` from every non-forked Test task, and the only task that runs them was bound to `sourceSets.test`. A module that keeps its tests in its own suites — for example to compile the same tests against several Scala versions — therefore has no task that runs its `*ForkedTest` classes at all.

Two modules are in exactly that state today, with forked tests that have never executed:

- `dd-java-agent/instrumentation/pekko/pekko-http-1.0` — 6 classes in `src/baseTest`
- `dd-java-agent/instrumentation/netty/netty-3.8` — 2 classes in `src/latestDepTest`

This PR only provides the mechanism. Switching those modules on is deliberately left out, because their dormant tests do not currently pass — running pekko's surfaces a real NPE in `PekkoHttpClientHelpers$PekkoHttpHeaders` during Data Streams injection — and each needs its own investigation.

# Additional Notes

This PR only adds the helper; enabling it in existing modules will be handled separately.

Validation:

- `:internal-api:forkedTest` passed 6 tests, confirming the default `test` source-set behavior is unchanged.
- A temporary Pekko opt-in registered the custom-source-set forked tasks and ran 146 test cases with no failures (86 conditionally skipped). The opt-in was reverted after validation.
- `spotlessGroovyGradleCheck` passed.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
