### PR TITLE
Extract Lambda event parsing out of LambdaAppSecHandler

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
@@ -1,11 +1,13 @@
 package datadog.trace.lambda;
 
 import static datadog.trace.api.gateway.Events.EVENTS;
+import static datadog.trace.lambda.LambdaEventParser.MAX_EVENT_SIZE;
+import static datadog.trace.lambda.LambdaEventParser.buildFullPath;
+import static datadog.trace.lambda.LambdaEventParser.parseEvent;
+import static datadog.trace.lambda.LambdaEventParser.parseJsonValue;
+import static datadog.trace.lambda.LambdaEventParser.parseResponse;
 
-import com.squareup.moshi.JsonAdapter;
-import com.squareup.moshi.Moshi;
 import datadog.logging.RatelimitedLogger;
-import datadog.trace.api.Config;
 import datadog.trace.api.ProductTraceSource;
 import datadog.trace.api.appsec.AppSecContext;
 import datadog.trace.api.function.TriConsumer;
@@ -24,24 +26,18 @@ import datadog.trace.bootstrap.instrumentation.api.ClientIpAddressData;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
-import datadog.trace.bootstrap.instrumentation.api.URIDataAdapterBase;
+import datadog.trace.lambda.LambdaEventParser.LambdaRequestData;
+import datadog.trace.lambda.LambdaEventParser.LambdaResponseData;
+import datadog.trace.lambda.LambdaEventParser.LambdaTriggerType;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,12 +49,6 @@ public class LambdaAppSecHandler {
 
   private static final Logger log = LoggerFactory.getLogger(LambdaAppSecHandler.class);
   private static final RatelimitedLogger rlLog = new RatelimitedLogger(log, 5, TimeUnit.MINUTES);
-
-  private static final Moshi MOSHI = new Moshi.Builder().build();
-  private static final JsonAdapter<Map> MAP_ADAPTER = MOSHI.adapter(Map.class);
-  private static final JsonAdapter<Object> OBJECT_ADAPTER = MOSHI.adapter(Object.class);
-
-  private static final int MAX_EVENT_SIZE = Config.get().getAppSecBodyParsingSizeLimit();
 
   // Carries the detected trigger type from processRequestStart to processResponseData within the
   // same Lambda invocation. Cleared in processRequestEnd.
@@ -88,8 +78,8 @@ public class LambdaAppSecHandler {
     }
 
     try {
-      LambdaEventData eventData = extractEventData((ByteArrayInputStream) event);
-      if (eventData == LambdaEventData.EMPTY) {
+      LambdaRequestData eventData = parseEvent((ByteArrayInputStream) event);
+      if (eventData == LambdaRequestData.EMPTY) {
         return null;
       }
       CURRENT_TRIGGER_TYPE.set(eventData.triggerType);
@@ -163,7 +153,7 @@ public class LambdaAppSecHandler {
       }
 
       String json = new String(bytes, StandardCharsets.UTF_8);
-      LambdaResponseData responseData = extractResponseData(json);
+      LambdaResponseData responseData = parseResponse(json);
 
       // Only process responses for known HTTP trigger types
       LambdaTriggerType triggerType = CURRENT_TRIGGER_TYPE.get();
@@ -179,7 +169,7 @@ public class LambdaAppSecHandler {
           Object fallbackBody;
           String fallbackContentType;
           try {
-            fallbackBody = OBJECT_ADAPTER.fromJson(json);
+            fallbackBody = parseJsonValue(json);
             fallbackContentType = "application/json";
           } catch (Exception e) {
             fallbackBody = json;
@@ -246,84 +236,6 @@ public class LambdaAppSecHandler {
     }
   }
 
-  static LambdaResponseData extractResponseData(String json) {
-    try {
-      Map<String, Object> response = MAP_ADAPTER.fromJson(json);
-      if (response == null) {
-        return null;
-      }
-
-      // Extract status code
-      int statusCode = 0;
-      Object statusCodeObj = response.get("statusCode");
-      if (statusCodeObj instanceof Number) {
-        statusCode = ((Number) statusCodeObj).intValue();
-      }
-
-      // Extract headers — keys are lowercased to normalise casing across API GW / ALB variants
-      Map<String, String> headers = new HashMap<>();
-      Map<String, String> rawHeaders = extractStringMap(response.get("headers"));
-      for (Map.Entry<String, String> entry : rawHeaders.entrySet()) {
-        headers.put(entry.getKey().toLowerCase(Locale.ROOT), entry.getValue());
-      }
-
-      // Merge multiValueHeaders if present (API GW v1 / ALB), also lowercasing keys
-      Object multiValueHeadersObj = response.get("multiValueHeaders");
-      if (multiValueHeadersObj instanceof Map) {
-        Map<?, ?> multiValueHeaders = (Map<?, ?>) multiValueHeadersObj;
-        for (Map.Entry<?, ?> entry : multiValueHeaders.entrySet()) {
-          if (entry.getKey() != null && entry.getValue() instanceof List) {
-            String key = String.valueOf(entry.getKey()).toLowerCase(Locale.ROOT);
-            List<?> values = (List<?>) entry.getValue();
-            String joinedValue =
-                values.stream().map(String::valueOf).collect(Collectors.joining(", "));
-            headers.put(key, joinedValue);
-          }
-        }
-      }
-
-      // Extract body
-      Object body = null;
-      Object bodyObj = response.get("body");
-      if (bodyObj != null) {
-        String bodyString = String.valueOf(bodyObj);
-
-        // Handle base64 encoding
-        Object isBase64EncodedObj = response.get("isBase64Encoded");
-        if (Boolean.TRUE.equals(isBase64EncodedObj) || "true".equals(isBase64EncodedObj)) {
-          try {
-            bodyString = new String(Base64.getDecoder().decode(bodyString), StandardCharsets.UTF_8);
-          } catch (Exception e) {
-            log.debug("Failed to decode base64 response body", e);
-            bodyString = null;
-          }
-        }
-
-        if (bodyString != null) {
-          String contentType = headers.get("content-type");
-
-          // If JSON content-type or unknown, attempt JSON parsing
-          // Normalise casing: media type tokens are case-insensitive per RFC 7231
-          String contentTypeLower =
-              contentType == null ? null : contentType.toLowerCase(Locale.ROOT);
-          if (contentTypeLower == null
-              || contentTypeLower.contains("json")
-              || contentTypeLower.contains("javascript")) {
-            Object parsed = parseBodyAsJson(bodyString);
-            body = parsed != null ? parsed : bodyString;
-          } else {
-            body = bodyString;
-          }
-        }
-      }
-
-      return new LambdaResponseData(statusCode, headers, body);
-    } catch (Exception e) {
-      log.debug("Failed to parse response data from JSON", e);
-      return null;
-    }
-  }
-
   /**
    * Merge AppSec context data into extension context.
    *
@@ -359,7 +271,7 @@ public class LambdaAppSecHandler {
     return extensionContext;
   }
 
-  private static AgentSpanContext processAppSecRequestData(LambdaEventData eventData) {
+  private static AgentSpanContext processAppSecRequestData(LambdaRequestData eventData) {
     AgentTracer.TracerAPI tracer = AgentTracer.get();
     Supplier<Flow<Object>> requestStartedCallback =
         tracer.getCallbackProvider(RequestContextSlot.APPSEC).getCallback(EVENTS.requestStarted());
@@ -465,530 +377,6 @@ public class LambdaAppSecHandler {
     return tagContext;
   }
 
-  private static LambdaEventData extractEventData(ByteArrayInputStream inputStream)
-      throws IOException {
-    inputStream.mark(0);
-    try {
-      int availableBytes = inputStream.available();
-
-      if (availableBytes <= 0 || availableBytes > MAX_EVENT_SIZE) {
-        log.debug(
-            "Event size {} exceeds limit {} or is invalid, skipping AppSec processing",
-            availableBytes,
-            MAX_EVENT_SIZE);
-        return LambdaEventData.EMPTY;
-      }
-
-      byte[] bytes = new byte[availableBytes];
-      int read = inputStream.read(bytes);
-      if (read <= 0) {
-        return LambdaEventData.EMPTY;
-      }
-      return extractEventDataFromJson(new String(bytes, 0, read, StandardCharsets.UTF_8));
-    } finally {
-      inputStream.reset();
-    }
-  }
-
-  private static LambdaEventData extractEventDataFromJson(String json) {
-    try {
-      // Parse JSON into a Map
-      Map<String, Object> event = MAP_ADAPTER.fromJson(json);
-      log.debug("Event JSON parsed successfully");
-
-      if (event == null) {
-        return LambdaEventData.EMPTY;
-      }
-
-      // Detect trigger type
-      LambdaTriggerType triggerType = detectTriggerType(event);
-      log.debug("Detected Lambda trigger type: {}", triggerType);
-
-      // Extract data based on trigger type
-      switch (triggerType) {
-        case API_GATEWAY_V1_REST:
-          return extractApiGatewayV1Data(event);
-        case API_GATEWAY_V2_HTTP:
-        case LAMBDA_URL:
-          return extractApiGatewayV2HttpData(event, triggerType);
-        case API_GATEWAY_V2_WEBSOCKET:
-          return extractApiGatewayV2WebSocketData(event);
-        case ALB:
-        case ALB_MULTI_VALUE:
-          return extractAlbData(event, triggerType);
-        default:
-          log.debug("Unknown trigger type, attempting generic extraction");
-          return extractGenericData(event);
-      }
-    } catch (Exception e) {
-      log.debug("Failed to parse event data from JSON", e);
-      return LambdaEventData.EMPTY;
-    }
-  }
-
-  static LambdaTriggerType detectTriggerType(Map<String, Object> event) {
-    Object requestContextObj = event.get("requestContext");
-
-    if (requestContextObj instanceof Map) {
-      Map<?, ?> requestContext = (Map<?, ?>) requestContextObj;
-
-      // Check for ALB trigger (has elb object)
-      if (requestContext.containsKey("elb")) {
-        // Check if event has multiValueHeaders
-        if (event.containsKey("multiValueHeaders")) {
-          return LambdaTriggerType.ALB_MULTI_VALUE;
-        }
-        return LambdaTriggerType.ALB;
-      }
-
-      // Check for WebSocket
-      if (requestContext.containsKey("connectionId")
-          && (requestContext.containsKey("eventType") || requestContext.containsKey("routeKey"))) {
-        return LambdaTriggerType.API_GATEWAY_V2_WEBSOCKET;
-      }
-
-      // Check for API Gateway v2 format
-      Object httpObj = requestContext.get("http");
-      if (httpObj instanceof Map) {
-        Object domainNameObj = requestContext.get("domainName");
-        if (domainNameObj instanceof String) {
-          String domainName = (String) domainNameObj;
-          if (domainName.contains("lambda-url")) {
-            return LambdaTriggerType.LAMBDA_URL;
-          } else {
-            return LambdaTriggerType.API_GATEWAY_V2_HTTP;
-          }
-        } else {
-          return LambdaTriggerType.LAMBDA_URL;
-        }
-      }
-
-      // Check for API Gateway v1 REST API
-      if (requestContext.containsKey("httpMethod") || requestContext.containsKey("requestId")) {
-        return LambdaTriggerType.API_GATEWAY_V1_REST;
-      }
-    }
-    return LambdaTriggerType.UNKNOWN;
-  }
-
-  /** Extracts data from API Gateway v1 (REST API) event */
-  private static LambdaEventData extractApiGatewayV1Data(Map<String, Object> event) {
-    Map<String, String> headers = extractHeaders(event.get("headers"));
-    Map<String, String> pathParameters = extractPathParameters(event.get("pathParameters"));
-    Map<String, List<String>> queryParameters =
-        extractQueryParameters(event.get("queryStringParameters"));
-    Object body = extractBody(event);
-
-    Map<?, ?> requestContext = (Map<?, ?>) event.get("requestContext");
-    String method = (String) requestContext.get("httpMethod");
-    String path = (String) event.get("path");
-
-    String sourceIp = null;
-    Object identityObj = requestContext.get("identity");
-    if (identityObj instanceof Map) {
-      Map<?, ?> identity = (Map<?, ?>) identityObj;
-      sourceIp = (String) identity.get("sourceIp");
-    }
-
-    return new LambdaEventData(
-        headers,
-        method,
-        path,
-        sourceIp,
-        null,
-        LambdaTriggerType.API_GATEWAY_V1_REST,
-        pathParameters,
-        queryParameters,
-        body);
-  }
-
-  /** Extracts data from API Gateway v2 (HTTP API) or Lambda URL event */
-  private static LambdaEventData extractApiGatewayV2HttpData(
-      Map<String, Object> event, LambdaTriggerType triggerType) {
-    Map<String, String> headers = extractHeadersWithCookies(event);
-    Map<String, String> pathParameters = extractPathParameters(event.get("pathParameters"));
-    Map<String, List<String>> queryParameters =
-        extractQueryParameters(event.get("queryStringParameters"));
-    Object body = extractBody(event);
-
-    Map<?, ?> requestContext = (Map<?, ?>) event.get("requestContext");
-    Map<?, ?> http = (Map<?, ?>) requestContext.get("http");
-
-    String method = (String) http.get("method");
-    String path = (String) http.get("path");
-    String sourceIp = (String) http.get("sourceIp");
-
-    // Extract port if available
-    Integer sourcePort = null;
-    Object portObj = http.get("sourcePort");
-    if (portObj instanceof Number) {
-      sourcePort = ((Number) portObj).intValue();
-    }
-
-    return new LambdaEventData(
-        headers,
-        method,
-        path,
-        sourceIp,
-        sourcePort,
-        triggerType,
-        pathParameters,
-        queryParameters,
-        body);
-  }
-
-  /** Extracts data from API Gateway v2 WebSocket event */
-  private static LambdaEventData extractApiGatewayV2WebSocketData(Map<String, Object> event) {
-    Map<String, String> headers = extractHeadersWithCookies(event);
-    Map<String, String> pathParameters = extractPathParameters(event.get("pathParameters"));
-    Map<String, List<String>> queryParameters =
-        extractQueryParameters(event.get("queryStringParameters"));
-    Object body = extractBody(event);
-
-    Map<?, ?> requestContext = (Map<?, ?>) event.get("requestContext");
-
-    String method = "WEBSOCKET";
-    String routeKey = (String) requestContext.get("routeKey");
-    String path = routeKey != null ? routeKey : "/";
-
-    String sourceIp = null;
-    Object identityObj = requestContext.get("identity");
-    if (identityObj instanceof Map) {
-      Map<?, ?> identity = (Map<?, ?>) identityObj;
-      sourceIp = (String) identity.get("sourceIp");
-    }
-
-    return new LambdaEventData(
-        headers,
-        method,
-        path,
-        sourceIp,
-        null,
-        LambdaTriggerType.API_GATEWAY_V2_WEBSOCKET,
-        pathParameters,
-        queryParameters,
-        body);
-  }
-
-  /** Extracts data from ALB event (with or without multi-value headers) */
-  private static LambdaEventData extractAlbData(
-      Map<String, Object> event, LambdaTriggerType triggerType) {
-    Map<String, String> headers;
-
-    if (triggerType == LambdaTriggerType.ALB_MULTI_VALUE) {
-      // Handle multi-value headers (combine multiple values with comma)
-      headers = new HashMap<>();
-      Object multiValueHeadersObj = event.get("multiValueHeaders");
-      if (multiValueHeadersObj instanceof Map) {
-        Map<?, ?> rawHeaders = (Map<?, ?>) multiValueHeadersObj;
-        for (Map.Entry<?, ?> entry : rawHeaders.entrySet()) {
-          if (entry.getKey() != null && entry.getValue() != null) {
-            String key = String.valueOf(entry.getKey());
-            if (entry.getValue() instanceof List) {
-              List<?> values = (List<?>) entry.getValue();
-              // Join multiple values with comma
-              String joinedValue =
-                  values.stream().map(String::valueOf).collect(Collectors.joining(", "));
-              headers.put(key, joinedValue);
-            } else {
-              headers.put(key, String.valueOf(entry.getValue()));
-            }
-          }
-        }
-      }
-    } else {
-      headers = extractHeaders(event.get("headers"));
-    }
-
-    Map<String, String> pathParameters = extractPathParameters(event.get("pathParameters"));
-
-    // ALB can have both queryStringParameters and multiValueQueryStringParameters
-    Map<String, List<String>> queryParameters;
-    if (triggerType == LambdaTriggerType.ALB_MULTI_VALUE) {
-      queryParameters =
-          extractMultiValueQueryParameters(event.get("multiValueQueryStringParameters"));
-    } else {
-      queryParameters = extractQueryParameters(event.get("queryStringParameters"));
-    }
-
-    Object body = extractBody(event);
-
-    String method = (String) event.get("httpMethod");
-    String path = (String) event.get("path");
-    String xff = headers.get("x-forwarded-for");
-    String sourceIp = null;
-    if (xff != null) {
-      int commaIdx = xff.indexOf(',');
-      sourceIp = (commaIdx >= 0 ? xff.substring(0, commaIdx) : xff).trim();
-    }
-
-    return new LambdaEventData(
-        headers, method, path, sourceIp, null, triggerType, pathParameters, queryParameters, body);
-  }
-
-  /** Generic data extraction for unknown trigger types (fallback) */
-  private static LambdaEventData extractGenericData(Map<String, Object> event) {
-    Map<String, String> headers = extractHeadersWithCookies(event);
-    Map<String, String> pathParameters = extractPathParameters(event.get("pathParameters"));
-    Map<String, List<String>> queryParameters =
-        extractQueryParameters(event.get("queryStringParameters"));
-    Object body = extractBody(event);
-
-    String method = null;
-    String path = null;
-    String sourceIp = null;
-
-    // Try to extract from requestContext if available
-    Object requestContextObj = event.get("requestContext");
-    if (requestContextObj instanceof Map) {
-      Map<?, ?> requestContext = (Map<?, ?>) requestContextObj;
-
-      Object httpObj = requestContext.get("http");
-      if (httpObj instanceof Map) {
-        Map<?, ?> http = (Map<?, ?>) httpObj;
-        method = (String) http.get("method");
-        path = (String) http.get("path");
-        sourceIp = (String) http.get("sourceIp");
-      } else {
-        Object methodObj = requestContext.get("httpMethod");
-        if (methodObj != null) {
-          method = String.valueOf(methodObj);
-        }
-
-        Object identityObj = requestContext.get("identity");
-        if (identityObj instanceof Map) {
-          Map<?, ?> identity = (Map<?, ?>) identityObj;
-          sourceIp = (String) identity.get("sourceIp");
-        }
-      }
-    }
-
-    // Try root level fields
-    if (method == null) {
-      Object methodObj = event.get("httpMethod");
-      if (methodObj != null) {
-        method = String.valueOf(methodObj);
-      }
-    }
-    if (path == null) {
-      Object pathObj = event.get("path");
-      if (pathObj != null) {
-        path = String.valueOf(pathObj);
-      }
-    }
-
-    return new LambdaEventData(
-        headers,
-        method,
-        path,
-        sourceIp,
-        null,
-        LambdaTriggerType.UNKNOWN,
-        pathParameters,
-        queryParameters,
-        body);
-  }
-
-  /**
-   * Generic helper method to extract string key-value pairs from an object. Converts all keys and
-   * values to strings, filtering out null entries.
-   */
-  private static Map<String, String> extractStringMap(Object mapObj) {
-    Map<String, String> result = new HashMap<>();
-    if (mapObj instanceof Map) {
-      Map<?, ?> rawMap = (Map<?, ?>) mapObj;
-      for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
-        if (entry.getKey() != null && entry.getValue() != null) {
-          String key = String.valueOf(entry.getKey());
-          String value = String.valueOf(entry.getValue());
-          result.put(key, value);
-        }
-      }
-    }
-    return result;
-  }
-
-  /** Helper method to extract headers from event */
-  private static Map<String, String> extractHeaders(Object headersObj) {
-    Map<String, String> headers = extractStringMap(headersObj);
-    log.debug("Extracted {} headers", headers.size());
-    if (headers.containsKey("cookie")) {
-      log.debug("Cookie header found with value length: {}", headers.get("cookie").length());
-    }
-    return headers;
-  }
-
-  /** Helper method to extract path parameters from event */
-  private static Map<String, String> extractPathParameters(Object pathParamsObj) {
-    Map<String, String> pathParams = extractStringMap(pathParamsObj);
-    log.debug("Extracted {} path parameters", pathParams.size());
-    return pathParams;
-  }
-
-  /**
-   * Helper method to extract query parameters from event. Converts Map<String, String> to
-   * Map<String, List<String>> format expected by AppSec.
-   */
-  private static Map<String, List<String>> extractQueryParameters(Object queryParamsObj) {
-    Map<String, List<String>> result = new HashMap<>();
-    if (queryParamsObj instanceof Map) {
-      Map<?, ?> rawMap = (Map<?, ?>) queryParamsObj;
-      for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
-        if (entry.getKey() != null && entry.getValue() != null) {
-          String key = String.valueOf(entry.getKey());
-          String value = String.valueOf(entry.getValue());
-          result.put(key, Collections.singletonList(value));
-        }
-      }
-    }
-    log.debug("Extracted {} query parameters", result.size());
-    return result;
-  }
-
-  /**
-   * Helper method to extract multi-value query parameters (used by ALB). Handles Map<String,
-   * List<String>> format directly.
-   */
-  private static Map<String, List<String>> extractMultiValueQueryParameters(Object queryParamsObj) {
-    Map<String, List<String>> result = new HashMap<>();
-    if (queryParamsObj instanceof Map) {
-      Map<?, ?> rawMap = (Map<?, ?>) queryParamsObj;
-      for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
-        if (entry.getKey() != null && entry.getValue() != null) {
-          String key = String.valueOf(entry.getKey());
-          if (entry.getValue() instanceof List) {
-            List<?> values = (List<?>) entry.getValue();
-            List<String> stringValues = new ArrayList<>();
-            for (Object value : values) {
-              if (value != null) {
-                stringValues.add(String.valueOf(value));
-              }
-            }
-            result.put(key, stringValues);
-          } else {
-            result.put(key, Collections.singletonList(String.valueOf(entry.getValue())));
-          }
-        }
-      }
-    }
-    log.debug("Extracted {} multi-value query parameters", result.size());
-    return result;
-  }
-
-  /**
-   * Helper method to build full path including query string. Lambda events provide path and query
-   * parameters separately, so we need to reconstruct the full URI for AppSec to parse.
-   */
-  private static String buildFullPath(String path, Map<String, List<String>> queryParameters) {
-    if (queryParameters == null || queryParameters.isEmpty()) {
-      return path;
-    }
-
-    StringBuilder fullPath = new StringBuilder(path);
-    fullPath.append('?');
-
-    boolean first = true;
-    for (Map.Entry<String, List<String>> entry : queryParameters.entrySet()) {
-      String key = entry.getKey();
-      for (String value : entry.getValue()) {
-        if (!first) {
-          fullPath.append('&');
-        }
-        first = false;
-        try {
-          // URL-encode key and value so that special characters (e.g. '&' inside a value) are not
-          // mistaken for query string delimiters when AppSec parses the raw query string.
-          fullPath.append(URLEncoder.encode(key, "UTF-8"));
-          if (value != null) {
-            fullPath.append('=').append(URLEncoder.encode(value, "UTF-8"));
-          }
-        } catch (java.io.UnsupportedEncodingException e) {
-          // UTF-8 is always available; fall back to unencoded
-          fullPath.append(key);
-          if (value != null) {
-            fullPath.append('=').append(value);
-          }
-        }
-      }
-    }
-
-    return fullPath.toString();
-  }
-
-  /**
-   * Helper method to extract and merge headers with cookies array from event. API Gateway v2
-   * provides a separate 'cookies' array that should be merged with headers.
-   */
-  private static Map<String, String> extractHeadersWithCookies(Map<String, Object> event) {
-    Map<String, String> headers = extractHeaders(event.get("headers"));
-
-    // API Gateway v2 provides a pre-parsed cookies array
-    Object cookiesObj = event.get("cookies");
-    if (cookiesObj instanceof List) {
-      List<?> cookiesList = (List<?>) cookiesObj;
-      if (!cookiesList.isEmpty()) {
-        // Join cookies with "; " separator per RFC 6265
-        String cookieValue =
-            cookiesList.stream().map(String::valueOf).collect(Collectors.joining("; "));
-
-        // Merge with existing cookie header if present
-        String existingCookie = headers.get("cookie");
-        if (existingCookie != null && !existingCookie.isEmpty()) {
-          headers.put("cookie", existingCookie + "; " + cookieValue);
-        } else {
-          headers.put("cookie", cookieValue);
-        }
-      }
-    }
-
-    return headers;
-  }
-
-  /** Helper method to extract and parse body from event */
-  private static Object extractBody(Map<String, Object> event) {
-    Object bodyObj = event.get("body");
-    if (bodyObj == null) {
-      return null;
-    }
-
-    String bodyString = String.valueOf(bodyObj);
-
-    // Check if body is base64 encoded (API Gateway feature)
-    Object isBase64EncodedObj = event.get("isBase64Encoded");
-    if (Boolean.TRUE.equals(isBase64EncodedObj) || "true".equals(isBase64EncodedObj)) {
-      try {
-        bodyString = new String(Base64.getDecoder().decode(bodyString), StandardCharsets.UTF_8);
-      } catch (Exception e) {
-        log.debug("Failed to decode base64 body", e);
-        return null;
-      }
-    }
-
-    // Try to parse as JSON
-    Object parsedBody = parseBodyAsJson(bodyString);
-    if (parsedBody != null) {
-      log.debug("Body parsed as JSON successfully");
-      return parsedBody;
-    }
-
-    // If not JSON, return the raw string
-    log.debug("Body is not JSON, returning raw string");
-    return bodyString;
-  }
-
-  /** Helper method to parse body as JSON */
-  private static Object parseBodyAsJson(String body) {
-    if (body == null || body.isEmpty() || "null".equals(body)) {
-      return null;
-    }
-
-    try {
-      return OBJECT_ADAPTER.fromJson(body);
-    } catch (Exception e) {
-      return null;
-    }
-  }
-
   /** Sets the current trigger type thread-local. Package-private for use in tests only. */
   static void setCurrentTriggerType(LambdaTriggerType type) {
     if (type == null) {
@@ -1049,163 +437,6 @@ public class LambdaAppSecHandler {
     @Override
     public void close() {
       // No-op for temporary context
-    }
-  }
-
-  /** Enum representing different AWS Lambda trigger types */
-  enum LambdaTriggerType {
-    API_GATEWAY_V1_REST, // API Gateway REST API (v1)
-    API_GATEWAY_V2_HTTP, // API Gateway HTTP API (v2)
-    API_GATEWAY_V2_WEBSOCKET, // API Gateway WebSocket
-    ALB, // Application Load Balancer
-    ALB_MULTI_VALUE, // ALB with multi-value headers
-    LAMBDA_URL, // Lambda Function URL
-    UNKNOWN; // Unknown or unsupported trigger
-
-    boolean isHttp() {
-      return this != UNKNOWN;
-    }
-  }
-
-  /** Object for Lambda event data needed for AppSec processing */
-  static class LambdaEventData {
-    final Map<String, String> headers;
-    final String method;
-    final String path;
-    final String sourceIp;
-    final Integer sourcePort;
-    final LambdaTriggerType triggerType;
-    final Map<String, String> pathParameters;
-    final Map<String, List<String>> queryParameters;
-    final Object body;
-
-    static final LambdaEventData EMPTY =
-        new LambdaEventData(
-            Collections.emptyMap(),
-            null,
-            null,
-            null,
-            null,
-            LambdaTriggerType.UNKNOWN,
-            Collections.emptyMap(),
-            Collections.emptyMap(),
-            null);
-
-    LambdaEventData(
-        Map<String, String> headers,
-        String method,
-        String path,
-        String sourceIp,
-        Integer sourcePort,
-        LambdaTriggerType triggerType,
-        Map<String, String> pathParameters,
-        Map<String, List<String>> queryParameters,
-        Object body) {
-      this.headers = headers;
-      this.method = method;
-      this.path = path;
-      this.sourceIp = sourceIp;
-      this.sourcePort = sourcePort;
-      this.triggerType = triggerType;
-      this.pathParameters = pathParameters;
-      this.queryParameters = queryParameters;
-      this.body = body;
-    }
-  }
-
-  /** Data extracted from a Lambda response for WAF analysis */
-  static class LambdaResponseData {
-    final int statusCode;
-    final Map<String, String> headers;
-    final Object body;
-
-    LambdaResponseData(int statusCode, Map<String, String> headers, Object body) {
-      this.statusCode = statusCode;
-      this.headers = headers;
-      this.body = body;
-    }
-  }
-
-  /** URIDataAdapter implementation for Lambda events. */
-  private static class LambdaURIDataAdapter extends URIDataAdapterBase {
-    private final String path;
-    private final String query;
-    private final String scheme;
-    private final int port;
-
-    LambdaURIDataAdapter(String pathWithQuery, Map<String, String> headers) {
-      if (pathWithQuery != null) {
-        int queryIndex = pathWithQuery.indexOf('?');
-        if (queryIndex != -1) {
-          this.path = pathWithQuery.substring(0, queryIndex);
-          this.query = pathWithQuery.substring(queryIndex + 1);
-        } else {
-          this.path = pathWithQuery;
-          this.query = null;
-        }
-      } else {
-        this.path = "/";
-        this.query = null;
-      }
-
-      String forwardedProto = headers != null ? headers.get("x-forwarded-proto") : null;
-      this.scheme =
-          (forwardedProto != null && !forwardedProto.isEmpty()) ? forwardedProto : "https";
-
-      String forwardedPort = headers != null ? headers.get("x-forwarded-port") : null;
-      int parsedPort = -1;
-      if (forwardedPort != null && !forwardedPort.isEmpty()) {
-        try {
-          parsedPort = Integer.parseInt(forwardedPort.trim());
-        } catch (NumberFormatException ignored) {
-        }
-      }
-      this.port = parsedPort > 0 ? parsedPort : 443;
-    }
-
-    @Override
-    public String scheme() {
-      return scheme;
-    }
-
-    @Override
-    public String host() {
-      return null;
-    }
-
-    @Override
-    public int port() {
-      return port;
-    }
-
-    @Override
-    public String path() {
-      return path;
-    }
-
-    @Override
-    public String fragment() {
-      return null;
-    }
-
-    @Override
-    public String query() {
-      return query;
-    }
-
-    @Override
-    public boolean supportsRaw() {
-      return true;
-    }
-
-    @Override
-    public String rawPath() {
-      return path;
-    }
-
-    @Override
-    public String rawQuery() {
-      return query;
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
@@ -1,0 +1,732 @@
+package datadog.trace.lambda;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import datadog.trace.api.Config;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parses AWS Lambda invocation payloads: detects the trigger type and extracts the HTTP request and
+ * response data the AppSec gateway callbacks need. Contains no AppSec logic.
+ */
+final class LambdaEventParser {
+
+  private static final Logger log = LoggerFactory.getLogger(LambdaEventParser.class);
+
+  private static final Moshi MOSHI = new Moshi.Builder().build();
+  private static final JsonAdapter<Map> MAP_ADAPTER = MOSHI.adapter(Map.class);
+  private static final JsonAdapter<Object> OBJECT_ADAPTER = MOSHI.adapter(Object.class);
+
+  static final int MAX_EVENT_SIZE = Config.get().getAppSecBodyParsingSizeLimit();
+
+  private LambdaEventParser() {}
+
+  /**
+   * Parses a Lambda event payload without consuming it.
+   *
+   * @param inputStream the raw event payload
+   * @return the extracted event data, or {@link LambdaRequestData#EMPTY} if the payload is empty,
+   *     too large or unparseable
+   */
+  static LambdaRequestData parseEvent(ByteArrayInputStream inputStream) throws IOException {
+    inputStream.mark(0);
+    try {
+      int availableBytes = inputStream.available();
+
+      if (availableBytes <= 0 || availableBytes > MAX_EVENT_SIZE) {
+        log.debug(
+            "Event size {} exceeds limit {} or is invalid, skipping AppSec processing",
+            availableBytes,
+            MAX_EVENT_SIZE);
+        return LambdaRequestData.EMPTY;
+      }
+
+      byte[] bytes = new byte[availableBytes];
+      int read = inputStream.read(bytes);
+      if (read <= 0) {
+        return LambdaRequestData.EMPTY;
+      }
+      return parseEvent(new String(bytes, 0, read, StandardCharsets.UTF_8));
+    } finally {
+      inputStream.reset();
+    }
+  }
+
+  static LambdaRequestData parseEvent(String json) {
+    try {
+      // Parse JSON into a Map
+      Map<String, Object> event = MAP_ADAPTER.fromJson(json);
+      log.debug("Event JSON parsed successfully");
+
+      if (event == null) {
+        return LambdaRequestData.EMPTY;
+      }
+
+      // Detect trigger type
+      LambdaTriggerType triggerType = detectTriggerType(event);
+      log.debug("Detected Lambda trigger type: {}", triggerType);
+
+      // Extract data based on trigger type
+      switch (triggerType) {
+        case API_GATEWAY_V1_REST:
+          return extractApiGatewayV1Data(event);
+        case API_GATEWAY_V2_HTTP:
+        case LAMBDA_URL:
+          return extractApiGatewayV2HttpData(event, triggerType);
+        case API_GATEWAY_V2_WEBSOCKET:
+          return extractApiGatewayV2WebSocketData(event);
+        case ALB:
+        case ALB_MULTI_VALUE:
+          return extractAlbData(event, triggerType);
+        default:
+          log.debug("Unknown trigger type, attempting generic extraction");
+          return extractGenericData(event);
+      }
+    } catch (Exception e) {
+      log.debug("Failed to parse event data from JSON", e);
+      return LambdaRequestData.EMPTY;
+    }
+  }
+
+  /**
+   * Parses a Lambda handler response.
+   *
+   * @param json the raw response payload
+   * @return the extracted response data, or {@code null} if the payload is not a JSON object
+   */
+  static LambdaResponseData parseResponse(String json) {
+    try {
+      Map<String, Object> response = MAP_ADAPTER.fromJson(json);
+      if (response == null) {
+        return null;
+      }
+
+      // Extract status code
+      int statusCode = 0;
+      Object statusCodeObj = response.get("statusCode");
+      if (statusCodeObj instanceof Number) {
+        statusCode = ((Number) statusCodeObj).intValue();
+      }
+
+      // Extract headers — keys are lowercased to normalise casing across API GW / ALB variants
+      Map<String, String> headers = new HashMap<>();
+      Map<String, String> rawHeaders = extractStringMap(response.get("headers"));
+      for (Map.Entry<String, String> entry : rawHeaders.entrySet()) {
+        headers.put(entry.getKey().toLowerCase(Locale.ROOT), entry.getValue());
+      }
+
+      // Merge multiValueHeaders if present (API GW v1 / ALB), also lowercasing keys
+      Object multiValueHeadersObj = response.get("multiValueHeaders");
+      if (multiValueHeadersObj instanceof Map) {
+        Map<?, ?> multiValueHeaders = (Map<?, ?>) multiValueHeadersObj;
+        for (Map.Entry<?, ?> entry : multiValueHeaders.entrySet()) {
+          if (entry.getKey() != null && entry.getValue() instanceof List) {
+            String key = String.valueOf(entry.getKey()).toLowerCase(Locale.ROOT);
+            List<?> values = (List<?>) entry.getValue();
+            String joinedValue =
+                values.stream().map(String::valueOf).collect(Collectors.joining(", "));
+            headers.put(key, joinedValue);
+          }
+        }
+      }
+
+      // Extract body
+      Object body = null;
+      Object bodyObj = response.get("body");
+      if (bodyObj != null) {
+        String bodyString = String.valueOf(bodyObj);
+
+        // Handle base64 encoding
+        Object isBase64EncodedObj = response.get("isBase64Encoded");
+        if (Boolean.TRUE.equals(isBase64EncodedObj) || "true".equals(isBase64EncodedObj)) {
+          try {
+            bodyString = new String(Base64.getDecoder().decode(bodyString), StandardCharsets.UTF_8);
+          } catch (Exception e) {
+            log.debug("Failed to decode base64 response body", e);
+            bodyString = null;
+          }
+        }
+
+        if (bodyString != null) {
+          String contentType = headers.get("content-type");
+
+          // If JSON content-type or unknown, attempt JSON parsing
+          // Normalise casing: media type tokens are case-insensitive per RFC 7231
+          String contentTypeLower =
+              contentType == null ? null : contentType.toLowerCase(Locale.ROOT);
+          if (contentTypeLower == null
+              || contentTypeLower.contains("json")
+              || contentTypeLower.contains("javascript")) {
+            Object parsed = parseBodyAsJson(bodyString);
+            body = parsed != null ? parsed : bodyString;
+          } else {
+            body = bodyString;
+          }
+        }
+      }
+
+      return new LambdaResponseData(statusCode, headers, body);
+    } catch (Exception e) {
+      log.debug("Failed to parse response data from JSON", e);
+      return null;
+    }
+  }
+
+  /**
+   * Parses an arbitrary JSON value, propagating parse failures so the caller can distinguish a
+   * malformed payload from a JSON {@code null}.
+   */
+  static Object parseJsonValue(String json) throws IOException {
+    return OBJECT_ADAPTER.fromJson(json);
+  }
+
+  static LambdaTriggerType detectTriggerType(Map<String, Object> event) {
+    Object requestContextObj = event.get("requestContext");
+
+    if (requestContextObj instanceof Map) {
+      Map<?, ?> requestContext = (Map<?, ?>) requestContextObj;
+
+      // Check for ALB trigger (has elb object)
+      if (requestContext.containsKey("elb")) {
+        // Check if event has multiValueHeaders
+        if (event.containsKey("multiValueHeaders")) {
+          return LambdaTriggerType.ALB_MULTI_VALUE;
+        }
+        return LambdaTriggerType.ALB;
+      }
+
+      // Check for WebSocket
+      if (requestContext.containsKey("connectionId")
+          && (requestContext.containsKey("eventType") || requestContext.containsKey("routeKey"))) {
+        return LambdaTriggerType.API_GATEWAY_V2_WEBSOCKET;
+      }
+
+      // Check for API Gateway v2 format
+      Object httpObj = requestContext.get("http");
+      if (httpObj instanceof Map) {
+        Object domainNameObj = requestContext.get("domainName");
+        if (domainNameObj instanceof String) {
+          String domainName = (String) domainNameObj;
+          if (domainName.contains("lambda-url")) {
+            return LambdaTriggerType.LAMBDA_URL;
+          } else {
+            return LambdaTriggerType.API_GATEWAY_V2_HTTP;
+          }
+        } else {
+          return LambdaTriggerType.LAMBDA_URL;
+        }
+      }
+
+      // Check for API Gateway v1 REST API
+      if (requestContext.containsKey("httpMethod") || requestContext.containsKey("requestId")) {
+        return LambdaTriggerType.API_GATEWAY_V1_REST;
+      }
+    }
+    return LambdaTriggerType.UNKNOWN;
+  }
+
+  /** Extracts data from API Gateway v1 (REST API) event */
+  private static LambdaRequestData extractApiGatewayV1Data(Map<String, Object> event) {
+    Map<String, String> headers = extractHeaders(event.get("headers"));
+    Map<String, String> pathParameters = extractPathParameters(event.get("pathParameters"));
+    Map<String, List<String>> queryParameters =
+        extractQueryParameters(event.get("queryStringParameters"));
+    Object body = extractBody(event);
+
+    Map<?, ?> requestContext = (Map<?, ?>) event.get("requestContext");
+    String method = (String) requestContext.get("httpMethod");
+    String path = (String) event.get("path");
+
+    String sourceIp = null;
+    Object identityObj = requestContext.get("identity");
+    if (identityObj instanceof Map) {
+      Map<?, ?> identity = (Map<?, ?>) identityObj;
+      sourceIp = (String) identity.get("sourceIp");
+    }
+
+    return new LambdaRequestData(
+        headers,
+        method,
+        path,
+        sourceIp,
+        null,
+        LambdaTriggerType.API_GATEWAY_V1_REST,
+        pathParameters,
+        queryParameters,
+        body);
+  }
+
+  /** Extracts data from API Gateway v2 (HTTP API) or Lambda URL event */
+  private static LambdaRequestData extractApiGatewayV2HttpData(
+      Map<String, Object> event, LambdaTriggerType triggerType) {
+    Map<String, String> headers = extractHeadersWithCookies(event);
+    Map<String, String> pathParameters = extractPathParameters(event.get("pathParameters"));
+    Map<String, List<String>> queryParameters =
+        extractQueryParameters(event.get("queryStringParameters"));
+    Object body = extractBody(event);
+
+    Map<?, ?> requestContext = (Map<?, ?>) event.get("requestContext");
+    Map<?, ?> http = (Map<?, ?>) requestContext.get("http");
+
+    String method = (String) http.get("method");
+    String path = (String) http.get("path");
+    String sourceIp = (String) http.get("sourceIp");
+
+    // Extract port if available
+    Integer sourcePort = null;
+    Object portObj = http.get("sourcePort");
+    if (portObj instanceof Number) {
+      sourcePort = ((Number) portObj).intValue();
+    }
+
+    return new LambdaRequestData(
+        headers,
+        method,
+        path,
+        sourceIp,
+        sourcePort,
+        triggerType,
+        pathParameters,
+        queryParameters,
+        body);
+  }
+
+  /** Extracts data from API Gateway v2 WebSocket event */
+  private static LambdaRequestData extractApiGatewayV2WebSocketData(Map<String, Object> event) {
+    Map<String, String> headers = extractHeadersWithCookies(event);
+    Map<String, String> pathParameters = extractPathParameters(event.get("pathParameters"));
+    Map<String, List<String>> queryParameters =
+        extractQueryParameters(event.get("queryStringParameters"));
+    Object body = extractBody(event);
+
+    Map<?, ?> requestContext = (Map<?, ?>) event.get("requestContext");
+
+    String method = "WEBSOCKET";
+    String routeKey = (String) requestContext.get("routeKey");
+    String path = routeKey != null ? routeKey : "/";
+
+    String sourceIp = null;
+    Object identityObj = requestContext.get("identity");
+    if (identityObj instanceof Map) {
+      Map<?, ?> identity = (Map<?, ?>) identityObj;
+      sourceIp = (String) identity.get("sourceIp");
+    }
+
+    return new LambdaRequestData(
+        headers,
+        method,
+        path,
+        sourceIp,
+        null,
+        LambdaTriggerType.API_GATEWAY_V2_WEBSOCKET,
+        pathParameters,
+        queryParameters,
+        body);
+  }
+
+  /** Extracts data from ALB event (with or without multi-value headers) */
+  private static LambdaRequestData extractAlbData(
+      Map<String, Object> event, LambdaTriggerType triggerType) {
+    Map<String, String> headers;
+
+    if (triggerType == LambdaTriggerType.ALB_MULTI_VALUE) {
+      // Handle multi-value headers (combine multiple values with comma)
+      headers = new HashMap<>();
+      Object multiValueHeadersObj = event.get("multiValueHeaders");
+      if (multiValueHeadersObj instanceof Map) {
+        Map<?, ?> rawHeaders = (Map<?, ?>) multiValueHeadersObj;
+        for (Map.Entry<?, ?> entry : rawHeaders.entrySet()) {
+          if (entry.getKey() != null && entry.getValue() != null) {
+            String key = String.valueOf(entry.getKey());
+            if (entry.getValue() instanceof List) {
+              List<?> values = (List<?>) entry.getValue();
+              // Join multiple values with comma
+              String joinedValue =
+                  values.stream().map(String::valueOf).collect(Collectors.joining(", "));
+              headers.put(key, joinedValue);
+            } else {
+              headers.put(key, String.valueOf(entry.getValue()));
+            }
+          }
+        }
+      }
+    } else {
+      headers = extractHeaders(event.get("headers"));
+    }
+
+    Map<String, String> pathParameters = extractPathParameters(event.get("pathParameters"));
+
+    // ALB can have both queryStringParameters and multiValueQueryStringParameters
+    Map<String, List<String>> queryParameters;
+    if (triggerType == LambdaTriggerType.ALB_MULTI_VALUE) {
+      queryParameters =
+          extractMultiValueQueryParameters(event.get("multiValueQueryStringParameters"));
+    } else {
+      queryParameters = extractQueryParameters(event.get("queryStringParameters"));
+    }
+
+    Object body = extractBody(event);
+
+    String method = (String) event.get("httpMethod");
+    String path = (String) event.get("path");
+    String xff = headers.get("x-forwarded-for");
+    String sourceIp = null;
+    if (xff != null) {
+      int commaIdx = xff.indexOf(',');
+      sourceIp = (commaIdx >= 0 ? xff.substring(0, commaIdx) : xff).trim();
+    }
+
+    return new LambdaRequestData(
+        headers, method, path, sourceIp, null, triggerType, pathParameters, queryParameters, body);
+  }
+
+  /** Generic data extraction for unknown trigger types (fallback) */
+  private static LambdaRequestData extractGenericData(Map<String, Object> event) {
+    Map<String, String> headers = extractHeadersWithCookies(event);
+    Map<String, String> pathParameters = extractPathParameters(event.get("pathParameters"));
+    Map<String, List<String>> queryParameters =
+        extractQueryParameters(event.get("queryStringParameters"));
+    Object body = extractBody(event);
+
+    String method = null;
+    String path = null;
+    String sourceIp = null;
+
+    // Try to extract from requestContext if available
+    Object requestContextObj = event.get("requestContext");
+    if (requestContextObj instanceof Map) {
+      Map<?, ?> requestContext = (Map<?, ?>) requestContextObj;
+
+      Object httpObj = requestContext.get("http");
+      if (httpObj instanceof Map) {
+        Map<?, ?> http = (Map<?, ?>) httpObj;
+        method = (String) http.get("method");
+        path = (String) http.get("path");
+        sourceIp = (String) http.get("sourceIp");
+      } else {
+        Object methodObj = requestContext.get("httpMethod");
+        if (methodObj != null) {
+          method = String.valueOf(methodObj);
+        }
+
+        Object identityObj = requestContext.get("identity");
+        if (identityObj instanceof Map) {
+          Map<?, ?> identity = (Map<?, ?>) identityObj;
+          sourceIp = (String) identity.get("sourceIp");
+        }
+      }
+    }
+
+    // Try root level fields
+    if (method == null) {
+      Object methodObj = event.get("httpMethod");
+      if (methodObj != null) {
+        method = String.valueOf(methodObj);
+      }
+    }
+    if (path == null) {
+      Object pathObj = event.get("path");
+      if (pathObj != null) {
+        path = String.valueOf(pathObj);
+      }
+    }
+
+    return new LambdaRequestData(
+        headers,
+        method,
+        path,
+        sourceIp,
+        null,
+        LambdaTriggerType.UNKNOWN,
+        pathParameters,
+        queryParameters,
+        body);
+  }
+
+  /**
+   * Generic helper method to extract string key-value pairs from an object. Converts all keys and
+   * values to strings, filtering out null entries.
+   */
+  private static Map<String, String> extractStringMap(Object mapObj) {
+    Map<String, String> result = new HashMap<>();
+    if (mapObj instanceof Map) {
+      Map<?, ?> rawMap = (Map<?, ?>) mapObj;
+      for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
+        if (entry.getKey() != null && entry.getValue() != null) {
+          String key = String.valueOf(entry.getKey());
+          String value = String.valueOf(entry.getValue());
+          result.put(key, value);
+        }
+      }
+    }
+    return result;
+  }
+
+  /** Helper method to extract headers from event */
+  private static Map<String, String> extractHeaders(Object headersObj) {
+    Map<String, String> headers = extractStringMap(headersObj);
+    log.debug("Extracted {} headers", headers.size());
+    if (headers.containsKey("cookie")) {
+      log.debug("Cookie header found with value length: {}", headers.get("cookie").length());
+    }
+    return headers;
+  }
+
+  /** Helper method to extract path parameters from event */
+  private static Map<String, String> extractPathParameters(Object pathParamsObj) {
+    Map<String, String> pathParams = extractStringMap(pathParamsObj);
+    log.debug("Extracted {} path parameters", pathParams.size());
+    return pathParams;
+  }
+
+  /**
+   * Helper method to extract query parameters from event. Converts Map<String, String> to
+   * Map<String, List<String>> format expected by AppSec.
+   */
+  private static Map<String, List<String>> extractQueryParameters(Object queryParamsObj) {
+    Map<String, List<String>> result = new HashMap<>();
+    if (queryParamsObj instanceof Map) {
+      Map<?, ?> rawMap = (Map<?, ?>) queryParamsObj;
+      for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
+        if (entry.getKey() != null && entry.getValue() != null) {
+          String key = String.valueOf(entry.getKey());
+          String value = String.valueOf(entry.getValue());
+          result.put(key, Collections.singletonList(value));
+        }
+      }
+    }
+    log.debug("Extracted {} query parameters", result.size());
+    return result;
+  }
+
+  /**
+   * Helper method to extract multi-value query parameters (used by ALB). Handles Map<String,
+   * List<String>> format directly.
+   */
+  private static Map<String, List<String>> extractMultiValueQueryParameters(Object queryParamsObj) {
+    Map<String, List<String>> result = new HashMap<>();
+    if (queryParamsObj instanceof Map) {
+      Map<?, ?> rawMap = (Map<?, ?>) queryParamsObj;
+      for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
+        if (entry.getKey() != null && entry.getValue() != null) {
+          String key = String.valueOf(entry.getKey());
+          if (entry.getValue() instanceof List) {
+            List<?> values = (List<?>) entry.getValue();
+            List<String> stringValues = new ArrayList<>();
+            for (Object value : values) {
+              if (value != null) {
+                stringValues.add(String.valueOf(value));
+              }
+            }
+            result.put(key, stringValues);
+          } else {
+            result.put(key, Collections.singletonList(String.valueOf(entry.getValue())));
+          }
+        }
+      }
+    }
+    log.debug("Extracted {} multi-value query parameters", result.size());
+    return result;
+  }
+
+  /**
+   * Helper method to build full path including query string. Lambda events provide path and query
+   * parameters separately, so we need to reconstruct the full URI for AppSec to parse.
+   */
+  static String buildFullPath(String path, Map<String, List<String>> queryParameters) {
+    if (queryParameters == null || queryParameters.isEmpty()) {
+      return path;
+    }
+
+    StringBuilder fullPath = new StringBuilder(path);
+    fullPath.append('?');
+
+    boolean first = true;
+    for (Map.Entry<String, List<String>> entry : queryParameters.entrySet()) {
+      String key = entry.getKey();
+      for (String value : entry.getValue()) {
+        if (!first) {
+          fullPath.append('&');
+        }
+        first = false;
+        try {
+          // URL-encode key and value so that special characters (e.g. '&' inside a value) are not
+          // mistaken for query string delimiters when AppSec parses the raw query string.
+          fullPath.append(URLEncoder.encode(key, "UTF-8"));
+          if (value != null) {
+            fullPath.append('=').append(URLEncoder.encode(value, "UTF-8"));
+          }
+        } catch (java.io.UnsupportedEncodingException e) {
+          // UTF-8 is always available; fall back to unencoded
+          fullPath.append(key);
+          if (value != null) {
+            fullPath.append('=').append(value);
+          }
+        }
+      }
+    }
+
+    return fullPath.toString();
+  }
+
+  /**
+   * Helper method to extract and merge headers with cookies array from event. API Gateway v2
+   * provides a separate 'cookies' array that should be merged with headers.
+   */
+  private static Map<String, String> extractHeadersWithCookies(Map<String, Object> event) {
+    Map<String, String> headers = extractHeaders(event.get("headers"));
+
+    // API Gateway v2 provides a pre-parsed cookies array
+    Object cookiesObj = event.get("cookies");
+    if (cookiesObj instanceof List) {
+      List<?> cookiesList = (List<?>) cookiesObj;
+      if (!cookiesList.isEmpty()) {
+        // Join cookies with "; " separator per RFC 6265
+        String cookieValue =
+            cookiesList.stream().map(String::valueOf).collect(Collectors.joining("; "));
+
+        // Merge with existing cookie header if present
+        String existingCookie = headers.get("cookie");
+        if (existingCookie != null && !existingCookie.isEmpty()) {
+          headers.put("cookie", existingCookie + "; " + cookieValue);
+        } else {
+          headers.put("cookie", cookieValue);
+        }
+      }
+    }
+
+    return headers;
+  }
+
+  /** Helper method to extract and parse body from event */
+  private static Object extractBody(Map<String, Object> event) {
+    Object bodyObj = event.get("body");
+    if (bodyObj == null) {
+      return null;
+    }
+
+    String bodyString = String.valueOf(bodyObj);
+
+    // Check if body is base64 encoded (API Gateway feature)
+    Object isBase64EncodedObj = event.get("isBase64Encoded");
+    if (Boolean.TRUE.equals(isBase64EncodedObj) || "true".equals(isBase64EncodedObj)) {
+      try {
+        bodyString = new String(Base64.getDecoder().decode(bodyString), StandardCharsets.UTF_8);
+      } catch (Exception e) {
+        log.debug("Failed to decode base64 body", e);
+        return null;
+      }
+    }
+
+    // Try to parse as JSON
+    Object parsedBody = parseBodyAsJson(bodyString);
+    if (parsedBody != null) {
+      log.debug("Body parsed as JSON successfully");
+      return parsedBody;
+    }
+
+    // If not JSON, return the raw string
+    log.debug("Body is not JSON, returning raw string");
+    return bodyString;
+  }
+
+  /** Helper method to parse body as JSON */
+  private static Object parseBodyAsJson(String body) {
+    if (body == null || body.isEmpty() || "null".equals(body)) {
+      return null;
+    }
+
+    try {
+      return OBJECT_ADAPTER.fromJson(body);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /** Enum representing different AWS Lambda trigger types */
+  enum LambdaTriggerType {
+    API_GATEWAY_V1_REST, // API Gateway REST API (v1)
+    API_GATEWAY_V2_HTTP, // API Gateway HTTP API (v2)
+    API_GATEWAY_V2_WEBSOCKET, // API Gateway WebSocket
+    ALB, // Application Load Balancer
+    ALB_MULTI_VALUE, // ALB with multi-value headers
+    LAMBDA_URL, // Lambda Function URL
+    UNKNOWN; // Unknown or unsupported trigger
+
+    boolean isHttp() {
+      return this != UNKNOWN;
+    }
+  }
+
+  /** Object for Lambda request data needed for AppSec processing */
+  static class LambdaRequestData {
+    final Map<String, String> headers;
+    final String method;
+    final String path;
+    final String sourceIp;
+    final Integer sourcePort;
+    final LambdaTriggerType triggerType;
+    final Map<String, String> pathParameters;
+    final Map<String, List<String>> queryParameters;
+    final Object body;
+
+    static final LambdaRequestData EMPTY =
+        new LambdaRequestData(
+            Collections.emptyMap(),
+            null,
+            null,
+            null,
+            null,
+            LambdaTriggerType.UNKNOWN,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            null);
+
+    LambdaRequestData(
+        Map<String, String> headers,
+        String method,
+        String path,
+        String sourceIp,
+        Integer sourcePort,
+        LambdaTriggerType triggerType,
+        Map<String, String> pathParameters,
+        Map<String, List<String>> queryParameters,
+        Object body) {
+      this.headers = headers;
+      this.method = method;
+      this.path = path;
+      this.sourceIp = sourceIp;
+      this.sourcePort = sourcePort;
+      this.triggerType = triggerType;
+      this.pathParameters = pathParameters;
+      this.queryParameters = queryParameters;
+      this.body = body;
+    }
+  }
+
+  /** Data extracted from a Lambda response for WAF analysis */
+  static class LambdaResponseData {
+    final int statusCode;
+    final Map<String, String> headers;
+    final Object body;
+
+    LambdaResponseData(int statusCode, Map<String, String> headers, Object body) {
+      this.statusCode = statusCode;
+      this.headers = headers;
+      this.body = body;
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaURIDataAdapter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaURIDataAdapter.java
@@ -1,0 +1,89 @@
+package datadog.trace.lambda;
+
+import datadog.trace.bootstrap.instrumentation.api.URIDataAdapterBase;
+import java.util.Map;
+
+/**
+ * {@link datadog.trace.bootstrap.instrumentation.api.URIDataAdapter} implementation for Lambda
+ * events, which expose the path and the query string separately rather than as a URI.
+ */
+class LambdaURIDataAdapter extends URIDataAdapterBase {
+  private final String path;
+  private final String query;
+  private final String scheme;
+  private final int port;
+
+  LambdaURIDataAdapter(String pathWithQuery, Map<String, String> headers) {
+    if (pathWithQuery != null) {
+      int queryIndex = pathWithQuery.indexOf('?');
+      if (queryIndex != -1) {
+        this.path = pathWithQuery.substring(0, queryIndex);
+        this.query = pathWithQuery.substring(queryIndex + 1);
+      } else {
+        this.path = pathWithQuery;
+        this.query = null;
+      }
+    } else {
+      this.path = "/";
+      this.query = null;
+    }
+
+    String forwardedProto = headers != null ? headers.get("x-forwarded-proto") : null;
+    this.scheme = (forwardedProto != null && !forwardedProto.isEmpty()) ? forwardedProto : "https";
+
+    String forwardedPort = headers != null ? headers.get("x-forwarded-port") : null;
+    int parsedPort = -1;
+    if (forwardedPort != null && !forwardedPort.isEmpty()) {
+      try {
+        parsedPort = Integer.parseInt(forwardedPort.trim());
+      } catch (NumberFormatException ignored) {
+      }
+    }
+    this.port = parsedPort > 0 ? parsedPort : 443;
+  }
+
+  @Override
+  public String scheme() {
+    return scheme;
+  }
+
+  @Override
+  public String host() {
+    return null;
+  }
+
+  @Override
+  public int port() {
+    return port;
+  }
+
+  @Override
+  public String path() {
+    return path;
+  }
+
+  @Override
+  public String fragment() {
+    return null;
+  }
+
+  @Override
+  public String query() {
+    return query;
+  }
+
+  @Override
+  public boolean supportsRaw() {
+    return true;
+  }
+
+  @Override
+  public String rawPath() {
+    return path;
+  }
+
+  @Override
+  public String rawQuery() {
+    return query;
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
@@ -1,6 +1,8 @@
 package datadog.trace.lambda;
 
 import static datadog.trace.api.gateway.Events.EVENTS;
+import static datadog.trace.lambda.LambdaEventParser.detectTriggerType;
+import static datadog.trace.lambda.LambdaEventParser.parseResponse;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -39,6 +41,7 @@ import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.core.DDCoreJavaSpecification;
+import datadog.trace.lambda.LambdaEventParser.LambdaTriggerType;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -151,10 +154,9 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
     Map<String, Object> event =
         mapOf("requestContext", mapOf("httpMethod", "GET", "requestId", "abc123"));
 
-    LambdaAppSecHandler.LambdaTriggerType triggerType =
-        LambdaAppSecHandler.detectTriggerType(event);
+    LambdaTriggerType triggerType = detectTriggerType(event);
 
-    assertEquals(LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST, triggerType);
+    assertEquals(LambdaTriggerType.API_GATEWAY_V1_REST, triggerType);
   }
 
   @Test
@@ -165,10 +167,9 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
             mapOf(
                 "http", mapOf("method", "POST", "path", "/api"), "domainName", "api.example.com"));
 
-    LambdaAppSecHandler.LambdaTriggerType triggerType =
-        LambdaAppSecHandler.detectTriggerType(event);
+    LambdaTriggerType triggerType = detectTriggerType(event);
 
-    assertEquals(LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V2_HTTP, triggerType);
+    assertEquals(LambdaTriggerType.API_GATEWAY_V2_HTTP, triggerType);
   }
 
   @Test
@@ -182,10 +183,9 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
                 "domainName",
                 "xyz123.lambda-url.us-east-1.on.aws"));
 
-    LambdaAppSecHandler.LambdaTriggerType triggerType =
-        LambdaAppSecHandler.detectTriggerType(event);
+    LambdaTriggerType triggerType = detectTriggerType(event);
 
-    assertEquals(LambdaAppSecHandler.LambdaTriggerType.LAMBDA_URL, triggerType);
+    assertEquals(LambdaTriggerType.LAMBDA_URL, triggerType);
   }
 
   @Test
@@ -199,10 +199,9 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
             "requestContext",
             mapOf("elb", mapOf("targetGroupArn", "arn:aws:...")));
 
-    LambdaAppSecHandler.LambdaTriggerType triggerType =
-        LambdaAppSecHandler.detectTriggerType(event);
+    LambdaTriggerType triggerType = detectTriggerType(event);
 
-    assertEquals(LambdaAppSecHandler.LambdaTriggerType.ALB, triggerType);
+    assertEquals(LambdaTriggerType.ALB, triggerType);
   }
 
   @Test
@@ -218,10 +217,9 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
             "requestContext",
             mapOf("elb", mapOf("targetGroupArn", "arn:aws:...")));
 
-    LambdaAppSecHandler.LambdaTriggerType triggerType =
-        LambdaAppSecHandler.detectTriggerType(event);
+    LambdaTriggerType triggerType = detectTriggerType(event);
 
-    assertEquals(LambdaAppSecHandler.LambdaTriggerType.ALB_MULTI_VALUE, triggerType);
+    assertEquals(LambdaTriggerType.ALB_MULTI_VALUE, triggerType);
   }
 
   @Test
@@ -229,10 +227,9 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
     Map<String, Object> event =
         mapOf("requestContext", mapOf("connectionId", "conn-123", "routeKey", "$connect"));
 
-    LambdaAppSecHandler.LambdaTriggerType triggerType =
-        LambdaAppSecHandler.detectTriggerType(event);
+    LambdaTriggerType triggerType = detectTriggerType(event);
 
-    assertEquals(LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V2_WEBSOCKET, triggerType);
+    assertEquals(LambdaTriggerType.API_GATEWAY_V2_WEBSOCKET, triggerType);
   }
 
   @Test
@@ -240,30 +237,27 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
     Map<String, Object> event =
         mapOf("requestContext", mapOf("connectionId", "conn-456", "eventType", "CONNECT"));
 
-    LambdaAppSecHandler.LambdaTriggerType triggerType =
-        LambdaAppSecHandler.detectTriggerType(event);
+    LambdaTriggerType triggerType = detectTriggerType(event);
 
-    assertEquals(LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V2_WEBSOCKET, triggerType);
+    assertEquals(LambdaTriggerType.API_GATEWAY_V2_WEBSOCKET, triggerType);
   }
 
   @Test
   void detectsUnknownTriggerTypeForUnrecognizedEvents() {
     Map<String, Object> event = mapOf("someUnknownField", "value");
 
-    LambdaAppSecHandler.LambdaTriggerType triggerType =
-        LambdaAppSecHandler.detectTriggerType(event);
+    LambdaTriggerType triggerType = detectTriggerType(event);
 
-    assertEquals(LambdaAppSecHandler.LambdaTriggerType.UNKNOWN, triggerType);
+    assertEquals(LambdaTriggerType.UNKNOWN, triggerType);
   }
 
   @Test
   void detectsUnknownTriggerTypeForEmptyRequestContext() {
     Map<String, Object> event = mapOf("requestContext", mapOf());
 
-    LambdaAppSecHandler.LambdaTriggerType triggerType =
-        LambdaAppSecHandler.detectTriggerType(event);
+    LambdaTriggerType triggerType = detectTriggerType(event);
 
-    assertEquals(LambdaAppSecHandler.LambdaTriggerType.UNKNOWN, triggerType);
+    assertEquals(LambdaTriggerType.UNKNOWN, triggerType);
   }
 
   @Test
@@ -271,10 +265,9 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
     Map<String, Object> event =
         mapOf("requestContext", mapOf("http", mapOf("method", "GET", "path", "/ambiguous")));
 
-    LambdaAppSecHandler.LambdaTriggerType triggerType =
-        LambdaAppSecHandler.detectTriggerType(event);
+    LambdaTriggerType triggerType = detectTriggerType(event);
 
-    assertEquals(LambdaAppSecHandler.LambdaTriggerType.LAMBDA_URL, triggerType);
+    assertEquals(LambdaTriggerType.LAMBDA_URL, triggerType);
   }
 
   // ============================================================================
@@ -531,7 +524,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void nullJsonEventReturnsEmpty() {
-    // MAP_ADAPTER.fromJson("null") returns null, triggering LambdaEventData.EMPTY path
+    // MAP_ADAPTER.fromJson("null") returns null, triggering LambdaRequestData.EMPTY path
     ByteArrayInputStream event = createInputStream("null");
 
     setupMockCallbacks(new Callbacks());
@@ -1545,7 +1538,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processResponseDataSkipsNonApiGwResponseWhenTriggerTypeIsUnknown() {
-    LambdaAppSecHandler.setCurrentTriggerType(LambdaAppSecHandler.LambdaTriggerType.UNKNOWN);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.UNKNOWN);
     ByteArrayOutputStream result = createOutputStream("{\"result\": \"hello\"}");
     Integer[] capturedStatus = {null};
     boolean[] headerDoneCalled = {false};
@@ -1560,7 +1553,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   @Test
   @SuppressWarnings("unchecked")
   void processResponseDataAppliesFallbackForHttpTriggerWithPlainJsonResponse() {
-    LambdaAppSecHandler.setCurrentTriggerType(LambdaAppSecHandler.LambdaTriggerType.LAMBDA_URL);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.LAMBDA_URL);
     ByteArrayOutputStream result = createOutputStream("{\"result\": \"hello\"}");
     Integer[] capturedStatus = {null};
     Map<String, String> capturedHeaders = new HashMap<>();
@@ -1585,8 +1578,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   void processResponseDataKeepsParsedHeadersAndBodyWhenStatusCodeIsZero() {
     // A response that has statusCode:0 with explicit headers/body should use the parsed data,
     // not discard it in favour of the plain-response fallback.
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     ByteArrayOutputStream result =
         createOutputStream(
             "{\"statusCode\": 0, \"headers\": {\"content-type\": \"text/plain\"}, \"body\": \"hello\"}");
@@ -1609,8 +1601,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processResponseDataAppliesFallbackForHttpTriggerWithNonJsonStringResponse() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     // JSON-encoded string (as returned by a RequestHandler<I, String>)
     ByteArrayOutputStream result = createOutputStream("\"Hello World!\"");
     Integer[] capturedStatus = {null};
@@ -1631,8 +1622,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   @Test
   @SuppressWarnings("unchecked")
   void processResponseDataWebSocketWithStatusCodeFiresResponseStarted() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V2_WEBSOCKET);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V2_WEBSOCKET);
     // $connect handler returning a proper statusCode — should be treated like any API-GW response
     ByteArrayOutputStream result = createOutputStream("{\"statusCode\": 200}");
     Integer[] capturedStatus = {null};
@@ -1647,8 +1637,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processResponseDataWebSocketWithoutStatusCodeUsesFallbackWithNoStatus() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V2_WEBSOCKET);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V2_WEBSOCKET);
     // Message-route handler returning arbitrary data — no statusCode, fallback path
     ByteArrayOutputStream result = createOutputStream("{\"message\": \"hello\"}");
     Integer[] capturedStatus = {null};
@@ -1681,8 +1670,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processResponseDataExtractsStatusCodeCorrectly() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     ByteArrayOutputStream result = createOutputStream("{\"statusCode\": 200, \"body\": \"ok\"}");
     Integer[] capturedStatus = {null};
     AgentSpan span =
@@ -1693,8 +1681,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processResponseDataExtractsStatusCodeAsIntegerFromDouble() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     ByteArrayOutputStream result =
         createOutputStream("{\"statusCode\": 404.0, \"body\": \"not found\"}");
     Integer[] capturedStatus = {null};
@@ -1729,8 +1716,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processResponseDataForwardsAllResponseHeaders() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     String json =
         "{\"statusCode\": 200, \"headers\": {\"content-type\": \"application/json\", \"x-custom\": \"val\", \"content-length\": \"42\", \"set-cookie\": \"a=1\"}}";
     ByteArrayOutputStream result = createOutputStream(json);
@@ -1746,8 +1732,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processResponseDataLowercasesHeaderKeys() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     String json =
         "{\"statusCode\": 200, \"headers\": {\"Content-Type\": \"text/html\", \"CONTENT-LENGTH\": \"10\"}}";
     ByteArrayOutputStream result = createOutputStream(json);
@@ -1760,8 +1745,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processResponseDataMergesMultiValueHeadersWithSingleValueHeaders() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     String json =
         "{\"statusCode\": 200, \"headers\": {\"content-type\": \"text/html\"}, \"multiValueHeaders\": {\"content-encoding\": [\"gzip\", \"br\"]}}";
     ByteArrayOutputStream result = createOutputStream(json);
@@ -1774,8 +1758,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processResponseDataHandlesEmptyHeaders() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     ByteArrayOutputStream result = createOutputStream("{\"statusCode\": 200}");
     Map<String, String> capturedHeaders = new HashMap<>();
     boolean[] headerDoneCalled = {false};
@@ -1792,8 +1775,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   @Test
   @SuppressWarnings("unchecked")
   void processResponseDataParsesJsonBody() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     String json =
         "{\"statusCode\": 200, \"headers\": {\"content-type\": \"application/json\"}, \"body\": \"{\\\"key\\\": \\\"value\\\"}\"}";
     ByteArrayOutputStream result = createOutputStream(json);
@@ -1806,8 +1788,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processResponseDataHandlesNonJsonBodyAsRawString() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     String json =
         "{\"statusCode\": 200, \"headers\": {\"content-type\": \"text/plain\"}, \"body\": \"plain text\"}";
     ByteArrayOutputStream result = createOutputStream(json);
@@ -1820,8 +1801,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   @Test
   @SuppressWarnings("unchecked")
   void processResponseDataHandlesBase64EncodedBody() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     String originalBody = "{\"decoded\": \"content\"}";
     String base64Body =
         Base64.getEncoder().encodeToString(originalBody.getBytes(StandardCharsets.UTF_8));
@@ -1860,8 +1840,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   @Test
   @SuppressWarnings("unchecked")
   void processResponseDataAttemptsJsonParseWhenNoContentType() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     ByteArrayOutputStream result =
         createOutputStream("{\"statusCode\": 200, \"body\": \"{\\\"a\\\": 1}\"}");
     Object[] capturedBody = {null};
@@ -1873,8 +1852,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processResponseDataFallsBackToRawStringWhenJsonParseFails() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     ByteArrayOutputStream result =
         createOutputStream("{\"statusCode\": 200, \"body\": \"not json {\"}");
     Object[] capturedBody = {null};
@@ -1887,8 +1865,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processResponseDataFiresEventsInCorrectOrder() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     String json =
         "{\"statusCode\": 200, \"headers\": {\"content-type\": \"application/json\"}, \"body\": \"{\\\"k\\\": \\\"v\\\"}\"}";
     ByteArrayOutputStream result = createOutputStream(json);
@@ -1927,8 +1904,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   @Test
   @SuppressWarnings("unchecked")
   void processResponseDataParsesBodyAsJsonForJavascriptContentType() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     String json =
         "{\"statusCode\": 200, \"headers\": {\"content-type\": \"application/javascript\"}, \"body\": \"{\\\"key\\\": \\\"val\\\"}\"}";
     ByteArrayOutputStream result = createOutputStream(json);
@@ -1941,8 +1917,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processResponseDataSkipsMultiValueHeadersEntryWithNonListValue() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     String json =
         "{\"statusCode\": 200, \"headers\": {\"content-type\": \"text/html\"}, \"multiValueHeaders\": {\"x-scalar\": \"not-a-list\", \"x-valid\": [\"v1\", \"v2\"]}}";
     ByteArrayOutputStream result = createOutputStream(json);
@@ -1956,8 +1931,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processResponseDataMultiValueHeadersOverrideSingleValueHeaders() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     String json =
         "{\"statusCode\": 200, \"headers\": {\"content-type\": \"text/html\"}, \"multiValueHeaders\": {\"content-type\": [\"application/json\", \"charset=utf-8\"]}}";
     ByteArrayOutputStream result = createOutputStream(json);
@@ -2017,8 +1991,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processResponseDataSkipsResponseStartedWhenCallbackIsNull() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     String json = "{\"statusCode\": 200, \"headers\": {\"content-type\": \"text/plain\"}}";
     ByteArrayOutputStream result = createOutputStream(json);
     Map<String, String> capturedHeaders = new HashMap<>();
@@ -2032,8 +2005,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processResponseDataSkipsResponseHeaderWhenCallbackIsNull() {
-    LambdaAppSecHandler.setCurrentTriggerType(
-        LambdaAppSecHandler.LambdaTriggerType.API_GATEWAY_V1_REST);
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     String json = "{\"statusCode\": 200, \"headers\": {\"content-type\": \"text/plain\"}}";
     ByteArrayOutputStream result = createOutputStream(json);
     Integer[] capturedStatus = {null};
@@ -2052,17 +2024,17 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void extractResponseDataReturnsNullForMalformedJson() {
-    assertNull(LambdaAppSecHandler.extractResponseData("{bad json"));
+    assertNull(parseResponse("{bad json"));
   }
 
   @Test
   void extractResponseDataReturnsNullForNullJsonParseResult() {
-    assertNull(LambdaAppSecHandler.extractResponseData("null"));
+    assertNull(parseResponse("null"));
   }
 
   @Test
   void extractResponseDataReturnsNullForEmptyString() {
-    assertNull(LambdaAppSecHandler.extractResponseData(""));
+    assertNull(parseResponse(""));
   }
 
   // ============================================================================


### PR DESCRIPTION
# What Does This Do

Splits `LambdaAppSecHandler` (1211 lines) into three files, with no behaviour change:

- **`LambdaEventParser`** (new) — all payload parsing: `parseEvent` (event payload and JSON string), `parseResponse`, `parseJsonValue`, `detectTriggerType`, the five per-trigger extractors and their helpers. Holds the Moshi adapters and `MAX_EVENT_SIZE`. The `LambdaTriggerType` enum and the `LambdaRequestData` / `LambdaResponseData` value types move here as nested types. Contains no AppSec imports.
- **`LambdaURIDataAdapter`** (new) — promoted from a private nested class to a top-level one, unchanged.
- **`LambdaAppSecHandler`** — down to ~400 lines, now only the gateway-callback logic: `processRequestStart`, `processRequestEnd`, `processResponseData`, `mergeContexts`, `processAppSecRequestData`, `TemporaryRequestContext` and the single `CURRENT_TRIGGER_TYPE` thread-local.

Method bodies are moved verbatim. The parser keeps returning the `LambdaRequestData.EMPTY` sentinel (compared by identity in `processRequestStart`) rather than `null`, and the generic extractor still returns populated data for `UNKNOWN` triggers, so unrecognised events continue to reach the WAF exactly as before.

`LambdaAppSecHandlerTest` is updated only where it names moved symbols — `LambdaTriggerType`, `detectTriggerType`, and `extractResponseData` which is now `parseResponse`. No assertions changed.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
