### PR TITLE
Bound feature flag evaluation aggregation memory

### DIFF
--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/FlagEvaluationAggregator.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/FlagEvaluationAggregator.java
@@ -4,6 +4,7 @@ import static datadog.trace.util.HashingUtils.addToHash;
 import static datadog.trace.util.HashingUtils.hash;
 
 import datadog.trace.api.featureflag.flagevaluation.FlagEvalEvent;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -11,6 +12,9 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+@SuppressFBWarnings(
+    value = {"AT_NONATOMIC_64BIT_PRIMITIVE", "AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE"},
+    justification = "The aggregator is confined to the single flag-evaluation serializer thread")
 final class FlagEvaluationAggregator {
 
   // Design assumptions — document the scale we sized for
@@ -32,6 +36,7 @@ final class FlagEvaluationAggregator {
   static final int GLOBAL_CAP = 131_072; // nearest power of two above FULL_BUCKET_SIZING_BASIS
   static final int PER_FLAG_CAP = PER_FLAG_BUCKET_SIZING_BASIS;
   static final int DEGRADED_CAP = 32_768; // nearest power of two above DEGRADED_BUCKET_SIZING_BASIS
+  static final long RETAINED_BYTE_BUDGET = 64L << 20;
 
   private static final byte CTX_TAG_STRING = 's';
   private static final byte CTX_TAG_BOOL = 'b';
@@ -45,7 +50,20 @@ final class FlagEvaluationAggregator {
   final Map<DegradedKey, EvalBucket> degradedTier = new HashMap<>();
   final Map<String, Integer> perFlagCount = new HashMap<>();
   final AtomicLong droppedDegradedOverflow = new AtomicLong(0);
+  final AtomicLong droppedByteBudget = new AtomicLong(0);
+  final AtomicLong degradedCardinalityCap = new AtomicLong(0);
+  final AtomicLong degradedByteBudget = new AtomicLong(0);
   final AtomicInteger globalFullCount = new AtomicInteger(0);
+  private final long retainedByteBudget;
+  private long retainedBytes;
+
+  FlagEvaluationAggregator() {
+    this(RETAINED_BYTE_BUDGET);
+  }
+
+  FlagEvaluationAggregator(final long retainedByteBudget) {
+    this.retainedByteBudget = Math.max(0, retainedByteBudget);
+  }
 
   void aggregate(final FlagEvalEvent event) {
     final boolean isDefault = event.variant == null;
@@ -66,48 +84,76 @@ final class FlagEvaluationAggregator {
 
     final int flagCount = perFlagCount.getOrDefault(event.flagKey, 0);
     if (globalFullCount.get() < GLOBAL_CAP && flagCount < PER_FLAG_CAP) {
-      fullTier.put(
-          fullKey,
-          new EvalBucket(
-              event.flagKey,
-              event.variant,
-              event.allocationKey,
-              event.targetingKey,
-              event.errorMessage,
-              event.evalTimeMs,
-              isDefault,
-              prunedAttrs,
-              observeFullEvaluationData));
-      globalFullCount.incrementAndGet();
-      perFlagCount.put(event.flagKey, flagCount + 1);
-      return;
+      final long bucketBytes =
+          FlagEvaluationMemoryEstimator.fullBucketBytes(event, prunedAttrs, ctxKey);
+      if (reserve(bucketBytes)) {
+        fullTier.put(
+            fullKey,
+            new EvalBucket(
+                event.flagKey,
+                event.variant,
+                event.allocationKey,
+                event.targetingKey,
+                event.errorMessage,
+                event.evalTimeMs,
+                isDefault,
+                prunedAttrs,
+                observeFullEvaluationData));
+        globalFullCount.incrementAndGet();
+        perFlagCount.put(event.flagKey, flagCount + 1);
+        return;
+      }
     }
 
+    final boolean degradedByByteBudget =
+        globalFullCount.get() < GLOBAL_CAP && flagCount < PER_FLAG_CAP;
     final DegradedKey degradedKey = buildDegradedKey(event);
     bucket = degradedTier.get(degradedKey);
     if (bucket != null) {
       bucket.merge(event.evalTimeMs, isDefault);
       bucket.observeFullEvaluationData &= observeFullEvaluationData;
+      countDegraded(degradedByByteBudget);
       return;
     }
 
     if (degradedTier.size() < DEGRADED_CAP) {
-      degradedTier.put(
-          degradedKey,
-          new EvalBucket(
-              event.flagKey,
-              event.variant,
-              event.allocationKey,
-              null,
-              event.errorMessage,
-              event.evalTimeMs,
-              isDefault,
-              null,
-              observeFullEvaluationData));
+      if (reserve(FlagEvaluationMemoryEstimator.degradedBucketBytes(event))) {
+        degradedTier.put(
+            degradedKey,
+            new EvalBucket(
+                event.flagKey,
+                event.variant,
+                event.allocationKey,
+                null,
+                event.errorMessage,
+                event.evalTimeMs,
+                isDefault,
+                null,
+                observeFullEvaluationData));
+        countDegraded(degradedByByteBudget);
+        return;
+      }
+      droppedByteBudget.incrementAndGet();
       return;
     }
 
     droppedDegradedOverflow.incrementAndGet();
+  }
+
+  private void countDegraded(final boolean degradedByByteBudget) {
+    if (degradedByByteBudget) {
+      degradedByteBudget.incrementAndGet();
+    } else {
+      degradedCardinalityCap.incrementAndGet();
+    }
+  }
+
+  private boolean reserve(final long bytes) {
+    if (bytes > retainedByteBudget - retainedBytes) {
+      return false;
+    }
+    retainedBytes += bytes;
+    return true;
   }
 
   boolean isEmpty() {
@@ -116,14 +162,6 @@ final class FlagEvaluationAggregator {
 
   int fullTierSize() {
     return fullTier.size();
-  }
-
-  long degradedEvaluationCount() {
-    long count = 0;
-    for (final EvalBucket bucket : degradedTier.values()) {
-      count += bucket.count;
-    }
-    return count;
   }
 
   int bucketCount() {
@@ -143,11 +181,22 @@ final class FlagEvaluationAggregator {
     degradedTier.clear();
     perFlagCount.clear();
     globalFullCount.set(0);
+    retainedBytes = 0;
+  }
+
+  long retainedBytes() {
+    return retainedBytes;
   }
 
   AggregatedState snapshot() {
     return new AggregatedState(
-        new HashMap<>(fullTier), new HashMap<>(degradedTier), droppedDegradedOverflow.get());
+        new HashMap<>(fullTier),
+        new HashMap<>(degradedTier),
+        droppedDegradedOverflow.get(),
+        droppedByteBudget.get(),
+        degradedCardinalityCap.get(),
+        degradedByteBudget.get(),
+        retainedBytes);
   }
 
   void simulateFullTierAtCap() {
@@ -441,14 +490,26 @@ final class FlagEvaluationAggregator {
     final Map<FullKey, EvalBucket> fullTier;
     final Map<DegradedKey, EvalBucket> degradedTier;
     final long droppedDegradedOverflow;
+    final long droppedByteBudget;
+    final long degradedCardinalityCap;
+    final long degradedByteBudget;
+    final long retainedBytes;
 
     AggregatedState(
         final Map<FullKey, EvalBucket> fullTier,
         final Map<DegradedKey, EvalBucket> degradedTier,
-        final long droppedDegradedOverflow) {
+        final long droppedDegradedOverflow,
+        final long droppedByteBudget,
+        final long degradedCardinalityCap,
+        final long degradedByteBudget,
+        final long retainedBytes) {
       this.fullTier = fullTier;
       this.degradedTier = degradedTier;
       this.droppedDegradedOverflow = droppedDegradedOverflow;
+      this.droppedByteBudget = droppedByteBudget;
+      this.degradedCardinalityCap = degradedCardinalityCap;
+      this.degradedByteBudget = degradedByteBudget;
+      this.retainedBytes = retainedBytes;
     }
   }
 }

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/FlagEvaluationMemoryEstimator.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/FlagEvaluationMemoryEstimator.java
@@ -1,0 +1,74 @@
+package com.datadog.featureflag;
+
+import datadog.trace.api.featureflag.flagevaluation.FlagEvalEvent;
+import java.util.Map;
+
+/** Conservatively estimates memory retained by one aggregation bucket. */
+final class FlagEvaluationMemoryEstimator {
+
+  // These constants include aligned object headers, references, and amortized HashMap storage.
+  // They intentionally overestimate JOL measurements made with 100-bucket representative graphs.
+  private static final long BUCKET_AND_INDEX_BYTES = 256;
+  private static final long CONTEXT_MAP_BYTES = 64;
+  private static final long CONTEXT_ENTRY_BYTES = 48;
+  private static final long STRING_BYTES = 40;
+  private static final long OTHER_VALUE_BYTES = 64;
+  private static final long MAX_BYTES_PER_CHARACTER = 2;
+
+  private FlagEvaluationMemoryEstimator() {}
+
+  static long fullBucketBytes(
+      final FlagEvalEvent event,
+      final Map<String, Object> prunedAttrs,
+      final String canonicalContextKey) {
+    long bytes = BUCKET_AND_INDEX_BYTES;
+    bytes = add(bytes, stringBytes(event.flagKey));
+    bytes = add(bytes, stringBytes(event.variant));
+    bytes = add(bytes, stringBytes(event.allocationKey));
+    bytes = add(bytes, stringBytes(event.targetingKey));
+    bytes = add(bytes, stringBytes(event.errorMessage));
+    bytes = add(bytes, stringBytes(canonicalContextKey));
+    if (prunedAttrs == null || prunedAttrs.isEmpty()) {
+      return bytes;
+    }
+
+    bytes = add(bytes, CONTEXT_MAP_BYTES);
+    for (final Map.Entry<String, Object> entry : prunedAttrs.entrySet()) {
+      bytes = add(bytes, CONTEXT_ENTRY_BYTES);
+      bytes = add(bytes, stringBytes(entry.getKey()));
+      bytes = add(bytes, contextValueBytes(entry.getValue()));
+    }
+    return bytes;
+  }
+
+  static long degradedBucketBytes(final FlagEvalEvent event) {
+    long bytes = BUCKET_AND_INDEX_BYTES;
+    bytes = add(bytes, stringBytes(event.flagKey));
+    bytes = add(bytes, stringBytes(event.variant));
+    bytes = add(bytes, stringBytes(event.allocationKey));
+    return add(bytes, stringBytes(event.errorMessage));
+  }
+
+  private static long contextValueBytes(final Object value) {
+    if (value instanceof String) {
+      return stringBytes((String) value);
+    }
+    if (value == null) {
+      return 0;
+    }
+    return add(OTHER_VALUE_BYTES, characterBytes(value.toString().length()));
+  }
+
+  private static long stringBytes(final String value) {
+    return value == null ? 0 : add(STRING_BYTES, characterBytes(value.length()));
+  }
+
+  private static long characterBytes(final int length) {
+    return MAX_BYTES_PER_CHARACTER * length;
+  }
+
+  private static long add(final long left, final long right) {
+    // Both inputs describe live Java objects. Their sum cannot approach the long range in one JVM.
+    return left + right;
+  }
+}

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/FlagEvaluationWriterImpl.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/FlagEvaluationWriterImpl.java
@@ -40,15 +40,15 @@ import org.slf4j.LoggerFactory;
  * string identity). Context pruning: deterministic (sort before cut), <=256 fields, string values
  * <=256 chars; the pruned attributes are what gets aggregated and serialized. Caps:
  * globalCap=131072, perFlagCap=10000, degradedCap=32768. Eval-time: min/max of
- * firstEvalMs/lastEvalMs across events in the same bucket. Runtime default: absent variant means
- * runtimeDefaultUsed=true. Flush interval: 10 seconds. Queue: bounded MessagePassingBlockingQueue
- * (capacity 2^16), non-blocking offer; on overflow the event is dropped and the
- * droppedQueueOverflow counter is incremented and surfaced on flush. Enqueue: lock-free. Producers
- * contend only on the MPSC queue, never on a monitor, so evaluation threads do not serialize
- * against each other. Shutdown: close() drains the queue and performs a final flush before the
- * worker thread exits. Because enqueue is lock-free, a producer can still offer during shutdown;
- * close() sweeps the queue once the worker has been joined, counting any remainder as a closed drop
- * so shutdown loss is observable rather than silent.
+ * firstEvalMs/lastEvalMs across events in the same bucket. Retained aggregation memory is limited
+ * to 64 MiB. Runtime default: absent variant means runtimeDefaultUsed=true. Flush interval: 10
+ * seconds. Queue: bounded MessagePassingBlockingQueue (capacity 2^12), non-blocking offer; on
+ * overflow the event is dropped and the droppedQueueOverflow counter is incremented and surfaced on
+ * flush. Enqueue: lock-free. Producers contend only on the MPSC queue, never on a monitor, so
+ * evaluation threads do not serialize against each other. Shutdown: close() drains the queue and
+ * performs a final flush before the worker thread exits. Because enqueue is lock-free, a producer
+ * can still offer during shutdown; close() sweeps the queue once the worker has been joined,
+ * counting any remainder as a closed drop so shutdown loss is observable rather than silent.
  */
 public class FlagEvaluationWriterImpl implements FlagEvaluationWriter {
 
@@ -65,8 +65,10 @@ public class FlagEvaluationWriterImpl implements FlagEvaluationWriter {
   static final String DROP_REASON_QUEUE_OVERFLOW = "queue_overflow";
   static final String DROP_REASON_CLOSED = "closed";
   static final String DROP_REASON_DEGRADED_CAP = "degraded_cap";
+  static final String DROP_REASON_BYTE_BUDGET = "byte_budget";
   static final String DROP_REASON_PAYLOAD_LIMIT = "payload_limit";
   static final String DEGRADED_REASON_CARDINALITY_CAP = "cardinality_cap";
+  static final String DEGRADED_REASON_BYTE_BUDGET = "byte_budget";
   static final String DEGRADED_REASON_PAYLOAD_LIMIT = "payload_limit";
   private static final String FLAG_EVALUATION_ROUTE = "flagevaluation";
   private static final CoreMetricCollector CORE_METRICS = CoreMetricCollector.getInstance();
@@ -449,6 +451,22 @@ public class FlagEvaluationWriterImpl implements FlagEvaluationWriter {
                 + " (best-effort telemetry)",
             dgDrops);
       }
+      final long byteBudgetDrops = aggregator.droppedByteBudget.getAndSet(0);
+      countMetric(FLAG_EVALUATION_DROPPED_METRIC, byteBudgetDrops, DROP_REASON_BYTE_BUDGET);
+      if (byteBudgetDrops > 0) {
+        LOGGER.warn(
+            "flag evaluation aggregation byte budget full - dropped {} evaluation(s)"
+                + " (best-effort telemetry)",
+            byteBudgetDrops);
+      }
+      countMetric(
+          FLAG_EVALUATION_DEGRADED_METRIC,
+          aggregator.degradedCardinalityCap.getAndSet(0),
+          DEGRADED_REASON_CARDINALITY_CAP);
+      countMetric(
+          FLAG_EVALUATION_DEGRADED_METRIC,
+          aggregator.degradedByteBudget.getAndSet(0),
+          DEGRADED_REASON_BYTE_BUDGET);
 
       // Drain per-reason context-truncation counters and emit one metric per unique reason tag.
       for (final Map.Entry<String, AtomicLong> entry : contextTruncatedCounts.entrySet()) {
@@ -462,10 +480,6 @@ public class FlagEvaluationWriterImpl implements FlagEvaluationWriter {
         return;
       }
       try {
-        countMetric(
-            FLAG_EVALUATION_DEGRADED_METRIC,
-            aggregator.degradedEvaluationCount(),
-            DEGRADED_REASON_CARDINALITY_CAP);
         final List<FlagEvaluationPayloads.FlagEvaluationEvent> events = buildEventList();
         if (events.isEmpty()) {
           return;

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/FlagEvaluationAggregatorTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/FlagEvaluationAggregatorTest.java
@@ -81,6 +81,110 @@ class FlagEvaluationAggregatorTest {
   }
 
   @Test
+  void byteBudgetOverflowRoutesToDegradedTierAndReportsReason() {
+    final Map<String, Object> attrs = context(10, 16, 32);
+    final FlagEvalEvent event = event("byte-flag", "on", "alloc1", "user-1", 1000L, true, attrs);
+    final long fullBucketBytes =
+        FlagEvaluationMemoryEstimator.fullBucketBytes(
+            event, attrs, FlagEvaluationAggregator.canonicalContextKey(attrs));
+    final long degradedBucketBytes = FlagEvaluationMemoryEstimator.degradedBucketBytes(event);
+    final FlagEvaluationAggregator aggregator = new FlagEvaluationAggregator(fullBucketBytes - 1);
+
+    aggregator.aggregate(event);
+
+    final FlagEvaluationAggregator.AggregatedState state = aggregator.snapshot();
+    assertEquals(0, state.fullTier.size());
+    assertEquals(1, state.degradedTier.size());
+    assertEquals(1, state.degradedByteBudget);
+    assertEquals(0, state.degradedCardinalityCap);
+    assertEquals(0, state.droppedByteBudget);
+    assertEquals(degradedBucketBytes, state.retainedBytes);
+  }
+
+  @Test
+  void byteBudgetDropsNewDegradedBucketWhenNoSpaceRemains() {
+    final Map<String, Object> attrs = context(10, 16, 32);
+    final FlagEvalEvent event =
+        event("drop-byte-flag", "on", "alloc1", "user-1", 1000L, true, attrs);
+    final long degradedBucketBytes = FlagEvaluationMemoryEstimator.degradedBucketBytes(event);
+    final FlagEvaluationAggregator aggregator =
+        new FlagEvaluationAggregator(degradedBucketBytes - 1);
+
+    aggregator.aggregate(event);
+
+    final FlagEvaluationAggregator.AggregatedState state = aggregator.snapshot();
+    assertTrue(state.fullTier.isEmpty());
+    assertTrue(state.degradedTier.isEmpty());
+    assertEquals(1, state.droppedByteBudget);
+    assertEquals(0, state.degradedByteBudget);
+    assertEquals(0, state.retainedBytes);
+  }
+
+  @Test
+  void existingBucketMergesWithoutReservingMoreBytes() {
+    final Map<String, Object> attrs = context(10, 16, 32);
+    final FlagEvalEvent event =
+        event("merge-byte-flag", "on", "alloc1", "user-1", 1000L, true, attrs);
+    final long fullBucketBytes =
+        FlagEvaluationMemoryEstimator.fullBucketBytes(
+            event, attrs, FlagEvaluationAggregator.canonicalContextKey(attrs));
+    final FlagEvaluationAggregator aggregator = new FlagEvaluationAggregator(fullBucketBytes);
+
+    aggregator.aggregate(event);
+    aggregator.aggregate(event);
+
+    final FlagEvaluationAggregator.AggregatedState state = aggregator.snapshot();
+    assertEquals(1, state.fullTier.size());
+    assertEquals(2, state.fullTier.values().iterator().next().count);
+    assertEquals(fullBucketBytes, state.retainedBytes);
+  }
+
+  @Test
+  void clearReleasesRetainedByteBudget() {
+    final FlagEvalEvent event = simpleEvent("clear-byte-flag", "on");
+    final long fullBucketBytes = FlagEvaluationMemoryEstimator.fullBucketBytes(event, null, "");
+    final FlagEvaluationAggregator aggregator = new FlagEvaluationAggregator(fullBucketBytes);
+
+    aggregator.aggregate(event);
+    assertEquals(fullBucketBytes, aggregator.retainedBytes());
+
+    aggregator.clear();
+    assertEquals(0, aggregator.retainedBytes());
+    aggregator.aggregate(event);
+    assertEquals(1, aggregator.fullTierSize());
+  }
+
+  @Test
+  void estimatorCoversMeasuredJolProfiles() {
+    final Map<String, Object> typical = context(256, 16, 32);
+    final FlagEvalEvent typicalEvent =
+        event("flag", "on", "allocation", fixedLength("subject", 64), 1L, true, typical);
+    final Map<String, Object> maximum = context(256, 256, 256);
+    final FlagEvalEvent maximumEvent =
+        event("flag", "on", "allocation", fixedLength("subject", 64), 1L, true, maximum);
+    final FlagEvalEvent protectedEvent =
+        event("flag", "on", "allocation", fixedLength("subject", 64), 1L, false, maximum);
+    final Map<String, Object> nullValue = new HashMap<>();
+    nullValue.put("nullable", null);
+    final FlagEvalEvent nullValueEvent =
+        event("flag", "on", "allocation", "subject", 1L, true, nullValue);
+
+    assertTrue(
+        FlagEvaluationMemoryEstimator.fullBucketBytes(
+                typicalEvent, typical, FlagEvaluationAggregator.canonicalContextKey(typical))
+            >= 60_021);
+    assertTrue(
+        FlagEvaluationMemoryEstimator.fullBucketBytes(
+                maximumEvent, maximum, FlagEvaluationAggregator.canonicalContextKey(maximum))
+            >= 297_589);
+    assertTrue(FlagEvaluationMemoryEstimator.fullBucketBytes(protectedEvent, null, "") >= 253);
+    assertTrue(
+        FlagEvaluationMemoryEstimator.fullBucketBytes(
+                nullValueEvent, nullValue, FlagEvaluationAggregator.canonicalContextKey(nullValue))
+            > 0);
+  }
+
+  @Test
   void perFlagCapOverflowRoutesToDegradedTierAndMergesSameDegradedKey() {
     final FlagEvaluationAggregator aggregator = new FlagEvaluationAggregator();
     aggregator.perFlagCount.put("hot-flag", FlagEvaluationAggregator.PER_FLAG_CAP);
@@ -201,6 +305,7 @@ class FlagEvaluationAggregatorTest {
     assertEquals(131_072, FlagEvaluationAggregator.GLOBAL_CAP);
     assertEquals(10_000, FlagEvaluationAggregator.PER_FLAG_CAP);
     assertEquals(32_768, FlagEvaluationAggregator.DEGRADED_CAP);
+    assertEquals(64L << 20, FlagEvaluationAggregator.RETAINED_BYTE_BUDGET);
   }
 
   @Test
@@ -392,6 +497,23 @@ class FlagEvaluationAggregatorTest {
 
   private static FlagEvalEvent simpleEvent(final String flagKey, final String variant) {
     return event(flagKey, variant, "alloc1", "user-1", 1000L, emptyMap());
+  }
+
+  private static Map<String, Object> context(
+      final int fieldCount, final int keyLength, final int valueLength) {
+    final Map<String, Object> attrs = new HashMap<>();
+    for (int field = 0; field < fieldCount; field++) {
+      attrs.put(fixedLength("key-" + field, keyLength), fixedLength("value-" + field, valueLength));
+    }
+    return attrs;
+  }
+
+  private static String fixedLength(final String prefix, final int length) {
+    final char[] value = new char[length];
+    final int prefixLength = Math.min(prefix.length(), length);
+    prefix.getChars(0, prefixLength, value, 0);
+    Arrays.fill(value, prefixLength, length, 'x');
+    return new String(value);
   }
 
   private static FlagEvaluationAggregator.FullKey fullKey(

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/FlagEvaluationWriterImplTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/FlagEvaluationWriterImplTest.java
@@ -88,6 +88,38 @@ class FlagEvaluationWriterImplTest {
   }
 
   @Test
+  void byteBudgetTelemetrySeparatesDegradedAndDroppedEvaluations() {
+    final BackendApi mockEvp = mock(BackendApi.class);
+    final FlagEvaluationTestSupport.TestWriterSetup setup = buildTestWriter(mockEvp);
+    setup.handler.aggregator.degradedCardinalityCap.addAndGet(2);
+    setup.handler.aggregator.degradedByteBudget.addAndGet(3);
+    setup.handler.aggregator.droppedByteBudget.addAndGet(4);
+
+    setup.handler.flush();
+
+    final Collection<? extends MetricCollector.Metric> metrics =
+        CoreMetricCollector.getInstance().drain();
+    assertEquals(
+        2,
+        metricSum(
+            metrics,
+            FlagEvaluationWriterImpl.FLAG_EVALUATION_DEGRADED_METRIC,
+            "reason:" + FlagEvaluationWriterImpl.DEGRADED_REASON_CARDINALITY_CAP));
+    assertEquals(
+        3,
+        metricSum(
+            metrics,
+            FlagEvaluationWriterImpl.FLAG_EVALUATION_DEGRADED_METRIC,
+            "reason:" + FlagEvaluationWriterImpl.DEGRADED_REASON_BYTE_BUDGET));
+    assertEquals(
+        4,
+        metricSum(
+            metrics,
+            FlagEvaluationWriterImpl.FLAG_EVALUATION_DROPPED_METRIC,
+            "reason:" + FlagEvaluationWriterImpl.DROP_REASON_BYTE_BUDGET));
+  }
+
+  @Test
   void startRegistersWriterAndCloseDeregistersIt() {
     final BackendApi mockEvp = mock(BackendApi.class);
     final BackendApiFactory factory = mock(BackendApiFactory.class);


### PR DESCRIPTION
## Motivation

The current count limits do not bound retained heap when full evaluation data is enabled. JOL measured a typical 256-field bucket at 60,021 bytes. It measured a maximum legal bucket at 297,589 bytes. At the global count limit, these profiles project to 7.3 GiB and 36.3 GiB. This memory can remain until the 10-second flush.

## Changes and Decisions

- Enforce a conservative 64 MiB estimated byte budget across full and degraded aggregation buckets.
- Merge existing buckets without a new byte reservation.
- Route a new full bucket to degraded aggregation when the byte budget is full.
- Drop the evaluation only when a degraded bucket cannot fit.
- Keep the existing count limits as secondary guards.
- Report byte-budget degradation and drops separately from cardinality limits.

## Validation

JOL measured the retained object graph after the first byte-budget degradation:

- Typical 256-field context: 735 full buckets and one degraded bucket retained 44,110,800 bytes.
- Maximum 256-field context: 118 full buckets and one degraded bucket retained 35,115,816 bytes.
- The estimator reserved 67,108,848 bytes and 66,840,328 bytes for these profiles.
- Smaller profiles reached the per-flag limit first. Protected data retained 2,466,400 bytes. A typical 10-field context retained 26,866,360 bytes.