### PR TITLE
Add null checks for calls to getAllLoadedClasses

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBEnablement.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/symbol/SymDBEnablement.java
@@ -129,7 +129,8 @@ public class SymDBEnablement implements ProductListener {
     try {
       classesToExtract =
           Arrays.stream(instrumentation.getAllLoadedClasses())
-              .filter(clazz -> !classNameFilter.isExcluded(clazz.getTypeName()))
+              // getAllLoadedClasses can return null classes (Class Unloading)
+              .filter(clazz -> clazz != null && !classNameFilter.isExcluded(clazz.getTypeName()))
               .filter(instrumentation::isModifiableClass)
               .toArray(Class<?>[]::new);
     } catch (Throwable ex) {

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SpringHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/SpringHelper.java
@@ -33,7 +33,8 @@ public class SpringHelper {
       // scan for getting an already loaded class and get the classloader
       ClassLoader springClassLoader = null;
       for (Class<?> clazz : inst.getAllLoadedClasses()) {
-        if (clazz.getName().startsWith("org.springframework.core")) {
+        // // getAllLoadedClasses can return null classes (Class Unloading)
+        if (clazz != null && clazz.getName().startsWith("org.springframework.core")) {
           springClassLoader = clazz.getClassLoader();
         }
       }

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymDBEnablementTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/symbol/SymDBEnablementTest.java
@@ -114,7 +114,7 @@ class SymDBEnablementTest {
   @Test
   public void parseLoadedClass() throws ClassNotFoundException, IOException {
     Class<?> testClass = loadSymbolClassFromJar();
-    when(instr.getAllLoadedClasses()).thenReturn(new Class[] {testClass});
+    when(instr.getAllLoadedClasses()).thenReturn(new Class[] {testClass, null});
     when(config.getThirdPartyIncludes())
         .thenReturn(
             Stream.of("com.datadog.debugger.", "org.springframework.samples.")

--- a/dd-java-agent/agent-installer/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDRediscoveryStrategy.java
+++ b/dd-java-agent/agent-installer/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDRediscoveryStrategy.java
@@ -72,7 +72,7 @@ public final class DDRediscoveryStrategy implements RedefinitionStrategy.Discove
       final Instrumentation instrumentation, final Set<Class<?>> visited) {
     List<Class<?>> retransforming = new ArrayList<>();
     for (Class<?> clazz : instrumentation.getAllLoadedClasses()) {
-      if (clazz != null) {
+      if (clazz == null) {
         // getAllLoadedClasses can return null classes (Class Unloading)
         continue;
       }

--- a/dd-java-agent/agent-installer/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDRediscoveryStrategy.java
+++ b/dd-java-agent/agent-installer/src/main/java/datadog/trace/agent/tooling/bytebuddy/DDRediscoveryStrategy.java
@@ -72,6 +72,10 @@ public final class DDRediscoveryStrategy implements RedefinitionStrategy.Discove
       final Instrumentation instrumentation, final Set<Class<?>> visited) {
     List<Class<?>> retransforming = new ArrayList<>();
     for (Class<?> clazz : instrumentation.getAllLoadedClasses()) {
+      if (clazz != null) {
+        // getAllLoadedClasses can return null classes (Class Unloading)
+        continue;
+      }
       ClassLoader classLoader = clazz.getClassLoader();
       if (null != classLoader) {
         if (canSkipClassLoaderByName(classLoader)) {

--- a/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/BootstrapClasspathSetupListener.java
+++ b/dd-java-agent/instrumentation-testing/src/main/java/datadog/trace/agent/test/BootstrapClasspathSetupListener.java
@@ -137,7 +137,9 @@ public class BootstrapClasspathSetupListener implements LauncherSessionListener 
     // Ensure there weren't any bootstrap classes loaded prematurely.
     Set<String> prematureBootstrapClasses = new TreeSet<>();
     for (Class<?> clazz : ByteBuddyAgent.getInstrumentation().getAllLoadedClasses()) {
-      if (isBootstrapClass(clazz)
+      // getAllLoadedClasses can return null classes (Class Unloading)
+      if (clazz != null
+          && isBootstrapClass(clazz)
           && clazz.getClassLoader() != null
           && !clazz.getName().equals("datadog.trace.api.DisableTestTrace")
           && !clazz.getName().startsWith("org.slf4j")) {


### PR DESCRIPTION
# What Does This Do
Instrumentation::getAllLoadedClasses can return null slot in the class array in case of class unloading. Make sure that all calls to the method check for null class while iterating over the returned array.

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [DEBUG-5575, DEBUG-5922]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
