### PR TITLE
Fix error spam from filtered out log probes

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -725,7 +725,7 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
   }
 
   private void processCaptureExpressions(CapturedContext context, LogStatus logStatus) {
-    if (captureExpressions == null || !logStatus.isSampled() || !logStatus.getCondition()) {
+    if (captureExpressions == null || !logStatus.shouldSend()) {
       return;
     }
     for (CaptureExpression captureExpression : captureExpressions) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/probe/LogProbe.java
@@ -725,7 +725,7 @@ public class LogProbe extends ProbeDefinition implements Sampled, CapturedContex
   }
 
   private void processCaptureExpressions(CapturedContext context, LogStatus logStatus) {
-    if (captureExpressions == null) {
+    if (captureExpressions == null || !logStatus.isSampled() || !logStatus.getCondition()) {
       return;
     }
     for (CaptureExpression captureExpression : captureExpressions) {

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/CapturedSnapshotTest.java
@@ -3021,6 +3021,31 @@ public class CapturedSnapshotTest extends CapturingTestBase {
   }
 
   @Test
+  public void captureExpressionsWithRejectingCondition() throws IOException, URISyntaxException {
+    final String CLASS_NAME = "CapturedSnapshot08";
+    LogProbe probe =
+        createProbeBuilder(PROBE_ID, CLASS_NAME, "doit", null)
+            .evaluateAt(MethodLocation.EXIT)
+            .captureSnapshot(false)
+            .when(new ProbeCondition(DSL.when(DSL.eq(DSL.value(1), DSL.value(2))), "1 == 2"))
+            .template("plain log", Collections.emptyList())
+            .captureExpressions(
+                Collections.singletonList(
+                    new LogProbe.CaptureExpression(
+                        "unknown_symbol",
+                        new ValueScript(ref("doesNotExist"), "doesNotExist"),
+                        null)))
+            .build();
+    TestSnapshotListener listener = installProbes(probe);
+    Class<?> testClass = compileAndLoadClass(CLASS_NAME);
+    for (int i = 0; i < 5; i++) {
+      int result = Reflect.onClass(testClass).call("main", "1").get();
+      assertEquals(3, result);
+    }
+    assertEquals(0, listener.snapshots.size());
+  }
+
+  @Test
   public void captureExpressionsPrimitives() throws IOException, URISyntaxException {
     final String CLASS_NAME = "CapturedSnapshot08";
     LogProbe probe =

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/probe/LogProbeTest.java
@@ -5,12 +5,16 @@ import static com.datadog.debugger.util.LogProbeTestHelper.parseTemplate;
 import static java.lang.String.format;
 import static java.lang.Thread.currentThread;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import com.datadog.debugger.agent.DebuggerAgentHelper;
+import com.datadog.debugger.el.DSL;
+import com.datadog.debugger.el.ProbeCondition;
+import com.datadog.debugger.el.ValueScript;
 import com.datadog.debugger.probe.LogProbe.Builder;
 import com.datadog.debugger.probe.LogProbe.LogStatus;
 import com.datadog.debugger.sink.DebuggerSink;
@@ -19,6 +23,7 @@ import com.datadog.debugger.sink.Snapshot;
 import datadog.context.ContextScope;
 import datadog.trace.api.Config;
 import datadog.trace.api.IdGenerationStrategy;
+import datadog.trace.api.sampling.ConstantSampler;
 import datadog.trace.bootstrap.debugger.CapturedContext;
 import datadog.trace.bootstrap.debugger.EvaluationError;
 import datadog.trace.bootstrap.debugger.MethodLocation;
@@ -340,6 +345,49 @@ public class LogProbeTest {
         "errorEntry", snapshot.getCaptures().getEntry().getCapturedThrowable().getMessage());
     assertEquals(
         "errorExit", snapshot.getCaptures().getReturn().getCapturedThrowable().getMessage());
+  }
+
+  @Test
+  public void captureExpressionsInActiveDebugSession() {
+    DebuggerAgentHelper.injectSink(new DebuggerSink(getConfig(), mock(ProbeStatusSink.class)));
+    TracerAPI tracer =
+        CoreTracer.builder().idGenerationStrategy(IdGenerationStrategy.fromName("random")).build();
+    AgentTracer.registerIfAbsent(tracer);
+    AgentSpan span = tracer.startSpan("log probe capture expression testing", "test span");
+    try (ContextScope scope = tracer.activateManualSpan(span)) {
+      span.setTag(Tags.PROPAGATED_DEBUG, DEBUG_SESSION_ID + ":1");
+      // the probe sampler always rejects: the active session decision must still win
+      ProbeRateLimiter.setSamplerSupplier(rate -> new ConstantSampler(false));
+      LogProbe logProbe =
+          createLog("log line")
+              .probeId(ProbeId.newId())
+              .evaluateAt(MethodLocation.EXIT)
+              .tags(format("session_id:%s", DEBUG_SESSION_ID))
+              .when(new ProbeCondition(DSL.when(DSL.eq(DSL.value(1), DSL.value(1))), "1 == 1"))
+              .captureExpressions(
+                  singletonList(
+                      new LogProbe.CaptureExpression(
+                          "greeting", new ValueScript(DSL.value("hello"), "'hello'"), null)))
+              .build();
+      logProbe.initSamplers();
+      CapturedContext entryContext = capturedContext(span, logProbe);
+      CapturedContext exitContext = capturedContext(span, logProbe);
+      logProbe.evaluate(entryContext, new LogStatus(logProbe), MethodLocation.ENTRY, false);
+      logProbe.evaluate(exitContext, new LogStatus(logProbe), MethodLocation.EXIT, false);
+      Snapshot snapshot = new Snapshot(currentThread(), logProbe, 3);
+      assertTrue(logProbe.fillSnapshot(entryContext, exitContext, emptyList(), snapshot));
+      assertEquals(
+          "hello",
+          snapshot
+              .getCaptures()
+              .getReturn()
+              .getCaptureExpressions()
+              .get("greeting")
+              .getValue()
+              .toString());
+    } finally {
+      ProbeRateLimiter.setSamplerSupplier(null);
+    }
   }
 
   private Builder createLog(String template) {


### PR DESCRIPTION
# What Does This Do

Avoids evaluating a log probe’s capture expressions when we already know the hit won’t be sent. This includes hits rejected by the probe condition, dropped by rate limiting, or from a disabled debug session.

# Motivation

Previously, capture expressions were evaluated on every probe hit, even when the probe condition failed. Since those captured values were never used, this was unnecessary work.

There was also a more serious issue when a capture expression failed to evaluate. The failure generated a debugger error event, but that event bypassed sampling. The sampler only runs when the probe condition passes or the condition itself fails, so these events kept the default "sampled" status.

As a result, none of the normal limits applied: the per-probe rate limit, the 1 error/second limit, or the global rate limit.

# Additional Notes

Reproduced by [a new system test](https://github.com/DataDog/system-tests/blob/main/tests/debugger/test_debugger_capture_expressions_errors.py), which sends 5 filtered out hits at more than 1s apart and requires at most 1 event.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [IDEAI-714]

[IDEAI-714]: https://datadoghq.atlassian.net/browse/IDEAI-714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
