### PR TITLE
Route Robolectric downloads through repository proxy

### DIFF
--- a/dd-smoke-tests/gradle/src/test/resources/test-succeed-robolectric/build.gradleTest
+++ b/dd-smoke-tests/gradle/src/test/resources/test-succeed-robolectric/build.gradleTest
@@ -13,10 +13,11 @@ apply plugin: 'java'
 // the 'com.android.base' plugin id, so applying an id-only stand-in exercises it.
 apply plugin: 'com.android.base'
 
+def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
+
 repositories {
   mavenLocal()
 
-  def proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")
   if (proxyUrl) {
     println "Using proxy repository: $proxyUrl"
     maven {
@@ -106,6 +107,10 @@ dependencies {
 
 test {
   useJUnit()
+  if (proxyUrl) {
+    // Robolectric resolves the Android SDK at test runtime, outside Gradle's dependency resolver.
+    systemProperty "robolectric.dependency.repo.url", proxyUrl
+  }
   // Coverage is validated by the other Gradle smoke scenarios; disable it here so this scenario
   // stays focused on the emulated-SDK (test.android.*) tags.
   environment "DD_CIVISIBILITY_CODE_COVERAGE_ENABLED", "false"


### PR DESCRIPTION
# What Does This Do

Routes Robolectric runtime Android SDK downloads through the configured Maven repository proxy.

# Motivation

Robolectric resolves SDK artifacts outside the Gradle dependency resolver, so it did not inherit the existing proxy configuration. Passing the proxy explicitly avoids direct runtime downloads from public Maven Central.

# Additional Notes

The failure occurred while Robolectric was fetching its Android SDK artifact at test runtime:

```text
AndroidJUnit4RunnerTest > classMethod FAILED
    java.lang.AssertionError at MavenArtifactFetcher.java:129
        Caused by: java.util.concurrent.ExecutionException at AbstractFuture.java:292
            Caused by: java.io.IOException at HttpURLConnection.java:2052
```

`MavenArtifactFetcher.java:129` is the Robolectric artifact-download failure path. The nested `HttpURLConnection` → `IOException` shows that the runtime fetch failed before the test assertion ran. A later retry passed, which is consistent with a transient download failure.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: N/A