### PR TITLE
Exclude unused Jetty artifacts from Kafka Muzzle

### DIFF
--- a/dd-java-agent/instrumentation/kafka/kafka-connect-0.11/build.gradle
+++ b/dd-java-agent/instrumentation/kafka/kafka-connect-0.11/build.gradle
@@ -6,54 +6,9 @@ muzzle {
     module = "connect-runtime"
     versions = "[0.11.0.0,)"
     javaVersion = "17"
-    // broken POMs: depend on non-existent org.eclipse.jetty:*:9.4.NN (7.x lines only; 8.x uses jetty 12)
-    // can be fixed after https://github.com/confluentinc/kafka-connect-storage-common/issues/468 is resolved
-    skipVersions += [
-      '7.4.14-ce',
-      '7.4.14-ccs',
-      '7.4.15-ce',
-      '7.4.15-ccs',
-      '7.5.13-ce',
-      '7.5.13-ccs',
-      '7.5.14-ce',
-      '7.5.14-ccs',
-      '7.5.15-ce',
-      '7.5.15-ccs',
-      '7.5.16-ce',
-      '7.5.16-ccs',
-      '7.6.10-ce',
-      '7.6.10-ccs',
-      '7.6.11-ce',
-      '7.6.11-ccs',
-      '7.6.12-ce',
-      '7.6.12-ccs',
-      '7.6.13-ce',
-      '7.6.13-ccs',
-      '7.7.8-ce',
-      '7.7.8-ccs',
-      '7.7.9-ce',
-      '7.7.9-ccs',
-      '7.7.10-ce',
-      '7.7.10-ccs',
-      '7.7.11-ce',
-      '7.7.11-ccs',
-      '7.8.7-ce',
-      '7.8.7-ccs',
-      '7.8.8-ce',
-      '7.8.8-ccs',
-      '7.8.9-ce',
-      '7.8.9-ccs',
-      '7.8.10-ce',
-      '7.8.10-ccs',
-      '7.9.6-ce',
-      '7.9.6-ccs',
-      '7.9.7-ce',
-      '7.9.7-ccs',
-      '7.9.8-ce',
-      '7.9.8-ccs',
-      '7.9.9-ce',
-      '7.9.9-ccs'
-    ]
+    // Some Confluent 7.x POMs reference unpublished Jetty artifacts that Muzzle does not need.
+    // See: https://github.com/confluentinc/kafka-connect-storage-common/issues/468
+    excludeDependency "org.eclipse.jetty:*"
     excludeDependency "io.confluent.cloud:*"
     excludeDependency "io.confluent.observability:*"
     excludeDependency "io.confluent.secure.compute:*"


### PR DESCRIPTION
# What Does This Do

Replaces the Kafka Connect Muzzle `skipVersions` list for affected Confluent 7.x releases with the existing Jetty dependency exclusion.

This allows Muzzle to sample and test those Kafka coordinates instead of skipping them.

# Motivation

Some Confluent 7.x POMs reference unpublished Jetty artifacts. The Kafka Connect instrumentation does not require Jetty, so Muzzle can exclude that dependency using its existing `excludeDependency` support.

This is a narrower follow-up to #12160 and avoids adding special POM-rewriting behavior to Muzzle.

# Additional Notes

Validation:

```bash
MAVEN_REPOSITORY_PROXY=https://packages.confluent.io/maven/ ./gradlew -PmavenRepositoryProxy=https://packages.confluent.io/maven/ :dd-java-agent:instrumentation:kafka:kafka-connect-0.11:muzzle
```

All 28 Muzzle checks passed.

Confluent tracking issue: https://github.com/confluentinc/kafka-connect-storage-common/issues/468

# Contributor Checklist

- [x] Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request) when referencing an issue
- [x] Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion — not applicable
- [x] Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors — not applicable
- [ ] Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: N/A