### PR TITLE
Bump java-profiler (ddprof) to 1.49.0

### DIFF
--- a/dd-java-agent/ddprof-lib/gradle.lockfile
+++ b/dd-java-agent/ddprof-lib/gradle.lockfile
@@ -5,7 +5,7 @@
 ch.qos.logback:logback-classic:1.2.13=testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.2.13=testCompileClasspath,testRuntimeClasspath
 com.datadoghq:dd-javac-plugin-client:0.2.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.datadoghq:ddprof:1.48.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.datadoghq:ddprof:1.49.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.github.javaparser:javaparser-core:3.25.6=codenarc
 com.github.spotbugs:spotbugs-annotations:4.9.8=compileClasspath,spotbugs
 com.github.spotbugs:spotbugs:4.9.8=spotbugs

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ scalafmt = "3.11.5"
 tabletest-formatter = "1.1.2"
 
 # DataDog libs and forks
-ddprof = "1.48.1"
+ddprof = "1.49.0"
 dogstatsd = "4.4.5"
 okhttp = "3.12.15" # Datadog fork to support Java 7
 


### PR DESCRIPTION
# What Does This Do

Bumps the bundled `java-profiler` (ddprof) native library dependency from 1.48.1 to 1.49.0.

# Motivation

Pick up the latest upstream ddprof release, including reliability and crash-safety fixes.

# Additional Notes

Most significant changes/fixes in [ddprof 1.49.0](https://github.com/DataDog/java-profiler/releases/tag/v_1.49.0):

- Missing `libgcc_s.so.1` on the host no longer causes a crash — [DataDog/java-profiler#689](https://github.com/DataDog/java-profiler/pull/689), [DataDog/java-profiler#720](https://github.com/DataDog/java-profiler/pull/720) (Alpine/musl)
- Avoid retaining invalid VM method pointers — [DataDog/java-profiler#699](https://github.com/DataDog/java-profiler/pull/699)
- Guard `Profiler::recordSample()` stack walk against faults — [DataDog/java-profiler#687](https://github.com/DataDog/java-profiler/pull/687)
- Guard `Recording::writeElement` against SIGSEGV on a corrupted metadata tree — [DataDog/java-profiler#692](https://github.com/DataDog/java-profiler/pull/692)
- Fix memory leak in `JfrMetadata::reset()` — [DataDog/java-profiler#694](https://github.com/DataDog/java-profiler/pull/694)
- Remove legacy DirectByteBuffer-based OTEP context storage (Phase 3) — [DataDog/java-profiler#696](https://github.com/DataDog/java-profiler/pull/696)
- Never patch the profiler's own import table — [DataDog/java-profiler#721](https://github.com/DataDog/java-profiler/pull/721)

# Contributor Checklist

- [x] Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- [ ] Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- [ ] Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR