### PR TITLE
Add dd-octo-sts trust policy for vuln-intake-triage (read-only)

### DIFF
--- a/.github/chainguard/vuln-intake-triage.fp-check-read.sts.yaml
+++ b/.github/chainguard/vuln-intake-triage.fp-check-read.sts.yaml
@@ -1,0 +1,9 @@
+issuer: https://ticino.identity.local-cluster.local-dc.fabric.dog:8443/v1/issuer/sycamore
+
+subject_pattern: "rapid-secops\\.vuln-intake-triage@kubernetes\\.us1\\.(staging|prod)\\.dog"
+
+claim_pattern:
+  email: "rapid-secops\\.vuln-intake-triage@kubernetes\\.us1\\.(staging|prod)\\.dog"
+
+permissions:
+  contents: read


### PR DESCRIPTION
Adds a `dd-octo-sts` trust policy granting Datadog's `vuln-intake-triage` service (running in the `rapid-secops` Kubernetes namespace) **read-only** (`contents: read`) access to this repo.

### Why

`vuln-intake-triage` fetches a bounded source-code window around SAST findings that point into this repo, and feeds it to an LLM-based false-positive check. Reading the relevant source is what lets the check distinguish a real finding from a false positive before it reaches a human triager.

### Scope

- **Only** `contents: read`. No other permissions are requested.
- Per-repo policy, scoped to this repo alone — not an org-wide policy.
- The subject/claim patterns are pinned to the service's exact staging and prod identities, so no other workload can mint a token under this policy.

### Reviewer context

dd-octo-sts user guide: https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/5138645099/User+guide+dd-octo-sts

The file follows the same structure as the existing policies in `.github/chainguard/`.