### PR TITLE
[reference] R2DBC net-new instrumentation — regen vs sharpened DB skill (toolkit output)

### DIFF
--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/build.gradle
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/build.gradle
@@ -1,0 +1,16 @@
+muzzle {
+  pass {
+    group = 'io.r2dbc'
+    module = 'r2dbc-spi'
+    versions = "[1.0.0.RELEASE,)"
+    assertInverse = false
+  }
+}
+
+apply from: "$rootDir/gradle/java.gradle"
+
+dependencies {
+  compileOnly group: 'io.r2dbc', name: 'r2dbc-spi', version: '1.0.0.RELEASE'
+
+  testImplementation group: 'io.r2dbc', name: 'r2dbc-spi', version: '1.0.0.RELEASE'
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/BatchExecuteAdvice.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/BatchExecuteAdvice.java
@@ -1,0 +1,62 @@
+package datadog.trace.instrumentation.r2dbc;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.r2dbc.R2dbcDecorator.DATABASE_QUERY;
+import static datadog.trace.instrumentation.r2dbc.R2dbcDecorator.DECORATE;
+import static datadog.trace.instrumentation.r2dbc.R2dbcDecorator.R2DBC_BATCH;
+
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import io.r2dbc.spi.Batch;
+import io.r2dbc.spi.Result;
+import net.bytebuddy.asm.Advice;
+import org.reactivestreams.Publisher;
+
+public class BatchExecuteAdvice {
+
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  public static AgentScope onEnter(@Advice.This Batch batch) {
+    int callDepth = CallDepthThreadLocalMap.incrementCallDepth(Batch.class);
+    if (callDepth > 0) {
+      return null;
+    }
+
+    R2dbcConnectionInfo connInfo =
+        InstrumentationContext.get(Batch.class, R2dbcConnectionInfo.class).get(batch);
+
+    AgentSpan span = startSpan("r2dbc-spi", DATABASE_QUERY);
+    DECORATE.afterStart(span);
+    DECORATE.onDatabase(span, connInfo);
+    span.setResourceName(R2DBC_BATCH);
+
+    return activateSpan(span);
+  }
+
+  @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+  public static void onExit(
+      @Advice.Enter AgentScope scope,
+      @Advice.Return(readOnly = false) Publisher<? extends Result> publisher,
+      @Advice.Thrown Throwable throwable) {
+    CallDepthThreadLocalMap.decrementCallDepth(Batch.class);
+    if (scope == null) {
+      return;
+    }
+
+    AgentSpan span = scope.span();
+    scope.close();
+
+    if (throwable != null) {
+      DECORATE.onError(span, throwable);
+      DECORATE.beforeFinish(span);
+      span.finish();
+    } else if (publisher != null) {
+      publisher = new TracingPublisher(publisher, span);
+    } else {
+      DECORATE.beforeFinish(span);
+      span.finish();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/BatchInstrumentation.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/BatchInstrumentation.java
@@ -1,0 +1,55 @@
+package datadog.trace.instrumentation.r2dbc;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import java.util.Collections;
+import java.util.Map;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(InstrumenterModule.class)
+public final class BatchInstrumentation extends InstrumenterModule.Tracing
+    implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
+
+  public BatchInstrumentation() {
+    super("r2dbc");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "io.r2dbc.spi.Batch";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named("io.r2dbc.spi.Batch"));
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap("io.r2dbc.spi.Batch", packageName + ".R2dbcConnectionInfo");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".R2dbcConnectionInfo",
+      packageName + ".R2dbcDecorator",
+      packageName + ".TracingPublisher",
+      packageName + ".TracingPublisher$TracingSubscriber",
+    };
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        named("execute").and(isPublic()).and(takesArguments(0)),
+        packageName + ".BatchExecuteAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/ConnectionCreateBatchAdvice.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/ConnectionCreateBatchAdvice.java
@@ -1,0 +1,21 @@
+package datadog.trace.instrumentation.r2dbc;
+
+import datadog.trace.bootstrap.InstrumentationContext;
+import io.r2dbc.spi.Batch;
+import io.r2dbc.spi.Connection;
+import net.bytebuddy.asm.Advice;
+
+public class ConnectionCreateBatchAdvice {
+
+  @Advice.OnMethodExit(suppress = Throwable.class)
+  public static void afterCreateBatch(
+      @Advice.This Connection connection, @Advice.Return Batch batch) {
+    if (batch != null) {
+      R2dbcConnectionInfo info =
+          InstrumentationContext.get(Connection.class, R2dbcConnectionInfo.class).get(connection);
+      if (info != null) {
+        InstrumentationContext.get(Batch.class, R2dbcConnectionInfo.class).put(batch, info);
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/ConnectionCreateStatementAdvice.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/ConnectionCreateStatementAdvice.java
@@ -1,0 +1,23 @@
+package datadog.trace.instrumentation.r2dbc;
+
+import datadog.trace.bootstrap.InstrumentationContext;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.Statement;
+import net.bytebuddy.asm.Advice;
+
+public class ConnectionCreateStatementAdvice {
+
+  @Advice.OnMethodExit(suppress = Throwable.class)
+  public static void afterCreateStatement(
+      @Advice.This Connection connection,
+      @Advice.Argument(0) String sql,
+      @Advice.Return Statement statement) {
+    if (statement != null) {
+      R2dbcConnectionInfo connInfo =
+          InstrumentationContext.get(Connection.class, R2dbcConnectionInfo.class).get(connection);
+      R2dbcStatementInfo stmtInfo = new R2dbcStatementInfo(sql, connInfo);
+      InstrumentationContext.get(Statement.class, R2dbcStatementInfo.class)
+          .put(statement, stmtInfo);
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/ConnectionFactoryCreateAdvice.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/ConnectionFactoryCreateAdvice.java
@@ -1,0 +1,28 @@
+package datadog.trace.instrumentation.r2dbc;
+
+import datadog.trace.bootstrap.InstrumentationContext;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactory;
+import net.bytebuddy.asm.Advice;
+import org.reactivestreams.Publisher;
+
+public class ConnectionFactoryCreateAdvice {
+
+  @Advice.OnMethodExit(suppress = Throwable.class)
+  public static void afterCreate(
+      @Advice.This ConnectionFactory factory,
+      @Advice.Return(readOnly = false) Publisher<? extends Connection> publisher) {
+    if (publisher == null) {
+      return;
+    }
+
+    R2dbcConnectionInfo info = R2dbcConnectionInfoExtractor.extract(factory);
+    if (info != null) {
+      publisher =
+          new MetadataWrappingPublisher(
+              publisher,
+              info,
+              InstrumentationContext.get(Connection.class, R2dbcConnectionInfo.class));
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/ConnectionFactoryInstrumentation.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/ConnectionFactoryInstrumentation.java
@@ -1,0 +1,56 @@
+package datadog.trace.instrumentation.r2dbc;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import java.util.Collections;
+import java.util.Map;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(InstrumenterModule.class)
+public final class ConnectionFactoryInstrumentation extends InstrumenterModule.Tracing
+    implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
+
+  public ConnectionFactoryInstrumentation() {
+    super("r2dbc", "r2dbc-spi");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "io.r2dbc.spi.ConnectionFactory";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named("io.r2dbc.spi.ConnectionFactory"));
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap(
+        "io.r2dbc.spi.Connection", packageName + ".R2dbcConnectionInfo");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".R2dbcConnectionInfo",
+      packageName + ".R2dbcConnectionInfoExtractor",
+      packageName + ".MetadataWrappingPublisher",
+      packageName + ".MetadataWrappingPublisher$MetadataWrappingSubscriber",
+    };
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        named("create").and(isPublic()).and(takesArguments(0)),
+        packageName + ".ConnectionFactoryCreateAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/ConnectionInstrumentation.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/ConnectionInstrumentation.java
@@ -1,0 +1,65 @@
+package datadog.trace.instrumentation.r2dbc;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import java.util.HashMap;
+import java.util.Map;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(InstrumenterModule.class)
+public final class ConnectionInstrumentation extends InstrumenterModule.Tracing
+    implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
+
+  public ConnectionInstrumentation() {
+    super("r2dbc");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "io.r2dbc.spi.Connection";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named("io.r2dbc.spi.Connection"));
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    Map<String, String> stores = new HashMap<>();
+    stores.put("io.r2dbc.spi.Statement", packageName + ".R2dbcStatementInfo");
+    stores.put("io.r2dbc.spi.Connection", packageName + ".R2dbcConnectionInfo");
+    stores.put("io.r2dbc.spi.Batch", packageName + ".R2dbcConnectionInfo");
+    return stores;
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".R2dbcConnectionInfo",
+      packageName + ".R2dbcStatementInfo",
+      packageName + ".R2dbcDecorator",
+    };
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        named("createStatement")
+            .and(isPublic())
+            .and(takesArguments(1))
+            .and(takesArgument(0, String.class)),
+        packageName + ".ConnectionCreateStatementAdvice");
+    transformer.applyAdvice(
+        named("createBatch").and(isPublic()).and(takesArguments(0)),
+        packageName + ".ConnectionCreateBatchAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/MetadataWrappingPublisher.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/MetadataWrappingPublisher.java
@@ -1,0 +1,72 @@
+package datadog.trace.instrumentation.r2dbc;
+
+import datadog.trace.bootstrap.ContextStore;
+import io.r2dbc.spi.Connection;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * Wraps a {@link Publisher} returned by {@code ConnectionFactory.create()} to associate each
+ * emitted {@link Connection} with its {@link R2dbcConnectionInfo} in the context store. This
+ * enables downstream Statement and Batch advice to access connection metadata for DBM tagging.
+ */
+public final class MetadataWrappingPublisher implements Publisher<Connection> {
+
+  private final Publisher<? extends Connection> delegate;
+  private final R2dbcConnectionInfo info;
+  private final ContextStore<Connection, R2dbcConnectionInfo> contextStore;
+
+  public MetadataWrappingPublisher(
+      Publisher<? extends Connection> delegate,
+      R2dbcConnectionInfo info,
+      ContextStore<Connection, R2dbcConnectionInfo> contextStore) {
+    this.delegate = delegate;
+    this.info = info;
+    this.contextStore = contextStore;
+  }
+
+  @Override
+  public void subscribe(Subscriber<? super Connection> subscriber) {
+    delegate.subscribe(new MetadataWrappingSubscriber(subscriber, info, contextStore));
+  }
+
+  static final class MetadataWrappingSubscriber implements Subscriber<Connection> {
+
+    private final Subscriber<? super Connection> delegate;
+    private final R2dbcConnectionInfo info;
+    private final ContextStore<Connection, R2dbcConnectionInfo> contextStore;
+
+    MetadataWrappingSubscriber(
+        Subscriber<? super Connection> delegate,
+        R2dbcConnectionInfo info,
+        ContextStore<Connection, R2dbcConnectionInfo> contextStore) {
+      this.delegate = delegate;
+      this.info = info;
+      this.contextStore = contextStore;
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+      delegate.onSubscribe(s);
+    }
+
+    @Override
+    public void onNext(Connection connection) {
+      if (connection != null) {
+        contextStore.put(connection, info);
+      }
+      delegate.onNext(connection);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      delegate.onError(t);
+    }
+
+    @Override
+    public void onComplete() {
+      delegate.onComplete();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/R2dbcConnectionInfo.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/R2dbcConnectionInfo.java
@@ -1,0 +1,41 @@
+package datadog.trace.instrumentation.r2dbc;
+
+/**
+ * Holds connection metadata extracted from an R2DBC Connection for use in span tagging. Captures
+ * host, port, user, database name, and database type to support Database Monitoring (DBM) features.
+ */
+public final class R2dbcConnectionInfo {
+  private final String host;
+  private final Integer port;
+  private final String user;
+  private final String dbName;
+  private final String dbType;
+
+  public R2dbcConnectionInfo(String host, Integer port, String user, String dbName, String dbType) {
+    this.host = host;
+    this.port = port;
+    this.user = user;
+    this.dbName = dbName;
+    this.dbType = dbType;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public Integer getPort() {
+    return port;
+  }
+
+  public String getUser() {
+    return user;
+  }
+
+  public String getDbName() {
+    return dbName;
+  }
+
+  public String getDbType() {
+    return dbType;
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/R2dbcConnectionInfoExtractor.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/R2dbcConnectionInfoExtractor.java
@@ -1,0 +1,78 @@
+package datadog.trace.instrumentation.r2dbc;
+
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.Option;
+import java.lang.reflect.Method;
+
+/**
+ * Extracts connection metadata from an R2DBC ConnectionFactory by looking for a {@code
+ * getOptions()} method that returns ConnectionFactoryOptions. This covers most R2DBC driver
+ * implementations.
+ */
+public final class R2dbcConnectionInfoExtractor {
+
+  public static R2dbcConnectionInfo extract(ConnectionFactory factory) {
+    try {
+      Method getOptions = null;
+      try {
+        getOptions = factory.getClass().getMethod("getOptions");
+      } catch (NoSuchMethodException e) {
+        // Not available
+      }
+
+      if (getOptions != null) {
+        Object options = getOptions.invoke(factory);
+        if (options instanceof ConnectionFactoryOptions) {
+          return fromOptions((ConnectionFactoryOptions) options);
+        }
+      }
+    } catch (Exception e) {
+      // Silently ignore - metadata extraction is best-effort
+    }
+    return null;
+  }
+
+  public static R2dbcConnectionInfo fromOptions(ConnectionFactoryOptions cfo) {
+    String host = safeGet(cfo, ConnectionFactoryOptions.HOST);
+    Integer port = safeGetInt(cfo, ConnectionFactoryOptions.PORT);
+    String user = safeGet(cfo, ConnectionFactoryOptions.USER);
+    String database = safeGet(cfo, ConnectionFactoryOptions.DATABASE);
+    String driver = safeGet(cfo, ConnectionFactoryOptions.DRIVER);
+
+    if (host != null || user != null || database != null || driver != null) {
+      return new R2dbcConnectionInfo(host, port, user, database, driver);
+    }
+    return null;
+  }
+
+  private static String safeGet(ConnectionFactoryOptions options, Option<?> option) {
+    try {
+      if (options.hasOption(option)) {
+        Object value = options.getValue(option);
+        return value != null ? value.toString() : null;
+      }
+    } catch (Exception e) {
+      // ignore
+    }
+    return null;
+  }
+
+  private static Integer safeGetInt(ConnectionFactoryOptions options, Option<?> option) {
+    try {
+      if (options.hasOption(option)) {
+        Object value = options.getValue(option);
+        if (value instanceof Integer) {
+          return (Integer) value;
+        } else if (value != null) {
+          return Integer.parseInt(value.toString());
+        }
+      }
+    } catch (Exception e) {
+      // ignore
+    }
+    return null;
+  }
+
+  private R2dbcConnectionInfoExtractor() {}
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/R2dbcDecorator.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/R2dbcDecorator.java
@@ -1,0 +1,93 @@
+package datadog.trace.instrumentation.r2dbc;
+
+import datadog.trace.api.naming.SpanNaming;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.bootstrap.instrumentation.decorator.DatabaseClientDecorator;
+import datadog.trace.bootstrap.instrumentation.jdbc.DBQueryInfo;
+
+public class R2dbcDecorator extends DatabaseClientDecorator<R2dbcConnectionInfo> {
+
+  public static final R2dbcDecorator DECORATE = new R2dbcDecorator();
+
+  public static final CharSequence R2DBC_SPI = UTF8BytesString.create("r2dbc-spi");
+  public static final CharSequence DATABASE_QUERY = UTF8BytesString.create("database.query");
+  public static final CharSequence R2DBC_BATCH = UTF8BytesString.create("r2dbc.batch");
+  private static final UTF8BytesString DB_QUERY = UTF8BytesString.create("DB Query");
+
+  private static final String DEFAULT_SERVICE_NAME =
+      SpanNaming.instance().namingSchema().database().service("r2dbc");
+
+  @Override
+  protected String[] instrumentationNames() {
+    return new String[] {"r2dbc", "r2dbc-spi"};
+  }
+
+  @Override
+  protected String service() {
+    return DEFAULT_SERVICE_NAME;
+  }
+
+  @Override
+  protected CharSequence component() {
+    return R2DBC_SPI;
+  }
+
+  @Override
+  protected CharSequence spanType() {
+    return InternalSpanTypes.SQL;
+  }
+
+  @Override
+  protected String dbType() {
+    return "r2dbc";
+  }
+
+  @Override
+  protected String dbUser(R2dbcConnectionInfo info) {
+    return info != null ? info.getUser() : null;
+  }
+
+  @Override
+  protected String dbInstance(R2dbcConnectionInfo info) {
+    return info != null ? info.getDbName() : null;
+  }
+
+  @Override
+  protected CharSequence dbHostname(R2dbcConnectionInfo info) {
+    return info != null ? info.getHost() : null;
+  }
+
+  public void onDatabase(AgentSpan span, R2dbcConnectionInfo info) {
+    String type = (info != null && info.getDbType() != null) ? info.getDbType() : dbType();
+    processDatabaseType(span, type);
+    if (info != null) {
+      onConnection(span, info);
+      if (info.getPort() != null && info.getPort() > 0) {
+        span.setTag(Tags.PEER_PORT, info.getPort());
+      }
+    }
+  }
+
+  public void onStatement(AgentSpan span, String sql) {
+    if (sql != null && !sql.isEmpty()) {
+      onRawStatement(span, sql);
+      DBQueryInfo info = DBQueryInfo.ofStatement(sql);
+      span.setResourceName(info.getSql());
+      span.setTag(Tags.DB_OPERATION, info.getOperation());
+    } else {
+      span.setResourceName(DB_QUERY);
+    }
+  }
+
+  @Override
+  protected void postProcessServiceAndOperationName(
+      AgentSpan span, DatabaseClientDecorator.NamingEntry namingEntry) {
+    if (namingEntry.getService() != null) {
+      span.setServiceName(namingEntry.getService(), component());
+    }
+    span.setOperationName(namingEntry.getOperation());
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/R2dbcStatementInfo.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/R2dbcStatementInfo.java
@@ -1,0 +1,24 @@
+package datadog.trace.instrumentation.r2dbc;
+
+/**
+ * Combines SQL statement text and connection metadata for a single R2DBC Statement. Stored in the
+ * context store keyed by Statement to make both the query and connection metadata available at
+ * execution time.
+ */
+public final class R2dbcStatementInfo {
+  private final String sql;
+  private final R2dbcConnectionInfo connectionInfo;
+
+  public R2dbcStatementInfo(String sql, R2dbcConnectionInfo connectionInfo) {
+    this.sql = sql;
+    this.connectionInfo = connectionInfo;
+  }
+
+  public String getSql() {
+    return sql;
+  }
+
+  public R2dbcConnectionInfo getConnectionInfo() {
+    return connectionInfo;
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/StatementExecuteAdvice.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/StatementExecuteAdvice.java
@@ -1,0 +1,64 @@
+package datadog.trace.instrumentation.r2dbc;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.r2dbc.R2dbcDecorator.DATABASE_QUERY;
+import static datadog.trace.instrumentation.r2dbc.R2dbcDecorator.DECORATE;
+
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
+import datadog.trace.bootstrap.InstrumentationContext;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Statement;
+import net.bytebuddy.asm.Advice;
+import org.reactivestreams.Publisher;
+
+public class StatementExecuteAdvice {
+
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  public static AgentScope onEnter(@Advice.This Statement statement) {
+    int callDepth = CallDepthThreadLocalMap.incrementCallDepth(Statement.class);
+    if (callDepth > 0) {
+      return null;
+    }
+
+    R2dbcStatementInfo stmtInfo =
+        InstrumentationContext.get(Statement.class, R2dbcStatementInfo.class).get(statement);
+
+    String sql = stmtInfo != null ? stmtInfo.getSql() : null;
+    R2dbcConnectionInfo connInfo = stmtInfo != null ? stmtInfo.getConnectionInfo() : null;
+
+    AgentSpan span = startSpan("r2dbc-spi", DATABASE_QUERY);
+    DECORATE.afterStart(span);
+    DECORATE.onDatabase(span, connInfo);
+    DECORATE.onStatement(span, sql);
+
+    return activateSpan(span);
+  }
+
+  @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+  public static void onExit(
+      @Advice.Enter AgentScope scope,
+      @Advice.Return(readOnly = false) Publisher<? extends Result> publisher,
+      @Advice.Thrown Throwable throwable) {
+    CallDepthThreadLocalMap.decrementCallDepth(Statement.class);
+    if (scope == null) {
+      return;
+    }
+
+    AgentSpan span = scope.span();
+    scope.close();
+
+    if (throwable != null) {
+      DECORATE.onError(span, throwable);
+      DECORATE.beforeFinish(span);
+      span.finish();
+    } else if (publisher != null) {
+      publisher = new TracingPublisher(publisher, span);
+    } else {
+      DECORATE.beforeFinish(span);
+      span.finish();
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/StatementInstrumentation.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/StatementInstrumentation.java
@@ -1,0 +1,56 @@
+package datadog.trace.instrumentation.r2dbc;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.implementsInterface;
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+import java.util.Collections;
+import java.util.Map;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+@AutoService(InstrumenterModule.class)
+public final class StatementInstrumentation extends InstrumenterModule.Tracing
+    implements Instrumenter.ForTypeHierarchy, Instrumenter.HasMethodAdvice {
+
+  public StatementInstrumentation() {
+    super("r2dbc");
+  }
+
+  @Override
+  public String hierarchyMarkerType() {
+    return "io.r2dbc.spi.Statement";
+  }
+
+  @Override
+  public ElementMatcher<TypeDescription> hierarchyMatcher() {
+    return implementsInterface(named("io.r2dbc.spi.Statement"));
+  }
+
+  @Override
+  public Map<String, String> contextStore() {
+    return Collections.singletonMap("io.r2dbc.spi.Statement", packageName + ".R2dbcStatementInfo");
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".R2dbcConnectionInfo",
+      packageName + ".R2dbcStatementInfo",
+      packageName + ".R2dbcDecorator",
+      packageName + ".TracingPublisher",
+      packageName + ".TracingPublisher$TracingSubscriber",
+    };
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(
+        named("execute").and(isPublic()).and(takesArguments(0)),
+        packageName + ".StatementExecuteAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/TracingPublisher.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/main/java/datadog/trace/instrumentation/r2dbc/TracingPublisher.java
@@ -1,0 +1,71 @@
+package datadog.trace.instrumentation.r2dbc;
+
+import static datadog.trace.instrumentation.r2dbc.R2dbcDecorator.DECORATE;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import io.r2dbc.spi.Result;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * Wraps a {@link Publisher} returned by {@code Statement.execute()} or {@code Batch.execute()} to
+ * finish the associated span when the publisher signals completion or error.
+ */
+public final class TracingPublisher implements Publisher<Result> {
+
+  private final Publisher<? extends Result> delegate;
+  private final AgentSpan span;
+
+  public TracingPublisher(Publisher<? extends Result> delegate, AgentSpan span) {
+    this.delegate = delegate;
+    this.span = span;
+  }
+
+  @Override
+  public void subscribe(Subscriber<? super Result> subscriber) {
+    delegate.subscribe(new TracingSubscriber(subscriber, span));
+  }
+
+  private static final class TracingSubscriber implements Subscriber<Result> {
+
+    private final Subscriber<? super Result> delegate;
+    private final AgentSpan span;
+
+    TracingSubscriber(Subscriber<? super Result> delegate, AgentSpan span) {
+      this.delegate = delegate;
+      this.span = span;
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+      delegate.onSubscribe(s);
+    }
+
+    @Override
+    public void onNext(Result result) {
+      delegate.onNext(result);
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      try {
+        DECORATE.onError(span, t);
+        DECORATE.beforeFinish(span);
+        span.finish();
+      } finally {
+        delegate.onError(t);
+      }
+    }
+
+    @Override
+    public void onComplete() {
+      try {
+        DECORATE.beforeFinish(span);
+        span.finish();
+      } finally {
+        delegate.onComplete();
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/test/java/datadog/trace/instrumentation/r2dbc/R2dbcInstrumentationTest.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/test/java/datadog/trace/instrumentation/r2dbc/R2dbcInstrumentationTest.java
@@ -1,0 +1,606 @@
+package datadog.trace.instrumentation.r2dbc;
+
+import static datadog.trace.agent.test.assertions.SpanMatcher.span;
+import static datadog.trace.agent.test.assertions.TagsMatcher.defaultTags;
+import static datadog.trace.agent.test.assertions.TagsMatcher.error;
+import static datadog.trace.agent.test.assertions.TagsMatcher.tag;
+import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.COMPONENT;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_INSTANCE;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_OPERATION;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_TYPE;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.DB_USER;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.PEER_HOSTNAME;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.PEER_PORT;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND;
+import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CLIENT;
+import static datadog.trace.test.junit.utils.assertions.Matchers.any;
+import static datadog.trace.test.junit.utils.assertions.Matchers.is;
+import static datadog.trace.test.junit.utils.assertions.Matchers.matches;
+
+import datadog.trace.agent.test.AbstractInstrumentationTest;
+import datadog.trace.agent.test.assertions.TraceMatcher;
+import datadog.trace.api.DDTags;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.Result;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import r2dbc.test.TestBatch;
+import r2dbc.test.TestConnection;
+import r2dbc.test.TestConnectionFactory;
+import r2dbc.test.TestStatement;
+
+class R2dbcInstrumentationTest extends AbstractInstrumentationTest {
+
+  /**
+   * Creates a Predicate that compares CharSequence values by string content. Needed because span
+   * operation and resource names are stored as UTF8BytesString which is not equal to a plain String
+   * via Object.equals().
+   */
+  private static Predicate<CharSequence> csEquals(String expected) {
+    return cs -> cs != null && cs.toString().equals(expected);
+  }
+
+  @Test
+  void statementExecuteCreatesASpan() throws Exception {
+    TestConnection connection = new TestConnection();
+    TestStatement statement = (TestStatement) connection.createStatement("SELECT * FROM users");
+    CountDownLatch latch = new CountDownLatch(1);
+
+    runUnderTrace(
+        "parent",
+        () -> {
+          Publisher<? extends Result> publisher = statement.execute();
+          publisher.subscribe(completionSubscriber(latch));
+          return null;
+        });
+    assert latch.await(10, TimeUnit.SECONDS);
+
+    assertTraces(
+        TraceMatcher.trace(
+            span().operationName("parent"),
+            span()
+                .childOfPrevious()
+                .operationName(Pattern.compile("r2dbc\\.query"))
+                .resourceName(csEquals("SELECT * FROM users"))
+                .type("sql")
+                .tags(
+                    tag(COMPONENT, matches("r2dbc-spi")),
+                    tag(SPAN_KIND, is(SPAN_KIND_CLIENT)),
+                    tag(DB_TYPE, is("r2dbc")),
+                    tag(DB_OPERATION, matches("SELECT")),
+                    tag(DDTags.DD_SVC_SRC, any()),
+                    defaultTags())));
+  }
+
+  @Test
+  void statementExecuteWithBindParametersCreatesASpan() throws Exception {
+    TestConnection connection = new TestConnection();
+    TestStatement statement =
+        (TestStatement) connection.createStatement("SELECT * FROM users WHERE id = ?");
+    statement.bind(0, 42);
+    CountDownLatch latch = new CountDownLatch(1);
+
+    runUnderTrace(
+        "parent",
+        () -> {
+          Publisher<? extends Result> publisher = statement.execute();
+          publisher.subscribe(completionSubscriber(latch));
+          return null;
+        });
+    assert latch.await(10, TimeUnit.SECONDS);
+
+    assertTraces(
+        TraceMatcher.trace(
+            span().operationName("parent"),
+            span()
+                .childOfPrevious()
+                .operationName(Pattern.compile("r2dbc\\.query"))
+                .resourceName(csEquals("SELECT * FROM users WHERE id = ?"))
+                .type("sql")
+                .tags(
+                    tag(COMPONENT, matches("r2dbc-spi")),
+                    tag(SPAN_KIND, is(SPAN_KIND_CLIENT)),
+                    tag(DB_TYPE, is("r2dbc")),
+                    tag(DB_OPERATION, matches("SELECT")),
+                    tag(DDTags.DD_SVC_SRC, any()),
+                    defaultTags())));
+  }
+
+  @Test
+  void batchExecuteCreatesASpan() throws Exception {
+    TestConnection connection = new TestConnection();
+    TestBatch batch = (TestBatch) connection.createBatch();
+    batch.add("INSERT INTO users (name) VALUES ('Alice')");
+    batch.add("INSERT INTO users (name) VALUES ('Bob')");
+    CountDownLatch latch = new CountDownLatch(1);
+
+    runUnderTrace(
+        "parent",
+        () -> {
+          Publisher<? extends Result> publisher = batch.execute();
+          publisher.subscribe(completionSubscriber(latch));
+          return null;
+        });
+    assert latch.await(10, TimeUnit.SECONDS);
+
+    assertTraces(
+        TraceMatcher.trace(
+            span().operationName("parent"),
+            span()
+                .childOfPrevious()
+                .operationName(Pattern.compile("r2dbc\\.query"))
+                .resourceName(csEquals("r2dbc.batch"))
+                .type("sql")
+                .tags(
+                    tag(COMPONENT, matches("r2dbc-spi")),
+                    tag(SPAN_KIND, is(SPAN_KIND_CLIENT)),
+                    tag(DB_TYPE, is("r2dbc")),
+                    tag(DDTags.DD_SVC_SRC, any()),
+                    defaultTags())));
+  }
+
+  @Test
+  void statementExecuteWithoutParentCreatesARootSpan() throws Exception {
+    TestConnection connection = new TestConnection();
+    TestStatement statement = (TestStatement) connection.createStatement("SELECT 1");
+    CountDownLatch latch = new CountDownLatch(1);
+
+    Publisher<? extends Result> publisher = statement.execute();
+    publisher.subscribe(completionSubscriber(latch));
+    assert latch.await(10, TimeUnit.SECONDS);
+
+    assertTraces(
+        TraceMatcher.trace(
+            span()
+                .operationName(Pattern.compile("r2dbc\\.query"))
+                .resourceName(csEquals("SELECT ?"))
+                .type("sql")
+                .tags(
+                    tag(COMPONENT, matches("r2dbc-spi")),
+                    tag(SPAN_KIND, is(SPAN_KIND_CLIENT)),
+                    tag(DB_TYPE, is("r2dbc")),
+                    tag(DB_OPERATION, matches("SELECT")),
+                    tag(DDTags.DD_SVC_SRC, any()),
+                    defaultTags())));
+  }
+
+  @Test
+  void statementExecutePropagatesErrorToSpan() throws Exception {
+    TestConnection connection = new TestConnection();
+    TestStatement statement = (TestStatement) connection.createStatement("INVALID SQL");
+    statement.setShouldFail(true);
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<Throwable> caughtError = new AtomicReference<>();
+
+    runUnderTrace(
+        "parent",
+        () -> {
+          Publisher<? extends Result> publisher = statement.execute();
+          publisher.subscribe(errorCapturingSubscriber(latch, caughtError));
+          return null;
+        });
+    assert latch.await(10, TimeUnit.SECONDS);
+    assert caughtError.get() != null;
+
+    assertTraces(
+        TraceMatcher.trace(
+            span().operationName("parent"),
+            span()
+                .childOfPrevious()
+                .operationName(Pattern.compile("r2dbc\\.query"))
+                .resourceName(csEquals("INVALID SQL"))
+                .type("sql")
+                .error()
+                .tags(
+                    tag(COMPONENT, matches("r2dbc-spi")),
+                    tag(SPAN_KIND, is(SPAN_KIND_CLIENT)),
+                    tag(DB_TYPE, is("r2dbc")),
+                    tag(DB_OPERATION, matches("INVALID")),
+                    error(RuntimeException.class, "query execution failed"),
+                    tag(DDTags.DD_SVC_SRC, any()),
+                    defaultTags())));
+  }
+
+  @Test
+  void batchExecutePropagatesErrorToSpan() throws Exception {
+    TestConnection connection = new TestConnection();
+    TestBatch batch = (TestBatch) connection.createBatch();
+    batch.add("INVALID SQL");
+    batch.setShouldFail(true);
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<Throwable> caughtError = new AtomicReference<>();
+
+    runUnderTrace(
+        "parent",
+        () -> {
+          Publisher<? extends Result> publisher = batch.execute();
+          publisher.subscribe(errorCapturingSubscriber(latch, caughtError));
+          return null;
+        });
+    assert latch.await(10, TimeUnit.SECONDS);
+    assert caughtError.get() != null;
+
+    assertTraces(
+        TraceMatcher.trace(
+            span().operationName("parent"),
+            span()
+                .childOfPrevious()
+                .operationName(Pattern.compile("r2dbc\\.query"))
+                .resourceName(csEquals("r2dbc.batch"))
+                .type("sql")
+                .error()
+                .tags(
+                    tag(COMPONENT, matches("r2dbc-spi")),
+                    tag(SPAN_KIND, is(SPAN_KIND_CLIENT)),
+                    tag(DB_TYPE, is("r2dbc")),
+                    error(RuntimeException.class, "batch execution failed"),
+                    tag(DDTags.DD_SVC_SRC, any()),
+                    defaultTags())));
+  }
+
+  @Test
+  void statementExecuteWithConnectionMetadataSetsDbTags() throws Exception {
+    ConnectionFactoryOptions options =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "db.example.com")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .option(ConnectionFactoryOptions.USER, "app_user")
+            .option(ConnectionFactoryOptions.DATABASE, "myapp_db")
+            .build();
+    TestConnectionFactory factory = new TestConnectionFactory(options);
+    AtomicReference<Connection> connectionRef = new AtomicReference<>();
+    CountDownLatch connLatch = new CountDownLatch(1);
+    factory
+        .create()
+        .subscribe(
+            new Subscriber<Connection>() {
+              @Override
+              public void onSubscribe(Subscription s) {
+                s.request(1);
+              }
+
+              @Override
+              public void onNext(Connection c) {
+                connectionRef.set(c);
+              }
+
+              @Override
+              public void onError(Throwable t) {
+                connLatch.countDown();
+              }
+
+              @Override
+              public void onComplete() {
+                connLatch.countDown();
+              }
+            });
+    assert connLatch.await(10, TimeUnit.SECONDS);
+    Connection connection = connectionRef.get();
+    assert connection != null;
+    TestStatement statement =
+        (TestStatement) connection.createStatement("SELECT * FROM orders WHERE id = ?");
+    statement.bind(0, 1);
+    CountDownLatch latch = new CountDownLatch(1);
+
+    runUnderTrace(
+        "parent",
+        () -> {
+          Publisher<? extends Result> publisher = statement.execute();
+          publisher.subscribe(completionSubscriber(latch));
+          return null;
+        });
+    assert latch.await(10, TimeUnit.SECONDS);
+
+    assertTraces(
+        TraceMatcher.trace(
+            span().operationName("parent"),
+            span()
+                .childOfPrevious()
+                .operationName(Pattern.compile("postgresql\\.query"))
+                .resourceName(csEquals("SELECT * FROM orders WHERE id = ?"))
+                .type("sql")
+                .tags(
+                    tag(COMPONENT, matches("r2dbc-spi")),
+                    tag(SPAN_KIND, is(SPAN_KIND_CLIENT)),
+                    tag(DB_TYPE, is("postgresql")),
+                    tag(DB_OPERATION, matches("SELECT")),
+                    tag(DB_INSTANCE, is("myapp_db")),
+                    tag(DB_USER, is("app_user")),
+                    tag(PEER_HOSTNAME, is("db.example.com")),
+                    tag(PEER_PORT, is(5432)),
+                    tag(DDTags.PEER_SERVICE_SOURCE, any()),
+                    tag(DDTags.DD_SVC_SRC, any()),
+                    defaultTags())));
+  }
+
+  @Test
+  void batchExecuteWithConnectionMetadataSetsDbTags() throws Exception {
+    ConnectionFactoryOptions options =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "db.example.com")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .option(ConnectionFactoryOptions.USER, "app_user")
+            .option(ConnectionFactoryOptions.DATABASE, "myapp_db")
+            .build();
+    TestConnectionFactory factory = new TestConnectionFactory(options);
+    AtomicReference<Connection> connectionRef = new AtomicReference<>();
+    CountDownLatch connLatch = new CountDownLatch(1);
+    factory
+        .create()
+        .subscribe(
+            new Subscriber<Connection>() {
+              @Override
+              public void onSubscribe(Subscription s) {
+                s.request(1);
+              }
+
+              @Override
+              public void onNext(Connection c) {
+                connectionRef.set(c);
+              }
+
+              @Override
+              public void onError(Throwable t) {
+                connLatch.countDown();
+              }
+
+              @Override
+              public void onComplete() {
+                connLatch.countDown();
+              }
+            });
+    assert connLatch.await(10, TimeUnit.SECONDS);
+    Connection connection = connectionRef.get();
+    assert connection != null;
+    TestBatch batch = (TestBatch) connection.createBatch();
+    batch.add("INSERT INTO users (name) VALUES ('Alice')");
+    batch.add("INSERT INTO users (name) VALUES ('Bob')");
+    CountDownLatch latch = new CountDownLatch(1);
+
+    runUnderTrace(
+        "parent",
+        () -> {
+          Publisher<? extends Result> publisher = batch.execute();
+          publisher.subscribe(completionSubscriber(latch));
+          return null;
+        });
+    assert latch.await(10, TimeUnit.SECONDS);
+
+    assertTraces(
+        TraceMatcher.trace(
+            span().operationName("parent"),
+            span()
+                .childOfPrevious()
+                .operationName(Pattern.compile("postgresql\\.query"))
+                .resourceName(csEquals("r2dbc.batch"))
+                .type("sql")
+                .tags(
+                    tag(COMPONENT, matches("r2dbc-spi")),
+                    tag(SPAN_KIND, is(SPAN_KIND_CLIENT)),
+                    tag(DB_TYPE, is("postgresql")),
+                    tag(DB_INSTANCE, is("myapp_db")),
+                    tag(DB_USER, is("app_user")),
+                    tag(PEER_HOSTNAME, is("db.example.com")),
+                    tag(PEER_PORT, is(5432)),
+                    tag(DDTags.PEER_SERVICE_SOURCE, any()),
+                    tag(DDTags.DD_SVC_SRC, any()),
+                    defaultTags())));
+  }
+
+  @Test
+  void statementExecuteErrorWithConnectionMetadataPreservesDbTags() throws Exception {
+    ConnectionFactoryOptions options =
+        ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "postgresql")
+            .option(ConnectionFactoryOptions.HOST, "db.example.com")
+            .option(ConnectionFactoryOptions.PORT, 5432)
+            .option(ConnectionFactoryOptions.USER, "app_user")
+            .option(ConnectionFactoryOptions.DATABASE, "myapp_db")
+            .build();
+    TestConnectionFactory factory = new TestConnectionFactory(options);
+    AtomicReference<Connection> connectionRef = new AtomicReference<>();
+    CountDownLatch connLatch = new CountDownLatch(1);
+    factory
+        .create()
+        .subscribe(
+            new Subscriber<Connection>() {
+              @Override
+              public void onSubscribe(Subscription s) {
+                s.request(1);
+              }
+
+              @Override
+              public void onNext(Connection c) {
+                connectionRef.set(c);
+              }
+
+              @Override
+              public void onError(Throwable t) {
+                connLatch.countDown();
+              }
+
+              @Override
+              public void onComplete() {
+                connLatch.countDown();
+              }
+            });
+    assert connLatch.await(10, TimeUnit.SECONDS);
+    Connection connection = connectionRef.get();
+    assert connection != null;
+    TestStatement statement = (TestStatement) connection.createStatement("INVALID SQL");
+    statement.setShouldFail(true);
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<Throwable> caughtError = new AtomicReference<>();
+
+    runUnderTrace(
+        "parent",
+        () -> {
+          Publisher<? extends Result> publisher = statement.execute();
+          publisher.subscribe(errorCapturingSubscriber(latch, caughtError));
+          return null;
+        });
+    assert latch.await(10, TimeUnit.SECONDS);
+    assert caughtError.get() != null;
+
+    assertTraces(
+        TraceMatcher.trace(
+            span().operationName("parent"),
+            span()
+                .childOfPrevious()
+                .operationName(Pattern.compile("postgresql\\.query"))
+                .resourceName(csEquals("INVALID SQL"))
+                .type("sql")
+                .error()
+                .tags(
+                    tag(COMPONENT, matches("r2dbc-spi")),
+                    tag(SPAN_KIND, is(SPAN_KIND_CLIENT)),
+                    tag(DB_TYPE, is("postgresql")),
+                    tag(DB_OPERATION, matches("INVALID")),
+                    tag(DB_INSTANCE, is("myapp_db")),
+                    tag(DB_USER, is("app_user")),
+                    tag(PEER_HOSTNAME, is("db.example.com")),
+                    tag(PEER_PORT, is(5432)),
+                    error(RuntimeException.class, "query execution failed"),
+                    tag(DDTags.PEER_SERVICE_SOURCE, any()),
+                    tag(DDTags.DD_SVC_SRC, any()),
+                    defaultTags())));
+  }
+
+  @Test
+  void connectionWithoutMetadataStillCreatesSpansWithoutDbTags() throws Exception {
+    TestConnection connection = new TestConnection();
+    TestStatement statement = (TestStatement) connection.createStatement("SELECT 1");
+    CountDownLatch latch = new CountDownLatch(1);
+
+    runUnderTrace(
+        "parent",
+        () -> {
+          Publisher<? extends Result> publisher = statement.execute();
+          publisher.subscribe(completionSubscriber(latch));
+          return null;
+        });
+    assert latch.await(10, TimeUnit.SECONDS);
+
+    assertTraces(
+        TraceMatcher.trace(
+            span().operationName("parent"),
+            span()
+                .childOfPrevious()
+                .operationName(Pattern.compile("r2dbc\\.query"))
+                .resourceName(csEquals("SELECT ?"))
+                .type("sql")
+                .tags(
+                    tag(COMPONENT, matches("r2dbc-spi")),
+                    tag(SPAN_KIND, is(SPAN_KIND_CLIENT)),
+                    tag(DB_TYPE, is("r2dbc")),
+                    tag(DB_OPERATION, matches("SELECT")),
+                    tag(DDTags.DD_SVC_SRC, any()),
+                    defaultTags())));
+  }
+
+  @Test
+  void multipleStatementExecutionsCreateSeparateSpans() throws Exception {
+    TestConnection connection = new TestConnection();
+    TestStatement statement1 = (TestStatement) connection.createStatement("SELECT * FROM users");
+    TestStatement statement2 =
+        (TestStatement) connection.createStatement("INSERT INTO users (name) VALUES ('test')");
+    CountDownLatch latch = new CountDownLatch(2);
+
+    runUnderTrace(
+        "parent",
+        () -> {
+          statement1.execute().subscribe(completionSubscriber(latch));
+          statement2.execute().subscribe(completionSubscriber(latch));
+          return null;
+        });
+    assert latch.await(10, TimeUnit.SECONDS);
+
+    assertTraces(
+        TraceMatcher.trace(
+            TraceMatcher.SORT_BY_START_TIME,
+            span().operationName("parent"),
+            span()
+                .childOfIndex(0)
+                .operationName(Pattern.compile("r2dbc\\.query"))
+                .resourceName(csEquals("SELECT * FROM users"))
+                .type("sql")
+                .tags(
+                    tag(COMPONENT, matches("r2dbc-spi")),
+                    tag(SPAN_KIND, is(SPAN_KIND_CLIENT)),
+                    tag(DB_TYPE, is("r2dbc")),
+                    tag(DB_OPERATION, matches("SELECT")),
+                    tag(DDTags.DD_SVC_SRC, any()),
+                    defaultTags()),
+            span()
+                .childOfIndex(0)
+                .operationName(Pattern.compile("r2dbc\\.query"))
+                .resourceName(csEquals("INSERT INTO users (name) VALUES (?)"))
+                .type("sql")
+                .tags(
+                    tag(COMPONENT, matches("r2dbc-spi")),
+                    tag(SPAN_KIND, is(SPAN_KIND_CLIENT)),
+                    tag(DB_TYPE, is("r2dbc")),
+                    tag(DB_OPERATION, matches("INSERT")),
+                    tag(DDTags.DD_SVC_SRC, any()),
+                    defaultTags())));
+  }
+
+  /** Creates a subscriber that counts down the latch on completion or error. */
+  private static Subscriber<Result> completionSubscriber(CountDownLatch latch) {
+    return new Subscriber<Result>() {
+      @Override
+      public void onSubscribe(Subscription s) {
+        s.request(Long.MAX_VALUE);
+      }
+
+      @Override
+      public void onNext(Result result) {}
+
+      @Override
+      public void onError(Throwable t) {
+        latch.countDown();
+      }
+
+      @Override
+      public void onComplete() {
+        latch.countDown();
+      }
+    };
+  }
+
+  /** Creates a subscriber that captures errors and counts down the latch. */
+  private static Subscriber<Result> errorCapturingSubscriber(
+      CountDownLatch latch, AtomicReference<Throwable> errorRef) {
+    return new Subscriber<Result>() {
+      @Override
+      public void onSubscribe(Subscription s) {
+        s.request(Long.MAX_VALUE);
+      }
+
+      @Override
+      public void onNext(Result result) {}
+
+      @Override
+      public void onError(Throwable t) {
+        errorRef.set(t);
+        latch.countDown();
+      }
+
+      @Override
+      public void onComplete() {
+        latch.countDown();
+      }
+    };
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/test/java/r2dbc/test/TestBatch.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/test/java/r2dbc/test/TestBatch.java
@@ -1,0 +1,48 @@
+package r2dbc.test;
+
+import io.r2dbc.spi.Batch;
+import io.r2dbc.spi.Result;
+import java.util.ArrayList;
+import java.util.List;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/** Stub implementation of io.r2dbc.spi.Batch for testing. */
+public class TestBatch implements Batch {
+  private final List<String> statements = new ArrayList<>();
+  private boolean shouldFail;
+
+  public void setShouldFail(boolean shouldFail) {
+    this.shouldFail = shouldFail;
+  }
+
+  @Override
+  public Batch add(String sql) {
+    statements.add(sql);
+    return this;
+  }
+
+  @Override
+  public Publisher<? extends Result> execute() {
+    return new Publisher<Result>() {
+      @Override
+      public void subscribe(Subscriber<? super Result> subscriber) {
+        subscriber.onSubscribe(
+            new Subscription() {
+              @Override
+              public void request(long n) {
+                if (shouldFail) {
+                  subscriber.onError(new RuntimeException("batch execution failed"));
+                } else {
+                  subscriber.onComplete();
+                }
+              }
+
+              @Override
+              public void cancel() {}
+            });
+      }
+    };
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/test/java/r2dbc/test/TestConnection.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/test/java/r2dbc/test/TestConnection.java
@@ -1,0 +1,188 @@
+package r2dbc.test;
+
+import io.r2dbc.spi.Batch;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionMetadata;
+import io.r2dbc.spi.IsolationLevel;
+import io.r2dbc.spi.Statement;
+import io.r2dbc.spi.TransactionDefinition;
+import io.r2dbc.spi.ValidationDepth;
+import java.time.Duration;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * Stub implementation of io.r2dbc.spi.Connection for testing. Provides factory methods to create
+ * TestStatement and TestBatch instances.
+ */
+public class TestConnection implements Connection {
+  private String dbName;
+  private String dbUser;
+  private String host;
+  private int port;
+  private String dbType;
+
+  public TestConnection() {}
+
+  public TestConnection(String host, int port, String dbUser, String dbName, String dbType) {
+    this.host = host;
+    this.port = port;
+    this.dbUser = dbUser;
+    this.dbName = dbName;
+    this.dbType = dbType;
+  }
+
+  public String getDbName() {
+    return dbName;
+  }
+
+  public String getDbUser() {
+    return dbUser;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public String getDbType() {
+    return dbType;
+  }
+
+  @Override
+  public Publisher<Void> beginTransaction() {
+    return emptyPublisher();
+  }
+
+  @Override
+  public Publisher<Void> beginTransaction(TransactionDefinition definition) {
+    return emptyPublisher();
+  }
+
+  @Override
+  public Publisher<Void> close() {
+    return emptyPublisher();
+  }
+
+  @Override
+  public Publisher<Void> commitTransaction() {
+    return emptyPublisher();
+  }
+
+  @Override
+  public Batch createBatch() {
+    return new TestBatch();
+  }
+
+  @Override
+  public Publisher<Void> createSavepoint(String name) {
+    return emptyPublisher();
+  }
+
+  @Override
+  public Statement createStatement(String sql) {
+    return new TestStatement(sql);
+  }
+
+  @Override
+  public boolean isAutoCommit() {
+    return true;
+  }
+
+  @Override
+  public ConnectionMetadata getMetadata() {
+    return new ConnectionMetadata() {
+      @Override
+      public String getDatabaseProductName() {
+        return "TestDB";
+      }
+
+      @Override
+      public String getDatabaseVersion() {
+        return "1.0";
+      }
+    };
+  }
+
+  @Override
+  public IsolationLevel getTransactionIsolationLevel() {
+    return IsolationLevel.READ_COMMITTED;
+  }
+
+  @Override
+  public Publisher<Void> releaseSavepoint(String name) {
+    return emptyPublisher();
+  }
+
+  @Override
+  public Publisher<Void> rollbackTransaction() {
+    return emptyPublisher();
+  }
+
+  @Override
+  public Publisher<Void> rollbackTransactionToSavepoint(String name) {
+    return emptyPublisher();
+  }
+
+  @Override
+  public Publisher<Void> setAutoCommit(boolean autoCommit) {
+    return emptyPublisher();
+  }
+
+  @Override
+  public Publisher<Void> setTransactionIsolationLevel(IsolationLevel isolationLevel) {
+    return emptyPublisher();
+  }
+
+  @Override
+  public Publisher<Boolean> validate(ValidationDepth depth) {
+    return new Publisher<Boolean>() {
+      @Override
+      public void subscribe(Subscriber<? super Boolean> subscriber) {
+        subscriber.onSubscribe(
+            new Subscription() {
+              @Override
+              public void request(long n) {
+                subscriber.onNext(true);
+                subscriber.onComplete();
+              }
+
+              @Override
+              public void cancel() {}
+            });
+      }
+    };
+  }
+
+  @Override
+  public Publisher<Void> setLockWaitTimeout(Duration timeout) {
+    return emptyPublisher();
+  }
+
+  @Override
+  public Publisher<Void> setStatementTimeout(Duration timeout) {
+    return emptyPublisher();
+  }
+
+  private static Publisher<Void> emptyPublisher() {
+    return new Publisher<Void>() {
+      @Override
+      public void subscribe(Subscriber<? super Void> subscriber) {
+        subscriber.onSubscribe(
+            new Subscription() {
+              @Override
+              public void request(long n) {
+                subscriber.onComplete();
+              }
+
+              @Override
+              public void cancel() {}
+            });
+      }
+    };
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/test/java/r2dbc/test/TestConnectionFactory.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/test/java/r2dbc/test/TestConnectionFactory.java
@@ -1,0 +1,80 @@
+package r2dbc.test;
+
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactoryMetadata;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/**
+ * Stub implementation of io.r2dbc.spi.ConnectionFactory for testing. Creates TestConnection
+ * instances with configurable connection metadata for DBM testing.
+ */
+public class TestConnectionFactory implements ConnectionFactory {
+  private final ConnectionFactoryOptions options;
+
+  public TestConnectionFactory(ConnectionFactoryOptions options) {
+    this.options = options;
+  }
+
+  public ConnectionFactoryOptions getOptions() {
+    return options;
+  }
+
+  @Override
+  public Publisher<? extends Connection> create() {
+    String host =
+        options.hasOption(ConnectionFactoryOptions.HOST)
+            ? (String) options.getValue(ConnectionFactoryOptions.HOST)
+            : null;
+    Integer port =
+        options.hasOption(ConnectionFactoryOptions.PORT)
+            ? (Integer) options.getValue(ConnectionFactoryOptions.PORT)
+            : 0;
+    String user =
+        options.hasOption(ConnectionFactoryOptions.USER)
+            ? (String) options.getValue(ConnectionFactoryOptions.USER)
+            : null;
+    String database =
+        options.hasOption(ConnectionFactoryOptions.DATABASE)
+            ? (String) options.getValue(ConnectionFactoryOptions.DATABASE)
+            : null;
+    String driver =
+        options.hasOption(ConnectionFactoryOptions.DRIVER)
+            ? (String) options.getValue(ConnectionFactoryOptions.DRIVER)
+            : null;
+
+    TestConnection connection =
+        new TestConnection(host, port != null ? port : 0, user, database, driver);
+    return new Publisher<Connection>() {
+      @Override
+      public void subscribe(Subscriber<? super Connection> subscriber) {
+        subscriber.onSubscribe(
+            new Subscription() {
+              @Override
+              public void request(long n) {
+                subscriber.onNext(connection);
+                subscriber.onComplete();
+              }
+
+              @Override
+              public void cancel() {}
+            });
+      }
+    };
+  }
+
+  @Override
+  public ConnectionFactoryMetadata getMetadata() {
+    return new ConnectionFactoryMetadata() {
+      @Override
+      public String getName() {
+        return options.hasOption(ConnectionFactoryOptions.DRIVER)
+            ? (String) options.getValue(ConnectionFactoryOptions.DRIVER)
+            : "test";
+      }
+    };
+  }
+}

--- a/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/test/java/r2dbc/test/TestStatement.java
+++ b/dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/src/test/java/r2dbc/test/TestStatement.java
@@ -1,0 +1,83 @@
+package r2dbc.test;
+
+import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Statement;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+
+/** Stub implementation of io.r2dbc.spi.Statement for testing. */
+public class TestStatement implements Statement {
+  private final String sql;
+  private boolean shouldFail;
+
+  public TestStatement(String sql) {
+    this.sql = sql;
+  }
+
+  public void setShouldFail(boolean shouldFail) {
+    this.shouldFail = shouldFail;
+  }
+
+  public String getSql() {
+    return sql;
+  }
+
+  @Override
+  public Statement add() {
+    return this;
+  }
+
+  @Override
+  public Statement bind(int index, Object value) {
+    return this;
+  }
+
+  @Override
+  public Statement bind(String name, Object value) {
+    return this;
+  }
+
+  @Override
+  public Statement bindNull(int index, Class<?> type) {
+    return this;
+  }
+
+  @Override
+  public Statement bindNull(String name, Class<?> type) {
+    return this;
+  }
+
+  @Override
+  public Publisher<? extends Result> execute() {
+    return new Publisher<Result>() {
+      @Override
+      public void subscribe(Subscriber<? super Result> subscriber) {
+        subscriber.onSubscribe(
+            new Subscription() {
+              @Override
+              public void request(long n) {
+                if (shouldFail) {
+                  subscriber.onError(new RuntimeException("query execution failed"));
+                } else {
+                  subscriber.onComplete();
+                }
+              }
+
+              @Override
+              public void cancel() {}
+            });
+      }
+    };
+  }
+
+  @Override
+  public Statement returnGeneratedValues(String... columns) {
+    return this;
+  }
+
+  @Override
+  public Statement fetchSize(int rows) {
+    return this;
+  }
+}

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -9289,6 +9289,54 @@
         "aliases": ["DD_TRACE_INTEGRATION_RATPACK_REQUEST_BODY_ENABLED", "DD_INTEGRATION_RATPACK_REQUEST_BODY_ENABLED"]
       }
     ],
+    "DD_TRACE_R2DBC_ANALYTICS_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "false",
+        "aliases": ["DD_R2DBC_ANALYTICS_ENABLED"]
+      }
+    ],
+    "DD_TRACE_R2DBC_ANALYTICS_SAMPLE_RATE": [
+      {
+        "version": "A",
+        "type": "decimal",
+        "default": "1.0",
+        "aliases": ["DD_R2DBC_ANALYTICS_SAMPLE_RATE"]
+      }
+    ],
+    "DD_TRACE_R2DBC_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "true",
+        "aliases": ["DD_TRACE_INTEGRATION_R2DBC_ENABLED", "DD_INTEGRATION_R2DBC_ENABLED"]
+      }
+    ],
+    "DD_TRACE_R2DBC_SPI_ANALYTICS_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "false",
+        "aliases": ["DD_R2DBC_SPI_ANALYTICS_ENABLED"]
+      }
+    ],
+    "DD_TRACE_R2DBC_SPI_ANALYTICS_SAMPLE_RATE": [
+      {
+        "version": "A",
+        "type": "decimal",
+        "default": "1.0",
+        "aliases": ["DD_R2DBC_SPI_ANALYTICS_SAMPLE_RATE"]
+      }
+    ],
+    "DD_TRACE_R2DBC_SPI_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "true",
+        "aliases": ["DD_TRACE_INTEGRATION_R2DBC_SPI_ENABLED", "DD_INTEGRATION_R2DBC_SPI_ENABLED"]
+      }
+    ],
     "DD_TRACE_REACTIVE_STREAMS_1_ENABLED": [
       {
         "version": "A",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -538,6 +538,7 @@ include(
   ":dd-java-agent:instrumentation:quartz-2.0",
   ":dd-java-agent:instrumentation:rabbitmq-amqp-2.7",
   ":dd-java-agent:instrumentation:ratpack-1.5",
+  ":dd-java-agent:instrumentation:r2dbc:r2dbc-1.0",
   ":dd-java-agent:instrumentation:reactive-streams-1.0",
   ":dd-java-agent:instrumentation:reactor-core-3.1",
   ":dd-java-agent:instrumentation:reactor-netty-1.0",


### PR DESCRIPTION
## What

Toolkit-generated R2DBC instrumentation (`io.r2dbc:r2dbc-spi:1.0.0.RELEASE`), **regenerated** by the apm-instrumentation-toolkit against its sharpened database-category rules. This is a **reference/research artifact — NOT a merge candidate.** It supersedes nothing; the original reference PR #12032 stays as-is.

Generated module: `dd-java-agent/instrumentation/r2dbc/r2dbc-1.0/`.

## Why this regen exists

#12032 was generated before the toolkit's database-category rules were sharpened (SPI-first targeting, eager connection-metadata capture, muzzle handling). This run tests whether the improved skill produces a better R2DBC — and it does, in architecture. But a live-trace comparison against the OpenTelemetry SDK surfaced that it still doesn't actually emit spans on a real driver, for a new, mechanical reason.

## Improvement over #12032 (architecture)

The DBM feature step now hooks the **OTel-correct entry point**:
- `ConnectionFactory.create()` + `ConnectionFactoryOptions` (host/port/database/user live here, not on `ConnectionMetadata`), threaded via a new `MetadataWrappingPublisher` → `R2dbcConnectionInfo` → statement/batch spans.
- `R2dbcDecorator` now populates `db.name` / `peer.hostname` / `db.user` / `peer.port` (in #12032 these were hardcoded `null`).

## Known defect — the finding (do NOT fix on this branch)

**The module is CI-green but emits ZERO spans on a real driver.**

- `:check`, `:muzzle`, `:allLatestDepTests` all pass; 11/11 unit tests pass.
- But every advice declares a **writable** `@Advice.Return(readOnly = false) Publisher<...>`, while real driver methods return the **concrete** `Mono`/`Flux`. Byte Buddy refuses to bind the interface into the concrete return slot, so class transformation fails at runtime and the classes load **uninstrumented**:

```
Cannot assign interface org.reactivestreams.Publisher to class reactor.core.publisher.Mono
    → io.r2dbc.pool.ConnectionPool        (ConnectionFactoryCreateAdvice)
Cannot assign interface org.reactivestreams.Publisher to class reactor.core.publisher.Mono
    → io.r2dbc.h2.H2ConnectionFactory     (ConnectionFactoryCreateAdvice)
Cannot assign interface org.reactivestreams.Publisher to class reactor.core.publisher.Flux
    → io.r2dbc.h2.H2Statement             (StatementExecuteAdvice)
```

So the (correct) new connection-metadata architecture never runs. The SPI-fake test suite binds where real drivers won't, which is why CI is green.

**Live verification** — Spring Data R2DBC / H2 app (eugenp `spring-reactive-data`), `GET /products` ×3:

| | this PR (regen) | #12032 | OpenTelemetry Java 2.30.0 |
|---|---|---|---|
| R2DBC spans | **0** | 0 | 13 |
| Byte Buddy transformation failures on real driver | 3 | 1 | — |
| Connection-metadata architecture | ✅ `ConnectionFactoryOptions` (but dead) | ❌ | ✅ works |
| CI-equivalent | ✅ BUILD SUCCESSFUL | (was red on muzzle scaffolding) | — |

## Remediation (for a future working version, not this branch)

Type the writable `@Advice.Return` so Byte Buddy can bind it against a concrete-`Mono`/`Flux`-returning method — e.g. `@Advice.Return(readOnly = false) Object` + cast, or `Advice.AssignReturned` — on all three advices (`ConnectionFactoryCreateAdvice`, `StatementExecuteAdvice`, `BatchExecuteAdvice`). AND add at least one integration test against a real driver (`r2dbc-h2`), not only an SPI fake.

## Provenance

- Toolkit branch `eval/java` @ `d9dcb160` (force-read DB rules R-DB-1..6).
- Full write-up + generated-source snapshot + logs: apm-instrumentation-toolkit `docs/eval-research/runs/r2dbc/attempt-dbskill-20260818/outcome.md` and `docs/eval-research/r2dbc-live-trace-comparison-2026-08-17.md`.

---
🤖 Generated by apm-instrumentation-toolkit. Reference/research artifact — not a merge candidate.
