### PR TITLE
Update TableTest to `1.2.2`.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,7 +75,7 @@ junit-platform = "1.14.1"
 mockito = "4.4.0"
 spock = "2.4-groovy-3.0"
 json-unit = "2.40.1"
-tabletest = "1.2.1"
+tabletest = "1.2.2"
 testcontainers = "1.21.4"
 
 [libraries]


### PR DESCRIPTION
# What Does This Do

Update TableTest to `1.2.2`.

# Motivation
Keep tools up-to-date.
