### PR TITLE
Extend poll time for Maven Central artifact verification job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1438,12 +1438,10 @@ verify_maven_central_deployment:
         "https://repo1.maven.org/maven2/com/datadoghq/dd-trace-api/${VERSION}/dd-trace-api-${VERSION}.jar"
         "https://repo1.maven.org/maven2/com/datadoghq/dd-trace-ot/${VERSION}/dd-trace-ot-${VERSION}.jar"
       )
-      # Try once immediately (fast path on job retry), then wait 5 mins for initial propagation,
-      # then try 4 more times with a minute delay between each retry.
+      # Try once immediately (fast path on job retry), then every 5 mins for 45 mins.
       TRY=0
-      MAX_TRIES=6
-      INITIAL_DELAY=300
-      RETRY_DELAY=60
+      MAX_TRIES=10
+      RETRY_DELAY=300
       while [ $TRY -lt $MAX_TRIES ]; do
         ARTIFACTS_AVAILABLE=true
         for URL in "${ARTIFACT_URLS[@]}"; do
@@ -1457,14 +1455,10 @@ verify_maven_central_deployment:
         fi
         TRY=$((TRY + 1))
         if [ $TRY -eq $MAX_TRIES ]; then
-          echo "The release was not available after 10 mins. Manually re-run the job to try again."
+          echo "The release was not available after 45 mins. Manually re-run the job to try again."
           exit 1
         fi
-        if [ $TRY -eq 1 ]; then
-          sleep $INITIAL_DELAY
-        else
-          sleep $RETRY_DELAY
-        fi
+        sleep $RETRY_DELAY
       done
 
 publishing-gate:


### PR DESCRIPTION
# What Does This Do

Extend the poll time for the `verify_maven_central_deployment` job to check every 5 min for 45 min. 

# Motivation

The publishing job takes ~20 min to execute after manually publishing the artifact from staging, so previously we _always_ had to re-run the job. By extending the poll-time to 45 min, we should catch most deployments without running the job infinitely.

# Additional Notes

The job can still be manually re-run if publishing takes > 45 min.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
