### PR TITLE
Clean up obsolete Muzzle skips

### DIFF
--- a/dd-java-agent/instrumentation/selenium-3.13/build.gradle
+++ b/dd-java-agent/instrumentation/selenium-3.13/build.gradle
@@ -10,8 +10,7 @@ muzzle {
     group = 'org.seleniumhq.selenium'
     module = 'selenium-java'
     versions = '[3.13.0,)'
-    skipVersions += ["4.10.0", "4.11.0"] // depends on non-existent io.netty:netty-transport-native-epoll:4.1.92.Final
-    skipVersions += "4.16.0" // depends on non-existent org.seleniumhq.selenium:selenium-devtools-v119:4.16.0
+    skipVersions += "4.16.0" // org.seleniumhq.selenium:selenium-devtools-v119:4.16.0 is missing its POM in Maven Central
   }
 }
 

--- a/dd-java-agent/instrumentation/testng/testng-7.0/build.gradle
+++ b/dd-java-agent/instrumentation/testng/testng-7.0/build.gradle
@@ -10,7 +10,6 @@ muzzle {
     group = 'org.testng'
     module = 'testng'
     versions = '[7.0.0,7.6)'
-    skipVersions += "7.1.0" //  depends on non-existent guice-4.1.0-no_aop
   }
   // TestNG 7.6+ is compiled with Java 11
   pass {
@@ -50,4 +49,3 @@ configurations.matching({ it.name.startsWith('test') }).configureEach({
     force group: 'org.testng', name: 'testng', version: '7.0.0'
   }
 })
-

--- a/dd-java-agent/instrumentation/undertow/undertow-common/build.gradle
+++ b/dd-java-agent/instrumentation/undertow/undertow-common/build.gradle
@@ -3,7 +3,6 @@ muzzle {
     group = "io.undertow"
     module = "undertow-core"
     versions = "[2.0.0.Final,2.3)"
-    skipVersions = ["2.2.25.Final"] // half propagated
     assertInverse = false
   }
 }


### PR DESCRIPTION
# What Does This Do

Remove obsolete Muzzle skips for TestNG, Selenium, and Undertow. Keep the Selenium 4.16.0 skip with a precise missing-POM comment.

# Motivation

The dependencies behind the removed skips now resolve successfully.

# Additional Notes

Validated with focused Muzzle checks and instrumentation tests.

# Contributor Checklist

- [x] Required labels added.
- [x] No documentation or CODEOWNERS changes needed.

Jira ticket: [N/A]