### PR TITLE
Fix OpenFeature provider hook test isolation

### DIFF
--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
@@ -8,6 +8,7 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -24,7 +25,6 @@ import dev.openfeature.sdk.EvaluationContext;
 import dev.openfeature.sdk.EventDetails;
 import dev.openfeature.sdk.Features;
 import dev.openfeature.sdk.FlagEvaluationDetails;
-import dev.openfeature.sdk.Hook;
 import dev.openfeature.sdk.OpenFeatureAPI;
 import dev.openfeature.sdk.ProviderEvaluation;
 import dev.openfeature.sdk.ProviderEvent;
@@ -33,7 +33,6 @@ import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.FatalError;
 import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
 import java.lang.reflect.Field;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -327,25 +326,34 @@ public class ProviderTest {
 
   @Test
   public void testGetProviderHooksReturnsFlagEvalHook() {
-    Provider provider =
-        new Provider(new Options().initTimeout(10, MILLISECONDS), mock(Evaluator.class));
-    List<Hook> hooks = provider.getProviderHooks();
-    assertThat(hooks.size(), equalTo(1));
-    assertThat(hooks.get(0) instanceof FlagEvalHook, equalTo(true));
+    final Evaluator evaluator = mock(Evaluator.class);
+    final Provider providerWithoutSpanEnrichment =
+        new Provider(new Options(), evaluator, Boolean.FALSE);
+    final Provider providerWithSpanEnrichment =
+        new Provider(new Options(), evaluator, Boolean.TRUE);
+
+    assertHasFlagEvalHook(providerWithoutSpanEnrichment);
+    assertHasFlagEvalHook(providerWithSpanEnrichment);
   }
 
   @Test
-  public void testShutdownCleansUpMetrics() throws Exception {
-    Evaluator evaluator = mock(Evaluator.class);
+  public void testShutdownCleansUpEvaluator() throws Exception {
+    final Evaluator evaluator = mock(Evaluator.class);
     when(evaluator.initialize(eq(10L), eq(MILLISECONDS), any())).thenReturn(true);
     when(evaluator.hasConfiguration()).thenReturn(true);
-    Provider provider = new Provider(new Options().initTimeout(10, MILLISECONDS), evaluator);
+    final Provider provider =
+        new Provider(new Options().initTimeout(10, MILLISECONDS), evaluator, Boolean.FALSE);
+
     provider.initialize(null);
     provider.shutdown();
+
     verify(evaluator).shutdown();
-    // After shutdown, getProviderHooks still returns a list (hook is still present but metrics is
-    // shut down)
-    assertThat(provider.getProviderHooks().size(), equalTo(1));
+  }
+
+  private static void assertHasFlagEvalHook(final Provider provider) {
+    assertTrue(
+        provider.getProviderHooks().stream().anyMatch(FlagEvalHook.class::isInstance),
+        "flag evaluation metrics hook should be registered");
   }
 
   public interface EvaluateMethod<E> {


### PR DESCRIPTION
## Motivation

Two `ProviderTest` cases produce false failures on `master` when the experimental span-enrichment gate is enabled in the test environment. The provider correctly registers an additional optional hook in that configuration, but the tests asserted that the complete hook list always contained exactly one entry. These [CI Visibility failures](https://app.datadoghq.com/ci/ci-cd/explorer?query=test_level%3Atest%20%40test.status%3A%28fail%29%20%40git.branch%3A%22master%22%20%40test.service%3Add-trace-java%20-%40ci.job.name%3Atest_flaky%2A%20%40test.suite%3Adatadog.trace.api.openfeature.ProviderTest&agg_m=count&agg_m_source=base&agg_t=count&ci_cd_explorer_tab=tests&citest_explorer_sort=%40test.name%2Casc&cols=%40test.status%2Ctimestamp%2C%40test.suite%3A327%2C%40test.name%3A354%2C%40duration%3A183%2C%40test.service%3A124%2C%40git.branch%2C%40ci.job.name&currentTab=overview&eventStack=&fromUser=true&index=citest&refresh_mode=sliding&start=1785527462426&end=1786132262426&paused=false) create noise for contributors and can hide real OpenFeature regressions.

## Changes

The provider-hook test now verifies the invariant it actually owns: the flag-evaluation metrics hook is registered whether span enrichment is disabled or enabled. It exercises both gate states explicitly and checks hook membership instead of relying on list size or ordering.

The shutdown test now has a name and assertion aligned with its behavior. It verifies evaluator shutdown and no longer couples lifecycle coverage to the number of optional provider hooks.

## Decisions

This is intentionally a test-only change because production behavior is correct: enabling span enrichment should add a hook. The tests reuse the existing explicit gate seam to cover both configurations deterministically, while the dedicated span-enrichment tests remain responsible for the optional hook's own registration behavior. No global environment mutation or timeout adjustment is introduced.

## Validation

- `./gradlew :products:feature-flagging:feature-flagging-api:test --tests datadog.trace.api.openfeature.ProviderTest :products:feature-flagging:feature-flagging-api:spotlessCheck -Prerun.tests.feature-flagging-api -PtestJvm=11 --no-daemon --stacktrace`
- `DD_EXPERIMENTAL_FLAGGING_PROVIDER_SPAN_ENRICHMENT_ENABLED=true ./gradlew :products:feature-flagging:feature-flagging-api:test --tests datadog.trace.api.openfeature.ProviderTest -Prerun.tests.feature-flagging-api -PtestJvm=11 --no-daemon --stacktrace`