### PR TITLE
Add `is_crash` tag to crash report

### DIFF
--- a/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/CrashUploader.java
+++ b/dd-java-agent/agent-crashtracking/src/main/java/datadog/crashtracking/CrashUploader.java
@@ -153,6 +153,7 @@ public final class CrashUploader {
     if (!tagsBuilder.toString().isEmpty()) {
       tagsBuilder.append(",");
     }
+    tagsBuilder.append("is_crash:true").append(',');
     tagsBuilder.append(VersionInfo.LIBRARY_VERSION_TAG).append('=').append(VersionInfo.VERSION);
     // PID can be empty if we cannot find it out from the system
     if (!PidHelper.getPid().isEmpty()) {
@@ -446,7 +447,7 @@ public final class CrashUploader {
           writer.name("tags").value(tagsForPing(storedConfig.reportUUID));
         } else {
           writer.name("level").value("ERROR");
-          writer.name("tags").value("severity:crash");
+          writer.name("tags").value("severity:crash,is_crash:true");
           writer.name("is_sensitive").value(true);
           writer.name("is_crash").value(true);
         }

--- a/dd-java-agent/agent-crashtracking/src/test/java/datadog/crashtracking/CrashUploaderTest.java
+++ b/dd-java-agent/agent-crashtracking/src/test/java/datadog/crashtracking/CrashUploaderTest.java
@@ -103,6 +103,7 @@ public class CrashUploaderTest {
     assertEquals(SERVICE, event.get("service").asText());
     assertEquals(CRASH, event.get("message").asText());
     assertEquals("ERROR", event.get("level").asText());
+    assertTrue(event.get("ddtags").asText().contains("is_crash:true"));
   }
 
   @Test
@@ -124,6 +125,7 @@ public class CrashUploaderTest {
     assertEquals(
         readFileAsString("sample-stacktrace.txt"), event.get("error").get("stack").asText());
     assertEquals("ERROR", event.get("level").asText());
+    assertTrue(event.get("ddtags").asText().contains("is_crash:true"));
   }
 
   private String readFileAsString(String resource) throws IOException {
@@ -297,7 +299,7 @@ public class CrashUploaderTest {
     assertThatJson(extracted.toJson())
         .whenIgnoringPaths("os_info", "metadata", "experimental")
         .isEqualTo(expected.toJson());
-    assertEquals("severity:crash", event.get("payload").get(0).get("tags").asText());
+    assertEquals("severity:crash,is_crash:true", event.get("payload").get(0).get("tags").asText());
     assertCommonPayload(event);
   }
 


### PR DESCRIPTION
# What Does This Do
Adds `is_crash` tag to crash reports


# Motivation
QOL improvement for querying + parity with other runtimes

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
