### PR TITLE
Fix Kafka Connect data streams test flake

### DIFF
--- a/dd-java-agent/instrumentation/kafka/kafka-connect-0.11/src/test/groovy/ConnectWorkerInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/kafka/kafka-connect-0.11/src/test/groovy/ConnectWorkerInstrumentationTest.groovy
@@ -29,8 +29,11 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 class ConnectWorkerInstrumentationTest extends InstrumentationSpecification {
+  private static final String SOURCE_TOPIC = 'source-test-topic'
+  private static final String SINK_TOPIC = 'sink-test-topic'
+
   @Shared
-  EmbeddedKafkaBroker embeddedKafka = new EmbeddedKafkaBroker(1, false, 1, 'test-topic')
+  EmbeddedKafkaBroker embeddedKafka = new EmbeddedKafkaBroker(1, false, 1, SOURCE_TOPIC, SINK_TOPIC)
 
   def setupSpec() {
     embeddedKafka.afterPropertiesSet() // Initializes the broker
@@ -97,7 +100,7 @@ class ConnectWorkerInstrumentationTest extends InstrumentationSpecification {
       'connector.class': 'org.apache.kafka.connect.file.FileStreamSourceConnector',
       'tasks.max'     : '1',
       'file'          : tempFile.getAbsolutePath(),
-      'topic'         : 'test-topic'
+      'topic'         : SOURCE_TOPIC
     ]
 
     // Latch to wait for connector addition
@@ -133,7 +136,7 @@ class ConnectWorkerInstrumentationTest extends InstrumentationSpecification {
     consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer")
 
     KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProps)
-    consumer.subscribe(['test-topic'])
+    consumer.subscribe([SOURCE_TOPIC])
 
     String receivedMessage = null
     for (int i = 0; i < 10; i++) {
@@ -144,30 +147,24 @@ class ConnectWorkerInstrumentationTest extends InstrumentationSpecification {
         break
       }
     }
-    TEST_DATA_STREAMS_WRITER.waitForGroups(2)
-
     then:
     receivedMessage == "Hello Kafka"
 
-    StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find {
-      it.parentHash == 0
-    }
+    List<StatsGroup> pathway = waitForPathway(SOURCE_TOPIC, "test-consumer-group")
+    StatsGroup first = pathway[0]
     verifyAll(first) {
       tags.hasAllTags(
       "direction:out",
-      "topic:test-topic",
+      "topic:" + SOURCE_TOPIC,
       "type:kafka"
       )
     }
 
-    StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find {
-      it.parentHash == first.hash
-    }
+    StatsGroup second = pathway[1]
     verifyAll(second) {
-      tags.hasAllTags("direction:in", "group:test-consumer-group", "topic:test-topic", "type:kafka")
+      tags.hasAllTags("direction:in", "group:test-consumer-group", "topic:" + SOURCE_TOPIC, "type:kafka")
     }
     TEST_DATA_STREAMS_WRITER.getServices().contains('file-source-connector')
-
 
     cleanup:
     consumer?.close()
@@ -233,7 +230,7 @@ class ConnectWorkerInstrumentationTest extends InstrumentationSpecification {
       'connector.class': 'org.apache.kafka.connect.file.FileStreamSinkConnector',
       'tasks.max'      : '1',
       'file'           : sinkFile.getAbsolutePath(),
-      'topics'         : 'test-topic'
+      'topics'         : SINK_TOPIC
     ]
 
     // Latch to wait for connector addition
@@ -265,7 +262,7 @@ class ConnectWorkerInstrumentationTest extends InstrumentationSpecification {
     producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer")
 
     KafkaProducer<String, String> producer = new KafkaProducer<>(producerProps)
-    producer.send(new ProducerRecord<>("test-topic", "key1", "Hello Kafka Sink"))
+    producer.send(new ProducerRecord<>(SINK_TOPIC, "key1", "Hello Kafka Sink"))
     producer.flush()
     producer.close()
 
@@ -278,31 +275,46 @@ class ConnectWorkerInstrumentationTest extends InstrumentationSpecification {
     }
 
     String fileContents = sinkFile.text
-    TEST_DATA_STREAMS_WRITER.waitForGroups(2)
-
     then:
     fileContents.contains("Hello Kafka Sink")
 
-    StatsGroup first = TEST_DATA_STREAMS_WRITER.groups.find {
-      it.parentHash == 0
-    }
+    List<StatsGroup> pathway = waitForPathway(SINK_TOPIC, "connect-file-sink-connector")
+    StatsGroup first = pathway[0]
     verifyAll(first) {
-      tags.hasAllTags("direction:out", "topic:test-topic", "type:kafka")
+      tags.hasAllTags("direction:out", "topic:" + SINK_TOPIC, "type:kafka")
     }
 
-    StatsGroup second = TEST_DATA_STREAMS_WRITER.groups.find {
-      it.parentHash == first.hash
-    }
+    StatsGroup second = pathway[1]
     verifyAll(second) {
-      tags.hasAllTags("direction:in", "group:connect-file-sink-connector", "topic:test-topic", "type:kafka")
+      tags.hasAllTags("direction:in", "group:connect-file-sink-connector", "topic:" + SINK_TOPIC, "type:kafka")
     }
     TEST_DATA_STREAMS_WRITER.getServices().contains('file-sink-connector')
-
 
     cleanup:
     herder?.stop()
     worker?.stop()
     sinkFile?.delete()
+  }
+
+  private List<StatsGroup> waitForPathway(String topic, String group) {
+    long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10)
+    while (System.currentTimeMillis() < deadline) {
+      StatsGroup producer = TEST_DATA_STREAMS_WRITER.groups.find {
+        it.parentHash == 0 &&
+        it.tags.hasAllTags("direction:out", "topic:" + topic, "type:kafka")
+      }
+      if (producer != null) {
+        StatsGroup consumer = TEST_DATA_STREAMS_WRITER.groups.find {
+          it.parentHash == producer.hash &&
+          it.tags.hasAllTags("direction:in", "group:" + group, "topic:" + topic, "type:kafka")
+        }
+        if (consumer != null) {
+          return [producer, consumer]
+        }
+      }
+      Thread.sleep(20)
+    }
+    throw new AssertionError("No matching data-stream pathway found for topic " + topic + " and group " + group)
   }
 
   @Override


### PR DESCRIPTION
# What Does This Do

- Isolates the Kafka Connect source and sink instrumentation tests on separate topics.
- Waits for the exact tagged producer-to-consumer data-stream pathway instead of assuming that any two recorded groups form the expected chain.

# Motivation

GitLab job [1915544954](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/jobs/1915544954) exposed a flaky sink instrumentation test. The shared topic retained the source test's record, so the sink connector could consume that stale record before the newly produced one. `waitForGroups(2)` then returned with a current producer group and an unrelated consumer group, causing the expected child lookup to return `null`.

Test failed with:
```
org.spockframework.runtime.SpockAssertionError: Target of 'verifyAll' block must not be null

Target of 'verifyAll' block must not be null
	at spock.lang.Specification.verifyAll(Specification.java:286)
	at ConnectWorkerInstrumentationTest.test kafka-connect sink instrumentation(ConnectWorkerInstrumentationTest.groovy:296)
```
And later passed via Develocity Gradle plugin retry.

# Additional Notes

Validation:

- `./gradlew :dd-java-agent:instrumentation:kafka:kafka-connect-0.11:test --tests 'ConnectWorkerInstrumentationTest' -PtestJvm=11 --rerun-tasks`
- `./gradlew :dd-java-agent:instrumentation:kafka:kafka-connect-0.11:spotlessCheck`
- Repository pre-commit formatting and CodeNarc checks

Relevant precedent PRs: none.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: N/A
