### PR TITLE
Configuration to use Depot on GitLab Ci to avoid rate limiting with Maven Central.

### DIFF
--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/muzzle/MuzzleMavenRepoUtils.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/muzzle/MuzzleMavenRepoUtils.kt
@@ -38,7 +38,7 @@ internal object MuzzleMavenRepoUtils {
       listOf(central)
     } else {
       val proxy = RemoteRepository.Builder("central-proxy", "default", mavenProxyUrl).build()
-      listOf(proxy, central)
+      listOf(proxy)
     }
   }
 

--- a/gradle/repositories.gradle
+++ b/gradle/repositories.gradle
@@ -8,8 +8,9 @@ repositories {
       url project.rootProject.property("mavenRepositoryProxy")
       allowInsecureProtocol = true
     }
+  } else {
+    mavenCentral()
   }
-  mavenCentral()
   // add maven central repository for snapshot dependencies
   maven {
     content {


### PR DESCRIPTION
# What Does This Do

Makes the configured Maven repository proxy authoritative for general dependency resolution:

- Gradle project repositories use `mavenRepositoryProxy` when configured and use `mavenCentral()` only when the proxy property is absent.
- Muzzle uses only `MAVEN_REPOSITORY_PROXY` when configured instead of querying both the proxy and Maven Central.

GitLab CI already supplies these proxy settings, so CI resolves these dependencies through Depot. Local and external builds without the settings continue to use Maven Central.

# Motivation

The main source of direct Maven Central traffic was the latest-dependency configurations that use dynamic versions such as `2.+`, `2.7.+`, and `2.3.20+`.

For a dynamic selector, Gradle must discover all matching versions. [Gradle documentation](https://docs.gradle.org/current/userguide/dependency_graph_resolution.html#sec:how-gradle-downloads-deps) explains that Gradle checks every defined repository for version metadata rather than stopping after the first repository responds. Consequently, declaring Depot first and Maven Central second did not make Central a passive fallback: Gradle requested `maven-metadata.xml` from both repositories for each dynamic dependency.

Under parallel CI load, those direct requests can accumulate behind shared egress and eventually result in Maven Central rate limiting. A representative failure was:

```text
Could not resolve com.typesafe.play:play-java_2.13:2.7.+.
Could not GET .../maven-metadata.xml.
Received status code 429 from server: Too Many Requests
```

Muzzle had the same issue for its version-range scans because its default repository list contained both the proxy and Maven Central.

This change keeps Depot as the general remote repository whenever the proxy is configured, so dynamic-version and Muzzle range lookups no longer query Maven Central alongside Depot through the general repository list.

# Additional Notes

Validation:

- Resolved `org.glassfish.grizzly:grizzly-http-server:2.3.20+` for `latestDepTestRuntimeClasspath` with the proxy configured; the resolver log showed Depot serving the metadata and no request to Maven Central.
- `./gradlew :buildSrc:test --tests datadog.gradle.plugin.muzzle.MuzzleMavenRepoUtilsTest` — 4 tests passed.
- `./gradlew :buildSrc:spotlessCheck`

Specialized repositories with explicit content filters are unchanged.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->