### PR TITLE
Improve backporting script

### DIFF
--- a/tooling/backport-pr-to-patch-release.sh
+++ b/tooling/backport-pr-to-patch-release.sh
@@ -39,22 +39,22 @@ fi
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 # Check gh is installed
 echo "- Checking gh is installed"
-gh --version 1>/dev/null 2>&1 || { echo "gh is not installed"; exit 1; }
+gh --version 1>/dev/null 2>&1 || { echo "  gh is not installed"; exit 1; }
 # Check jq is installed
 echo "- Checking jq is installed"
-jq --version 1>/dev/null 2>&1 || { echo "jq is not installed"; exit 1; }
+jq --version 1>/dev/null 2>&1 || { echo "  jq is not installed"; exit 1; }
 # Check there is no local changes
 echo "- Checking there is no local changes"
-git diff --exit-code || { echo "There are local changes"; exit 1; }
+git diff --exit-code || { echo "  There are local changes"; exit 1; }
 # Check remote branch exists
 echo "- Checking remote release branch exists"
-git fetch --quiet
-git show-ref --verify --quiet "refs/remotes/origin/$PATCH_RELEASE_BRANCH" 1>/dev/null 2>&1 || { echo "Branch $PATCH_RELEASE_BRANCH does not exist"; exit 1; }
+git fetch --quiet origin
+git show-ref --verify --quiet "refs/remotes/origin/$PATCH_RELEASE_BRANCH" 1>/dev/null 2>&1 || { echo "  Branch $PATCH_RELEASE_BRANCH does not exist"; exit 1; }
 # Check PR exists
 echo "- Checking PR exists"
 PR_COMMITS=$(gh pr view "$PR_NUMBER" --json commits --jq '.commits[].oid')
 if [ -z "$PR_COMMITS" ]; then
-    echo "PR $PR_NUMBER does not exist"
+    echo "  PR $PR_NUMBER does not exist"
     exit 1
 fi
 # Check all individual commits are still present
@@ -62,8 +62,8 @@ USE_MERGE_COMMIT=0
 echo "- Checking all individual commits are still present"
 for PR_COMMIT in $PR_COMMITS; do
     if ! git cat-file -e "$PR_COMMIT"; then
-        echo "Commit $PR_COMMIT from PR $PR_NUMBER is no longer present in the repository."
-        echo "This can happen when PR is squashed and remote branch is removed afterwards, original commits can be garbage collected."
+        echo "  Commit $PR_COMMIT from PR $PR_NUMBER is no longer present in the repository."
+        echo "  This can happen when PR is squashed and remote branch is removed afterwards, original commits can be garbage collected."
         USE_MERGE_COMMIT=1
         break
     fi
@@ -74,9 +74,9 @@ if [ $USE_MERGE_COMMIT -eq 0 ]; then
     for PR_COMMIT in $PR_COMMITS; do
         PARENT_COUNT=$(git rev-list --parents -n 1 "$PR_COMMIT" 2>/dev/null | wc -w)
         if [ "$PARENT_COUNT" -gt 2 ]; then
-            echo "PR $PR_NUMBER contains a merge commit: $PR_COMMIT"
-            echo "Merge commit changes: https://github.com/DataDog/dd-trace-java/commit/${PR_COMMIT}"
-            echo "PR commit list: https://github.com/DataDog/dd-trace-java/pull/${PR_NUMBER}/commits"
+            echo "  PR $PR_NUMBER contains a merge commit: $PR_COMMIT"
+            echo "  Merge commit changes: https://github.com/DataDog/dd-trace-java/commit/${PR_COMMIT}"
+            echo "  PR commit list: https://github.com/DataDog/dd-trace-java/pull/${PR_NUMBER}/commits"
             USE_MERGE_COMMIT=1
             break
         fi
@@ -84,12 +84,12 @@ if [ $USE_MERGE_COMMIT -eq 0 ]; then
 fi
 # Ask to use merge commit rather than individual commits
 if [ $USE_MERGE_COMMIT -eq 1 ]; then
-    echo -n "Would you like to cherry-pick the PR ${PR_NUMBER} merge commit instead of each of its commits individually? (y/n) "
+    echo -n "  Would you like to cherry-pick the PR ${PR_NUMBER} merge commit instead of each of its commits individually? (y/n) "
     read -r ANSWER
     if [ "$ANSWER" == "y" ]; then
         PR_COMMITS=$(gh pr view "$PR_NUMBER" --json mergeCommit --jq '.mergeCommit.oid')
     else
-        echo "Aborting. Please back-port the PR manually then."
+        echo "  Aborting. Please back-port the PR manually then."
         exit 1
     fi
 fi
@@ -100,13 +100,11 @@ PR_LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name] | join(
 #
 # Backport PR to patch release branch.
 #
-# Checkout release branch
-git checkout "$PATCH_RELEASE_BRANCH"
-# Ensure the branch is up-to-date
-git pull
+# Start backporting
+echo "- Backporting PR $PR_NUMBER to $PATCH_RELEASE_BRANCH"
 # Create a new branch for the backport
 BRANCH_NAME="$USER/backport-pr-$PR_NUMBER"
-git checkout -b "$BRANCH_NAME"
+git checkout -b "$BRANCH_NAME" "origin/$PATCH_RELEASE_BRANCH"
 # Cherry-pick PR commits
 for PR_COMMIT in $PR_COMMITS; do
     git cherry-pick -x "$PR_COMMIT"
@@ -114,15 +112,16 @@ done
 # Push the branch
 git push -u origin "$BRANCH_NAME" --no-verify
 # Create a PR
-gh pr create --base "$PATCH_RELEASE_BRANCH" \
+PR_URL=$(gh pr create --base "$PATCH_RELEASE_BRANCH" \
     --head "$BRANCH_NAME" \
     --title "🍒 $PR_NUMBER - $PR_TITLE" \
     --body "Backport #$PR_NUMBER to $PATCH_RELEASE_BRANCH" \
-    --label "$PR_LABELS"
+    --label "$PR_LABELS")
+echo "  Backport completed: $PR_URL"
 
 #
 # Clean up.
 #
 # Restore current branch
-echo "- Restoring original state"
+echo "- Restoring original working copy state"
 git checkout "$CURRENT_BRANCH"


### PR DESCRIPTION
# What Does This Do

This PR improves the backporting script to:

- make output clearer introducing sections and indentation (help identifying shell command outputs)
- create backport branch directly from origin reference (make sure no divergence are present locally)
- add final message when backport completed

# Motivation

The goal is to improve usability of the script and distinguish automated command outputs from the script state.

# Additional Notes

Here is the new output:
```shell
tooling/backport-pr-to-patch-release-new.sh v1.65.x 12181
- Checking gh is installed
- Checking jq is installed
- Checking there is no local changes
- Checking remote release branch exists
- Checking PR exists
- Checking all individual commits are still present
- Checking PR does not contain merge commit
- Backporting PR 12181 to release/v1.65.x
branch 'bruce.bujon/backport-pr-12181' set up to track 'origin/release/v1.65.x'.
Switched to a new branch 'bruce.bujon/backport-pr-12181'
[bruce.bujon/backport-pr-12181 871267d0d3] feat(tooling): Improve backporting script
 Date: Tue Aug 11 09:24:20 2026 +0200
 1 file changed, 20 insertions(+), 21 deletions(-)
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 16 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (4/4), 868 bytes | 868.00 KiB/s, done.
Total 4 (delta 3), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.
remote:
remote: Create a pull request for 'bruce.bujon/backport-pr-12181' on GitHub by visiting:
remote:      https://github.com/DataDog/dd-trace-java/pull/new/bruce.bujon/backport-pr-12181
remote:
To github.com:DataDog/dd-trace-java.git
 * [new branch]            bruce.bujon/backport-pr-12181 -> bruce.bujon/backport-pr-12181
branch 'bruce.bujon/backport-pr-12181' set up to track 'origin/bruce.bujon/backport-pr-12181'.
  Backport completed: https://github.com/DataDog/dd-trace-java/pull/12183
- Restoring original working copy state
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
```

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
