### PR TITLE
Update Spotless to 8.10.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
   id("dd-trace-java.config-inversion-linter")
   id("dd-trace-java.ci-jobs")
 
-  id("com.diffplug.spotless") version "8.4.0"
+  alias(libs.plugins.spotless)
   id("me.champeau.gradle.japicmp") version "0.4.3"
   id("com.github.spotbugs") version "6.5.10"
   id("de.thetaphi.forbiddenapis") version "3.10"
@@ -43,10 +43,10 @@ with(extensions["spotlessPredeclare"] as SpotlessExtension) {
     tableTestFormatter(libs.versions.tabletest.formatter.get())
   }
   groovyGradle {
-    greclipse()
+    greclipse(libs.versions.greclipse.get())
   }
   groovy {
-    greclipse()
+    greclipse(libs.versions.greclipse.get())
   }
   kotlinGradle {
     ktlint(libs.versions.ktlint.get())

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   `java-gradle-plugin`
   `kotlin-dsl`
   `jvm-test-suite`
-  id("com.diffplug.spotless") version "8.4.0"
+  alias(libs.plugins.spotless)
 }
 
 // The buildSrc still needs to target Java 8 as build time instrumentation and muzzle plugin

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -4,7 +4,7 @@ import org.gradle.api.file.DuplicatesStrategy.INCLUDE
 
 plugins {
   java
-  id("com.diffplug.spotless") version "8.4.0"
+  alias(libs.plugins.spotless)
   alias(libs.plugins.shadow)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,8 +11,10 @@ spotbugs_annotations = "4.10.3"
 
 # Source code formatters
 google-java-format = "1.36.1"
+greclipse = "4.27" # Pinned. See: https://github.com/diffplug/spotless/issues/3013
 ktlint = "1.8.0"
 scalafmt = "3.11.5"
+spotless = "8.9.0"
 tabletest-formatter = "1.1.2"
 
 # DataDog libs and forks
@@ -200,3 +202,4 @@ spock = ["spock-core", "objenesis"]
 
 [plugins]
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ google-java-format = "1.36.1"
 greclipse = "4.27" # Pinned. See: https://github.com/diffplug/spotless/issues/3013
 ktlint = "1.8.0"
 scalafmt = "3.11.5"
-spotless = "8.9.0"
+spotless = "8.10.0"
 tabletest-formatter = "1.1.2"
 
 # DataDog libs and forks

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -38,7 +38,7 @@ spotless {
     } else {
       target '*.gradle'
     }
-    greclipse().configFile(configPath + '/enforcement/spotless-groovy.properties')
+    greclipse(libs.versions.greclipse.get()).configFile(configPath + '/enforcement/spotless-groovy.properties')
   }
 
   kotlinGradle {
@@ -61,7 +61,7 @@ spotless {
         // so it formats Java files by default (unless `excludeJava` is used).
       }
       targetExclude(buildDirectoryFiles)
-      greclipse().configFile(configPath + '/enforcement/spotless-groovy.properties')
+      greclipse(libs.versions.greclipse.get()).configFile(configPath + '/enforcement/spotless-groovy.properties')
     }
   }
 

--- a/test-published-dependencies/build.gradle.kts
+++ b/test-published-dependencies/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("com.diffplug.spotless") version "8.4.0"
+  alias(libs.plugins.spotless)
 }
 
 val sharedConfigDirectory = "$rootDir/../gradle"


### PR DESCRIPTION
# What Does This Do

Updates Spotless to [8.10.0](https://github.com/diffplug/spotless/releases/tag/gradle%2F8.10.0) and centralizes its plugin version in the version catalog. GrEclipse remains pinned to 4.27 because of [diffplug/spotless#3013](https://github.com/diffplug/spotless/issues/3013).

# Motivation

Keep formatter tooling current and use the version catalog consistently.

# Additional Notes

Validated with `./gradlew spotlessCheck` and the standalone `test-published-dependencies` Spotless check.

# Contributor Checklist

- [x] Internal build tooling change