### PR TITLE
Bump Tomcat smoke test to 9.0.120

### DIFF
--- a/dd-smoke-tests/springboot-tomcat/build.gradle
+++ b/dd-smoke-tests/springboot-tomcat/build.gradle
@@ -9,7 +9,7 @@ description = 'SpringBoot Tomcat Smoke Tests.'
 
 def serverName = 'tomcat'
 def serverModule = 'tomcat-9'
-def serverVersion = '9.0.117'
+def serverVersion = '9.0.120'
 def serverExtension = 'zip'
 
 repositories {

--- a/dd-smoke-tests/springboot-tomcat/gradle.lockfile
+++ b/dd-smoke-tests/springboot-tomcat/gradle.lockfile
@@ -115,5 +115,5 @@ org.spockframework:spock-core:2.4-groovy-3.0=testCompileClasspath,testRuntimeCla
 org.tabletest:tabletest-junit:1.2.2=testCompileClasspath,testRuntimeClasspath
 org.tabletest:tabletest-parser:1.2.1=testCompileClasspath,testRuntimeClasspath
 org.xmlresolver:xmlresolver:5.3.3=spotbugs
-tomcat:tomcat-9:9.0.117=serverFile
+tomcat:tomcat-9:9.0.120=serverFile
 empty=annotationProcessor,runtimeClasspath,spotbugsPlugins,testAnnotationProcessor


### PR DESCRIPTION
# What Does This Do

Bumps the Spring Boot Tomcat smoke test from Tomcat `9.0.117` to `9.0.120` and refreshes its Gradle lock entry.

# Motivation

The weekly Gradle dependency update workflow can no longer resolve the pinned Tomcat distribution:

```
Execution failed for task ':dd-smoke-tests:springboot-tomcat:resolveAndLockAll'.
> Could not resolve all files for configuration ':dd-smoke-tests:springboot-tomcat:serverFile'.
   > Could not find tomcat:tomcat-9:9.0.117.
     Searched in:
       https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.117/bin/apache-tomcat-9.0.117.zip
```

Apache's current-release CDN now serves Tomcat `9.0.120`; the pinned `9.0.117` URL returns 404. Updating the smoke test restores clean dependency resolution. This follows the same remediation used in #11091 when Tomcat `9.0.115` aged out of the CDN.

# Additional Notes

Validation:

- `./gradlew :dd-smoke-tests:springboot-tomcat:resolveAndLockAll --write-locks`
- `./gradlew :dd-smoke-tests:springboot-tomcat:test` — 202 tests passed
- `./gradlew :dd-smoke-tests:springboot-tomcat:spotlessCheck`

# Contributor Checklist

- [x] Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-using-a-keyword) when referencing an issue
- [x] Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion — not applicable
- [x] Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors — not applicable
- [ ] Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: N/A