### PR TITLE
Restore Confluent versions to Kafka Muzzle checks

### DIFF
--- a/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/build.gradle
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-0.11/build.gradle
@@ -1,4 +1,6 @@
 muzzle {
+  extraRepository("confluent-releases", "https://packages.confluent.io/maven/")
+
   pass {
     name = "since-0.11"
     group = "org.apache.kafka"
@@ -67,5 +69,4 @@ tasks.named("iastLatestDepTest3", Test) {
   javaLauncher = getJavaLauncherFor(17)
   jvmArgs = ['--add-opens', 'java.base/java.util=ALL-UNNAMED']
 }
-
 

--- a/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/build.gradle
+++ b/dd-java-agent/instrumentation/kafka/kafka-clients-3.8/build.gradle
@@ -1,4 +1,6 @@
 muzzle {
+  extraRepository("confluent-releases", "https://packages.confluent.io/maven/")
+
   pass {
     group = "org.apache.kafka"
     module = "kafka-clients"

--- a/dd-java-agent/instrumentation/kafka/kafka-connect-0.11/build.gradle
+++ b/dd-java-agent/instrumentation/kafka/kafka-connect-0.11/build.gradle
@@ -1,4 +1,6 @@
 muzzle {
+  extraRepository("confluent-releases", "https://packages.confluent.io/maven/")
+
   pass {
     group = "org.apache.kafka"
     module = "connect-runtime"

--- a/dd-java-agent/instrumentation/kafka/kafka-streams-0.11/build.gradle
+++ b/dd-java-agent/instrumentation/kafka/kafka-streams-0.11/build.gradle
@@ -1,4 +1,6 @@
 muzzle {
+  extraRepository("confluent-releases", "https://packages.confluent.io/maven/")
+
   pass {
     group = "org.apache.kafka"
     module = "kafka-streams"

--- a/dd-java-agent/instrumentation/kafka/kafka-streams-1.0/build.gradle
+++ b/dd-java-agent/instrumentation/kafka/kafka-streams-1.0/build.gradle
@@ -1,4 +1,6 @@
 muzzle {
+  extraRepository("confluent-releases", "https://packages.confluent.io/maven/")
+
   pass {
     group = "org.apache.kafka"
     module = "kafka-streams"


### PR DESCRIPTION
# What Does This Do

Adds the Confluent Maven repository as an explicit Muzzle version source for all Kafka instrumentations that test `org.apache.kafka` artifacts.

Muzzle now combines the Maven Central version list obtained through the existing Depot proxy/fallback flow with Confluent's `-ce`, `-ccs`, and other published Kafka versions.

# Motivation

Depot previously returned Confluent metadata for some `org.apache.kafka` coordinates. After Depot was corrected to behave as a Maven Central proxy, those Confluent versions were no longer discoverable by Kafka Muzzle ranges, even though exact Confluent artifacts remained downloadable.

Without an explicit Confluent Muzzle repository, compatibility checks could remain green while silently dropping Confluent version coverage. Declaring the upstream directly makes that coverage intentional and independent of Depot's Maven Central metadata behavior.

# Additional Notes

- Exact dependency downloads continue to use the normal Gradle repository order, with Depot preferred in CI.
- This follows the existing `confluent-schema-registry-4.1` Muzzle repository pattern.
- PR #12160 demonstrates the intended `-ce` and `-ccs` compatibility coverage.

Validation:

- Spotless checks for all five affected Kafka instrumentation modules.
- Dry-run planning for all five affected Muzzle tasks with the CI Depot proxy configured.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: N/A

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
