### PR TITLE
fix(12155): set aws.queue.name tag from QueueUrl field in aws-sdk/sqs instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/aws-java/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sdk-2.2/src/main/java/datadog/trace/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -153,6 +153,10 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
             url -> {
               span.setTag(InstrumentationTags.AWS_QUEUE_URL, url);
               setPeerService(span, InstrumentationTags.AWS_QUEUE_URL, url);
+              int lastSlash = url.lastIndexOf('/');
+              if (lastSlash >= 0 && lastSlash < url.length() - 1) {
+                setQueueName(span, url.substring(lastSlash + 1));
+              }
             });
     request.getValueForField("QueueName", String.class).ifPresent(name -> setQueueName(span, name));
 

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
@@ -178,7 +178,7 @@ abstract class Aws2ClientTest extends VersionedNamingTestBase {
               checkPeerService = true
             }
             urlTags("${server.address}${path}", ExpectedQueryParams.getExpectedQueryParams(operation))
-            if (operation == "SendMessage") {
+            if (operation == "SendMessage" || operation == "SendMessageBatch") {
               // this is a corner case. The issues is that the aws integration should not set the service name
               // but it's doing it.
               serviceNameSource "java-aws-sdk"
@@ -216,13 +216,33 @@ abstract class Aws2ClientTest extends VersionedNamingTestBase {
             <ResponseMetadata><RequestId>27daac76-34dd-47df-bd01-1f6e873584a0</RequestId></ResponseMetadata>
         </SendMessageResponse>
         """
-    "Sqs"      | "SendMessageBatch"  | "POST" | "/"                   | "27daac76-34dd-47df-bd01-1f6e873584a1" | SqsClient.builder()      | { c -> c.sendMessageBatch(SendMessageBatchRequest.builder().queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/somequeue").entries(SendMessageBatchRequestEntry.builder().id("1").messageBody("body1").build()).build()) } | """
+    "Sqs"      | "SendMessageBatch"  | "POST" | "/"                   | "27daac76-34dd-47df-bd01-1f6e873584a1" | SqsClient.builder()      | { c -> c.sendMessageBatch(SendMessageBatchRequest.builder().queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/somequeue").entries(SendMessageBatchRequestEntry.builder().id("1").messageBody("body1").build(), SendMessageBatchRequestEntry.builder().id("2").messageBody("body2").build(), SendMessageBatchRequestEntry.builder().id("3").messageBody("body3").build(), SendMessageBatchRequestEntry.builder().id("4").messageBody("body4").build(), SendMessageBatchRequestEntry.builder().id("5").messageBody("body5").build()).build()) } | """
         <SendMessageBatchResponse>
             <SendMessageBatchResult>
                 <SendMessageBatchResultEntry>
                     <Id>1</Id>
-                    <MD5OfMessageBody>d41d8cd98f00b204e9800998ecf8427e</MD5OfMessageBody>
+                    <MD5OfMessageBody>d6ed8ba2adae5a938c5a3757bcccf4dd</MD5OfMessageBody>
                     <MessageId>5fea7756-0ea4-451a-a703-a558b933e274</MessageId>
+                </SendMessageBatchResultEntry>
+                <SendMessageBatchResultEntry>
+                    <Id>2</Id>
+                    <MD5OfMessageBody>76af63c5bd77b2a3a2cfcbd52645fa38</MD5OfMessageBody>
+                    <MessageId>5fea7756-0ea4-451a-a703-a558b933e275</MessageId>
+                </SendMessageBatchResultEntry>
+                <SendMessageBatchResultEntry>
+                    <Id>3</Id>
+                    <MD5OfMessageBody>5525786dab1a6e4b36a0b49fe1090875</MD5OfMessageBody>
+                    <MessageId>5fea7756-0ea4-451a-a703-a558b933e276</MessageId>
+                </SendMessageBatchResultEntry>
+                <SendMessageBatchResultEntry>
+                    <Id>4</Id>
+                    <MD5OfMessageBody>0039fc0a2fa335c82bfd08f6a068ee1c</MD5OfMessageBody>
+                    <MessageId>5fea7756-0ea4-451a-a703-a558b933e277</MessageId>
+                </SendMessageBatchResultEntry>
+                <SendMessageBatchResultEntry>
+                    <Id>5</Id>
+                    <MD5OfMessageBody>6cc1cbeba9aa648e1c2f668712b72ddf</MD5OfMessageBody>
+                    <MessageId>5fea7756-0ea4-451a-a703-a558b933e278</MessageId>
                 </SendMessageBatchResultEntry>
             </SendMessageBatchResult>
             <ResponseMetadata><RequestId>27daac76-34dd-47df-bd01-1f6e873584a1</RequestId></ResponseMetadata>
@@ -332,7 +352,7 @@ abstract class Aws2ClientTest extends VersionedNamingTestBase {
               checkPeerService = true
             }
             urlTags("${server.address}${path}", ExpectedQueryParams.getExpectedQueryParams(operation))
-            if (operation == "SendMessage") {
+            if (operation == "SendMessage" || operation == "SendMessageBatch") {
               // this is a corner case. The issues is that the aws integration should not set the service name
               // but it's doing it.
               serviceNameSource "java-aws-sdk"
@@ -370,13 +390,33 @@ abstract class Aws2ClientTest extends VersionedNamingTestBase {
             <ResponseMetadata><RequestId>27daac76-34dd-47df-bd01-1f6e873584a0</RequestId></ResponseMetadata>
         </SendMessageResponse>
         """
-    "Sqs"      | "SendMessageBatch"  | "POST" | "/"                   | "27daac76-34dd-47df-bd01-1f6e873584a1" | SqsAsyncClient.builder()      | { c -> c.sendMessageBatch(SendMessageBatchRequest.builder().queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/somequeue").entries(SendMessageBatchRequestEntry.builder().id("1").messageBody("body1").build()).build()) } | """
+    "Sqs"      | "SendMessageBatch"  | "POST" | "/"                   | "27daac76-34dd-47df-bd01-1f6e873584a1" | SqsAsyncClient.builder()      | { c -> c.sendMessageBatch(SendMessageBatchRequest.builder().queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/somequeue").entries(SendMessageBatchRequestEntry.builder().id("1").messageBody("body1").build(), SendMessageBatchRequestEntry.builder().id("2").messageBody("body2").build(), SendMessageBatchRequestEntry.builder().id("3").messageBody("body3").build(), SendMessageBatchRequestEntry.builder().id("4").messageBody("body4").build(), SendMessageBatchRequestEntry.builder().id("5").messageBody("body5").build()).build()) } | """
         <SendMessageBatchResponse>
             <SendMessageBatchResult>
                 <SendMessageBatchResultEntry>
                     <Id>1</Id>
-                    <MD5OfMessageBody>d41d8cd98f00b204e9800998ecf8427e</MD5OfMessageBody>
+                    <MD5OfMessageBody>d6ed8ba2adae5a938c5a3757bcccf4dd</MD5OfMessageBody>
                     <MessageId>5fea7756-0ea4-451a-a703-a558b933e274</MessageId>
+                </SendMessageBatchResultEntry>
+                <SendMessageBatchResultEntry>
+                    <Id>2</Id>
+                    <MD5OfMessageBody>76af63c5bd77b2a3a2cfcbd52645fa38</MD5OfMessageBody>
+                    <MessageId>5fea7756-0ea4-451a-a703-a558b933e275</MessageId>
+                </SendMessageBatchResultEntry>
+                <SendMessageBatchResultEntry>
+                    <Id>3</Id>
+                    <MD5OfMessageBody>5525786dab1a6e4b36a0b49fe1090875</MD5OfMessageBody>
+                    <MessageId>5fea7756-0ea4-451a-a703-a558b933e276</MessageId>
+                </SendMessageBatchResultEntry>
+                <SendMessageBatchResultEntry>
+                    <Id>4</Id>
+                    <MD5OfMessageBody>0039fc0a2fa335c82bfd08f6a068ee1c</MD5OfMessageBody>
+                    <MessageId>5fea7756-0ea4-451a-a703-a558b933e277</MessageId>
+                </SendMessageBatchResultEntry>
+                <SendMessageBatchResultEntry>
+                    <Id>5</Id>
+                    <MD5OfMessageBody>6cc1cbeba9aa648e1c2f668712b72ddf</MD5OfMessageBody>
+                    <MessageId>5fea7756-0ea4-451a-a703-a558b933e278</MessageId>
                 </SendMessageBatchResultEntry>
             </SendMessageBatchResult>
             <ResponseMetadata><RequestId>27daac76-34dd-47df-bd01-1f6e873584a1</RequestId></ResponseMetadata>
@@ -508,7 +548,7 @@ abstract class Aws2ClientTest extends VersionedNamingTestBase {
           measured true
           parent()
           tags {
-            if (operation == "SendMessage") {
+            if (operation == "SendMessage" || operation == "SendMessageBatch") {
               // this is a corner case. The issues is that the aws integration should not set the service name
               // but it's doing it.
               serviceNameSource "java-aws-sdk"
@@ -588,7 +628,7 @@ class Aws2ClientV0ForkedTest extends Aws2ClientTest {
     if ("Sns" == awsService && "Publish" == awsOperation) {
       return "sns"
     }
-    if ("Sqs" == awsService && "SendMessage" == awsOperation) {
+    if ("Sqs" == awsService && ("SendMessage" == awsOperation || "SendMessageBatch" == awsOperation)) {
       return "sqs"
     }
     return "java-aws-sdk"
@@ -604,7 +644,7 @@ class Aws2ClientV1ForkedTest extends Aws2ClientTest {
 
   @Override
   String expectedOperation(String awsService, String awsOperation) {
-    if (awsService == "Sqs" && awsOperation == "SendMessage") {
+    if (awsService == "Sqs" && (awsOperation == "SendMessage" || awsOperation == "SendMessageBatch")) {
       return "aws.sqs.send"
     }
     if (awsService == "Sns" && awsOperation == "Publish") {

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sdk-2.2/src/test/groovy/Aws2ClientTest.groovy
@@ -41,6 +41,8 @@ import software.amazon.awssdk.services.sns.model.PublishRequest
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.CreateQueueRequest
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 import spock.lang.AutoCleanup
 import spock.lang.Shared
@@ -153,9 +155,11 @@ abstract class Aws2ClientTest extends VersionedNamingTestBase {
               "queuename" "somequeue"
               peerServiceFrom("aws.queue.name")
               checkPeerService = true
-            } else if (service == "Sqs" && operation == "SendMessage") {
-              "aws.queue.url" "someurl"
-              peerServiceFrom("aws.queue.url")
+            } else if (service == "Sqs" && (operation == "SendMessage" || operation == "SendMessageBatch")) {
+              "aws.queue.url" "https://sqs.us-east-1.amazonaws.com/123456789012/somequeue"
+              "aws.queue.name" "somequeue"
+              "queuename" "somequeue"
+              peerServiceFrom("aws.queue.name")
               checkPeerService = true
             } else if (service == "Sns" && operation == "Publish") {
               "aws.topic.name" "some-topic"
@@ -202,7 +206,7 @@ abstract class Aws2ClientTest extends VersionedNamingTestBase {
             <ResponseMetadata><RequestId>7a62c49f-347e-4fc4-9331-6e8e7a96aa73</RequestId></ResponseMetadata>
         </CreateQueueResponse>
         """
-    "Sqs"      | "SendMessage"       | "POST" | "/"                   | "27daac76-34dd-47df-bd01-1f6e873584a0" | SqsClient.builder()      | { c -> c.sendMessage(SendMessageRequest.builder().queueUrl("someurl").messageBody("").build()) }                                                                | """
+    "Sqs"      | "SendMessage"       | "POST" | "/"                   | "27daac76-34dd-47df-bd01-1f6e873584a0" | SqsClient.builder()      | { c -> c.sendMessage(SendMessageRequest.builder().queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/somequeue").messageBody("").build()) }                                                                | """
         <SendMessageResponse>
             <SendMessageResult>
                 <MD5OfMessageBody>d41d8cd98f00b204e9800998ecf8427e</MD5OfMessageBody>
@@ -211,6 +215,18 @@ abstract class Aws2ClientTest extends VersionedNamingTestBase {
             </SendMessageResult>
             <ResponseMetadata><RequestId>27daac76-34dd-47df-bd01-1f6e873584a0</RequestId></ResponseMetadata>
         </SendMessageResponse>
+        """
+    "Sqs"      | "SendMessageBatch"  | "POST" | "/"                   | "27daac76-34dd-47df-bd01-1f6e873584a1" | SqsClient.builder()      | { c -> c.sendMessageBatch(SendMessageBatchRequest.builder().queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/somequeue").entries(SendMessageBatchRequestEntry.builder().id("1").messageBody("body1").build()).build()) } | """
+        <SendMessageBatchResponse>
+            <SendMessageBatchResult>
+                <SendMessageBatchResultEntry>
+                    <Id>1</Id>
+                    <MD5OfMessageBody>d41d8cd98f00b204e9800998ecf8427e</MD5OfMessageBody>
+                    <MessageId>5fea7756-0ea4-451a-a703-a558b933e274</MessageId>
+                </SendMessageBatchResultEntry>
+            </SendMessageBatchResult>
+            <ResponseMetadata><RequestId>27daac76-34dd-47df-bd01-1f6e873584a1</RequestId></ResponseMetadata>
+        </SendMessageBatchResponse>
         """
     "Sns"      | "Publish"           | "POST" | "/"                   | "d74b8436-ae13-5ab4-a9ff-ce54dfea72a0" | SnsClient.builder()      | { c -> c.publish(PublishRequest.builder().topicArn("arn:aws:sns::123:some-topic").message("").build()) }                                                        | """
         <PublishResponse xmlns="https://sns.amazonaws.com/doc/2010-03-31/">
@@ -293,9 +309,11 @@ abstract class Aws2ClientTest extends VersionedNamingTestBase {
               "queuename" "somequeue"
               peerServiceFrom("aws.queue.name")
               checkPeerService = true
-            } else if (service == "Sqs" && operation == "SendMessage") {
-              "aws.queue.url" "someurl"
-              peerServiceFrom("aws.queue.url")
+            } else if (service == "Sqs" && (operation == "SendMessage" || operation == "SendMessageBatch")) {
+              "aws.queue.url" "https://sqs.us-east-1.amazonaws.com/123456789012/somequeue"
+              "aws.queue.name" "somequeue"
+              "queuename" "somequeue"
+              peerServiceFrom("aws.queue.name")
               checkPeerService = true
             } else if (service == "Sns" && operation == "Publish") {
               "aws.topic.name" "some-topic"
@@ -342,7 +360,7 @@ abstract class Aws2ClientTest extends VersionedNamingTestBase {
             <ResponseMetadata><RequestId>7a62c49f-347e-4fc4-9331-6e8e7a96aa73</RequestId></ResponseMetadata>
         </CreateQueueResponse>
         """
-    "Sqs"      | "SendMessage"       | "POST" | "/"                   | "27daac76-34dd-47df-bd01-1f6e873584a0" | SqsAsyncClient.builder()      | { c -> c.sendMessage(SendMessageRequest.builder().queueUrl("someurl").messageBody("").build()) }                                 | """
+    "Sqs"      | "SendMessage"       | "POST" | "/"                   | "27daac76-34dd-47df-bd01-1f6e873584a0" | SqsAsyncClient.builder()      | { c -> c.sendMessage(SendMessageRequest.builder().queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/somequeue").messageBody("").build()) }                                 | """
         <SendMessageResponse>
             <SendMessageResult>
                 <MD5OfMessageBody>d41d8cd98f00b204e9800998ecf8427e</MD5OfMessageBody>
@@ -351,6 +369,18 @@ abstract class Aws2ClientTest extends VersionedNamingTestBase {
             </SendMessageResult>
             <ResponseMetadata><RequestId>27daac76-34dd-47df-bd01-1f6e873584a0</RequestId></ResponseMetadata>
         </SendMessageResponse>
+        """
+    "Sqs"      | "SendMessageBatch"  | "POST" | "/"                   | "27daac76-34dd-47df-bd01-1f6e873584a1" | SqsAsyncClient.builder()      | { c -> c.sendMessageBatch(SendMessageBatchRequest.builder().queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/somequeue").entries(SendMessageBatchRequestEntry.builder().id("1").messageBody("body1").build()).build()) } | """
+        <SendMessageBatchResponse>
+            <SendMessageBatchResult>
+                <SendMessageBatchResultEntry>
+                    <Id>1</Id>
+                    <MD5OfMessageBody>d41d8cd98f00b204e9800998ecf8427e</MD5OfMessageBody>
+                    <MessageId>5fea7756-0ea4-451a-a703-a558b933e274</MessageId>
+                </SendMessageBatchResultEntry>
+            </SendMessageBatchResult>
+            <ResponseMetadata><RequestId>27daac76-34dd-47df-bd01-1f6e873584a1</RequestId></ResponseMetadata>
+        </SendMessageBatchResponse>
         """
     "Sns"      | "Publish"           | "POST" | "/"                   | "d74b8436-ae13-5ab4-a9ff-ce54dfea72a0" | SnsAsyncClient.builder()      | { c -> c.publish(PublishRequest.builder().topicArn("arn:aws:sns::123:some-topic").message("").build()) }                         | """
         <PublishResponse xmlns="https://sns.amazonaws.com/doc/2010-03-31/">
@@ -511,7 +541,9 @@ abstract class Aws2ClientTest extends VersionedNamingTestBase {
               "aws.queue.name" "test-queue"
               "queuename" "test-queue"
             } else if (service == "Sqs" && operation == "SendMessage") {
-              "aws.queue.url" "test-queue-url"
+              "aws.queue.url" "https://sqs.us-east-1.amazonaws.com/123456789012/test-queue"
+              "aws.queue.name" "test-queue"
+              "queuename" "test-queue"
             } else if (service == "Sns" && operation == "Publish") {
               "aws.topic.name" "test-topic"
               "topicname" "test-topic"
@@ -537,7 +569,7 @@ abstract class Aws2ClientTest extends VersionedNamingTestBase {
     service    | operation      | method | path                  | builder                  | call                                                                                                              | body                                                                                                                               | requestId
     "S3"       | "CreateBucket" | "PUT"  | "/test-bucket"        | S3Client.builder()       | { c -> c.createBucket(CreateBucketRequest.builder().bucket("test-bucket").build()) }                              | ""                                                                                                                                 | "UNKNOWN"
     "Sqs"      | "CreateQueue"  | "POST" | "/"                   | SqsClient.builder()      | { c -> c.createQueue(CreateQueueRequest.builder().queueName("test-queue").build()) }                              | """<CreateQueueResponse><CreateQueueResult><QueueUrl>https://queue.amazonaws.com/123456789012/test-queue</QueueUrl></CreateQueueResult><ResponseMetadata><RequestId>test-request-id</RequestId></ResponseMetadata></CreateQueueResponse>""" | "test-request-id"
-    "Sqs"      | "SendMessage"  | "POST" | "/"                   | SqsClient.builder()      | { c -> c.sendMessage(SendMessageRequest.builder().queueUrl("test-queue-url").messageBody("test").build()) }       | """<SendMessageResponse><SendMessageResult><MD5OfMessageBody>098f6bcd4621d373cade4e832627b4f6</MD5OfMessageBody><MessageId>test-msg-id</MessageId></SendMessageResult><ResponseMetadata><RequestId>test-request-id</RequestId></ResponseMetadata></SendMessageResponse>""" | "test-request-id"
+    "Sqs"      | "SendMessage"  | "POST" | "/"                   | SqsClient.builder()      | { c -> c.sendMessage(SendMessageRequest.builder().queueUrl("https://sqs.us-east-1.amazonaws.com/123456789012/test-queue").messageBody("test").build()) }       | """<SendMessageResponse><SendMessageResult><MD5OfMessageBody>098f6bcd4621d373cade4e832627b4f6</MD5OfMessageBody><MessageId>test-msg-id</MessageId></SendMessageResult><ResponseMetadata><RequestId>test-request-id</RequestId></ResponseMetadata></SendMessageResponse>""" | "test-request-id"
     "Sns"      | "Publish"      | "POST" | "/"                   | SnsClient.builder()      | { c -> c.publish(PublishRequest.builder().topicArn("arn:aws:sns::123:test-topic").message("test").build()) }     | """<PublishResponse xmlns="https://sns.amazonaws.com/doc/2010-03-31/"><PublishResult><MessageId>test-msg-id</MessageId></PublishResult><ResponseMetadata><RequestId>test-request-id</RequestId></ResponseMetadata></PublishResponse>""" | "test-request-id"
     "DynamoDb" | "CreateTable"  | "POST" | "/"                   | DynamoDbClient.builder() | { c -> c.createTable(CreateTableRequest.builder().tableName("test-table").build()) }                              | ""                                                                                                                                 | "UNKNOWN"
     "Kinesis"  | "DeleteStream" | "POST" | "/"                   | KinesisClient.builder()  | { c -> c.deleteStream(DeleteStreamRequest.builder().streamName("test-stream").build()) }                          | ""                                                                                                                                 | "UNKNOWN"

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsDecorator.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sqs/SqsDecorator.java
@@ -84,11 +84,23 @@ public class SqsDecorator extends MessagingClientDecorator {
     span.setTag("aws.agent", COMPONENT_NAME);
     span.setTag("aws.queue.url", queueUrl);
     span.setTag("aws.requestId", requestId);
+    setQueueNameFromUrl(span, queueUrl);
   }
 
   public void onTimeInQueue(final AgentSpan span, final String queueUrl, String requestId) {
     span.setResourceName(SQS_DELIVER);
     span.setTag("aws.queue.url", queueUrl);
     span.setTag("aws.requestId", requestId);
+    setQueueNameFromUrl(span, queueUrl);
+  }
+
+  private static void setQueueNameFromUrl(final AgentSpan span, final String queueUrl) {
+    if (queueUrl == null) return;
+    int lastSlash = queueUrl.lastIndexOf('/');
+    if (lastSlash >= 0 && lastSlash < queueUrl.length() - 1) {
+      String queueName = queueUrl.substring(lastSlash + 1);
+      span.setTag("aws.queue.name", queueName);
+      span.setTag("queuename", queueName);
+    }
   }
 }

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/test/groovy/LegacySqsClientForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/test/groovy/LegacySqsClientForkedTest.groovy
@@ -97,6 +97,8 @@ class LegacySqsClientForkedTest extends InstrumentationSpecification {
             "aws.operation" "SendMessage"
             "aws.agent" "java-aws-sdk"
             "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            "aws.queue.name" "somequeue"
+            "queuename" "somequeue"
             "aws.requestId" { it.trim() == "00000000-0000-0000-0000-000000000000" } // the test server seem messing with request id and insert \n
             urlTags("http://localhost:${address.port}/", ExpectedQueryParams.getExpectedQueryParams("SendMessage"))
             defaultTags()
@@ -143,6 +145,8 @@ class LegacySqsClientForkedTest extends InstrumentationSpecification {
             "aws.operation" "ReceiveMessage"
             "aws.agent" "java-aws-sdk"
             "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            "aws.queue.name" "somequeue"
+            "queuename" "somequeue"
             "aws.requestId" { it.trim() == "00000000-0000-0000-0000-000000000000" } // the test server seem messing with request id and insert \n
             urlTags("http://localhost:${address.port}/", ExpectedQueryParams.getExpectedQueryParams(("ReceiveMessage")))
             defaultTags()
@@ -225,6 +229,8 @@ class LegacySqsClientForkedTest extends InstrumentationSpecification {
             "aws.operation" "SendMessage"
             "aws.agent" "java-aws-sdk"
             "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            "aws.queue.name" "somequeue"
+            "queuename" "somequeue"
             "aws.requestId" { it.trim() == "00000000-0000-0000-0000-000000000000" } // the test server seem messing with request id and insert \n
             urlTags("http://localhost:${address.port}/", ExpectedQueryParams.getExpectedQueryParams("SendMessage"))
             defaultTags()
@@ -288,6 +294,8 @@ class LegacySqsClientForkedTest extends InstrumentationSpecification {
             "aws.operation" "DeleteMessage"
             "aws.agent" "java-aws-sdk"
             "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            "aws.queue.name" "somequeue"
+            "queuename" "somequeue"
             "aws.requestId" { it.trim() == "00000000-0000-0000-0000-000000000000" } // the test server seem messing with request id and insert \n
             urlTags("http://localhost:${address.port}/", ExpectedQueryParams.getExpectedQueryParams("DeleteMessage"))
             defaultTags()
@@ -333,6 +341,8 @@ class LegacySqsClientForkedTest extends InstrumentationSpecification {
             "aws.operation" "ReceiveMessage"
             "aws.agent" "java-aws-sdk"
             "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+            "aws.queue.name" "somequeue"
+            "queuename" "somequeue"
             "aws.requestId" { it.trim() == "00000000-0000-0000-0000-000000000000" } // the test server seem messing with request id and insert \n
             urlTags("http://localhost:${address.port}/", ExpectedQueryParams.getExpectedQueryParams("ReceiveMessage"))
             defaultTags()

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/test/groovy/TimeInQueueForkedTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/test/groovy/TimeInQueueForkedTest.groovy
@@ -306,6 +306,8 @@ class TimeInQueueForkedTest extends InstrumentationSpecification {
         "aws.operation" "SendMessageBatch"
         "aws.agent" "java-aws-sdk"
         "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+        "aws.queue.name" "somequeue"
+        "queuename" "somequeue"
         "aws.requestId" { it.trim() == "00000000-0000-0000-0000-000000000000" } // the test server seem messing with request id and insert \n
         urlTags("http://localhost:${address.port}/", ExpectedQueryParams.getExpectedQueryParams("SendMessageBatch"))
         serviceNameSource("java-aws-sdk")
@@ -331,6 +333,8 @@ class TimeInQueueForkedTest extends InstrumentationSpecification {
         "aws.operation" "ReceiveMessage"
         "aws.agent" "java-aws-sdk"
         "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+        "aws.queue.name" "somequeue"
+        "queuename" "somequeue"
         "aws.requestId" { it.trim() == "00000000-0000-0000-0000-000000000000" } // the test server seem messing with request id and insert \n
         // when using time in queue, the instrumentation always set the service name for the receive span
         // while it's the same as dd-service, forcing a service name means setting the _dd.svc_src tag
@@ -353,6 +357,8 @@ class TimeInQueueForkedTest extends InstrumentationSpecification {
         "$Tags.COMPONENT" "java-aws-sdk"
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_BROKER
         "aws.queue.url" "http://localhost:${address.port}/000000000000/somequeue"
+        "aws.queue.name" "somequeue"
+        "queuename" "somequeue"
         "aws.requestId" { it.trim() == "00000000-0000-0000-0000-000000000000" } // the test server seem messing with request id and insert \n
         defaultTags(true)
       }

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/test/java/SqsClientTest.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sqs-2.0/src/test/java/SqsClientTest.java
@@ -452,6 +452,10 @@ abstract class SqsClientTestBase extends AbstractInstrumentationTest {
     assertEquals(awsOperation, tagValue(span, "aws.operation"));
     assertEquals("java-aws-sdk", tagValue(span, "aws.agent"));
     assertEquals(queueUrl, tagValue(span, "aws.queue.url"));
+    if (awsOperation.equals("SendMessage") || awsOperation.equals("ReceiveMessage")) {
+      String expectedQueueName = queueUrl.substring(queueUrl.lastIndexOf('/') + 1);
+      assertEquals(expectedQueueName, tagValue(span, "aws.queue.name"));
+    }
     assertEquals(requestId(), tagValue(span, "aws.requestId").trim());
   }
 
@@ -702,6 +706,11 @@ abstract class SqsClientReceiveIterationTestBase extends AbstractInstrumentation
     assertEquals(awsOperation, tagValue(span, "aws.operation"));
     assertEquals("java-aws-sdk", tagValue(span, "aws.agent"));
     assertEquals(expectedQueueUrl(), tagValue(span, "aws.queue.url"));
+    if (awsOperation.equals("SendMessage") || awsOperation.equals("ReceiveMessage")) {
+      String expectedQueueName =
+          expectedQueueUrl().substring(expectedQueueUrl().lastIndexOf('/') + 1);
+      assertEquals(expectedQueueName, tagValue(span, "aws.queue.name"));
+    }
     assertEquals("00000000-0000-0000-0000-000000000000", tagValue(span, "aws.requestId"));
   }
 


### PR DESCRIPTION
# What Does This Do

For SQS operations this sets the `aws.queue.name` tag based on the _QueueUrl_ field in the request.

# Motivation

In AWS SDK V2 the SQS operations mutating messages on a queue only have a _QueueUrl_ field in the request.
As a consequence the `aws.queue.name` tag is never set, and the peer for the span is not inferred correctly.
The queue url does contain the queue name, similar as to how the sns topic arn contains the topic name.
This change determines the queue name based on the queue url in SQS operations.

# Additional Notes

Fixes: #12155 