### PR TITLE
Skip AppSec for non-HTTP Lambda triggers and report _dd.appsec.unsupported_event_type

### DIFF
--- a/dd-java-agent/instrumentation/aws-java/aws-java-lambda-handler-1.2/src/test/java/LambdaHandlerInstrumentationTest.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-lambda-handler-1.2/src/test/java/LambdaHandlerInstrumentationTest.java
@@ -289,6 +289,34 @@ abstract class LambdaHandlerInstrumentationTest extends AbstractInstrumentationT
   }
 
   @Test
+  void appSecIsSkippedAndReportedUnsupportedForNonHttpEvent() throws IOException {
+    String eventJson = "{\"Records\": [{\"eventSource\": \"aws:sqs\", \"body\": \"hello\"}]}";
+
+    ByteArrayInputStream input =
+        new ByteArrayInputStream(eventJson.getBytes(StandardCharsets.UTF_8));
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    new HandlerStreaming().handleRequest(input, output, newContext());
+
+    assertFalse(appSecStarted);
+    assertNull(capturedMethod);
+    assertNull(capturedPath);
+    assertTrue(capturedHeaders.isEmpty());
+    assertNull(capturedBody);
+    assertFalse(appSecEnded);
+    assertNull(capturedResponseStatus);
+    // Tag matching is exhaustive, so this also asserts the span carries no http.* tag
+    assertTraces(
+        trace(
+            span()
+                .type(DDSpanTypes.SERVERLESS)
+                .error(false)
+                .tags(
+                    defaultTags(),
+                    tag("request_id", is(REQUEST_ID)),
+                    tag("_dd.appsec.unsupported_event_type", is(1)))));
+  }
+
+  @Test
   void responseCallbacksAreInvokedForJsonEncodedResponse() throws IOException {
     String eventJson =
         "{"
@@ -382,7 +410,8 @@ abstract class LambdaHandlerInstrumentationTest extends AbstractInstrumentationT
     assertTrue(capturedResponseHeaders.isEmpty());
     assertNull(capturedResponseBody);
     assertFalse(responseHeaderDoneCalled);
-    assertTrue(appSecEnded);
+    // AppSec skipped the invocation entirely, so there is no request context to end
+    assertFalse(appSecEnded);
     assertTraces(trace(span().type(DDSpanTypes.SERVERLESS).error(false)));
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
@@ -57,7 +57,9 @@ public class LambdaAppSecHandler {
   private static final Logger log = LoggerFactory.getLogger(LambdaAppSecHandler.class);
   private static final RatelimitedLogger rlLog = new RatelimitedLogger(log, 5, TimeUnit.MINUTES);
 
-  /** Marks an invocation AppSec did not process because the trigger is not HTTP. */
+  /** Marks an invocation AppSec did not process because the trigger is not HTTP, or if 
+   * the even is unreadable (not a {@code ByteArrayInputStream}, empty, oversized, or
+   * unparseable). */
   private static final String UNSUPPORTED_EVENT_TYPE_METRIC = "_dd.appsec.unsupported_event_type";
 
   // Carries the detected trigger type from processRequestStart to processResponseData within the

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
@@ -132,13 +132,13 @@ public class LambdaAppSecHandler {
     LambdaTriggerType triggerType = CURRENT_TRIGGER_TYPE.get();
     CURRENT_TRIGGER_TYPE.remove();
 
-if (triggerType==null || !ActiveSubsystems.APPSEC_ACTIVE || span == null)  {
+    if (!ActiveSubsystems.APPSEC_ACTIVE || span == null || triggerType == null) {
       return;
     }
 
     // A null trigger type means processRequestStart never ran, so the invocation was not analysed
     // at all, which is not the same as an unsupported trigger.
-    if (triggerType != null && !triggerType.isHttp()) {
+    if (!triggerType.isHttp()) {
       span.setMetric(UNSUPPORTED_EVENT_TYPE_METRIC, 1);
       return;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
@@ -57,9 +57,10 @@ public class LambdaAppSecHandler {
   private static final Logger log = LoggerFactory.getLogger(LambdaAppSecHandler.class);
   private static final RatelimitedLogger rlLog = new RatelimitedLogger(log, 5, TimeUnit.MINUTES);
 
-  /** Marks an invocation AppSec did not process because the trigger is not HTTP, or if 
-   * the even is unreadable (not a {@code ByteArrayInputStream}, empty, oversized, or
-   * unparseable). */
+  /**
+   * Marks an invocation AppSec did not process because the trigger is not HTTP, or if the even is
+   * unreadable (not a {@code ByteArrayInputStream}, empty, oversized, or unparseable).
+   */
   private static final String UNSUPPORTED_EVENT_TYPE_METRIC = "_dd.appsec.unsupported_event_type";
 
   // Carries the detected trigger type from processRequestStart to processResponseData within the

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
@@ -57,10 +57,7 @@ public class LambdaAppSecHandler {
   private static final Logger log = LoggerFactory.getLogger(LambdaAppSecHandler.class);
   private static final RatelimitedLogger rlLog = new RatelimitedLogger(log, 5, TimeUnit.MINUTES);
 
-  /**
-   * Marks an invocation AppSec did not process because the trigger is not HTTP. Mirrors {@code
-   * _dd.appsec.unsupported_event_type} in the Python and Node.js Lambda tracers.
-   */
+  /** Marks an invocation AppSec did not process because the trigger is not HTTP. */
   private static final String UNSUPPORTED_EVENT_TYPE_METRIC = "_dd.appsec.unsupported_event_type";
 
   // Carries the detected trigger type from processRequestStart to processResponseData within the
@@ -71,9 +68,6 @@ public class LambdaAppSecHandler {
    * Processes AppSec request data at the start of a Lambda invocation: invokes all relevant AppSec
    * gateway callbacks on the parsed event, and, for recognised HTTP triggers, applies the HTTP tags
    * to the returned context so they land on the invocation span at creation.
-   *
-   * <p>Invocations whose trigger is not an HTTP one are skipped entirely, as in the Python and
-   * Node.js Lambda tracers; {@link #processRequestEnd(AgentSpan)} marks them on the span instead.
    *
    * @param event the Lambda event object
    * @return a {@link TagContext} carrying the AppSec request context and the HTTP tags, or null if
@@ -103,6 +97,7 @@ public class LambdaAppSecHandler {
       CURRENT_TRIGGER_TYPE.set(eventData.triggerType);
       if (!eventData.triggerType.isHttp()) {
         log.debug("Trigger type {} is not HTTP, skipping AppSec processing", eventData.triggerType);
+        // unsupported event metric is added on request end since span doesn't exist yet
         return null;
       }
       // v2 payloads carry the request line verbatim; the others expose the path and a decoded
@@ -126,9 +121,7 @@ public class LambdaAppSecHandler {
 
   /**
    * Invokes the requestEnded gateway callback to add AppSec data to the span, propagates the
-   * sampling decision of trace-tagging rules, and clears the per-invocation state. Invocations
-   * skipped by {@link #processRequestStart(Object)} because their trigger is not HTTP are marked
-   * with {@value #UNSUPPORTED_EVENT_TYPE_METRIC} instead.
+   * sampling decision of trace-tagging rules, and clears the per-invocation state.
    *
    * @param span the current span
    */
@@ -140,10 +133,9 @@ public class LambdaAppSecHandler {
       return;
     }
 
-    // A null trigger type means processRequestStart never ran for this invocation, which is not an
-    // HTTP request either. Both cases are reported the same way, and nothing below applies since
-    // no AppSec request context was created.
-    if (triggerType == null || !triggerType.isHttp()) {
+    // A null trigger type means processRequestStart never ran, so the invocation was not analysed
+    // at all, which is not the same as an unsupported trigger.
+    if (triggerType != null && !triggerType.isHttp()) {
       span.setMetric(UNSUPPORTED_EVENT_TYPE_METRIC, 1);
       return;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
@@ -57,6 +57,12 @@ public class LambdaAppSecHandler {
   private static final Logger log = LoggerFactory.getLogger(LambdaAppSecHandler.class);
   private static final RatelimitedLogger rlLog = new RatelimitedLogger(log, 5, TimeUnit.MINUTES);
 
+  /**
+   * Marks an invocation AppSec did not process because the trigger is not HTTP. Mirrors {@code
+   * _dd.appsec.unsupported_event_type} in the Python and Node.js Lambda tracers.
+   */
+  private static final String UNSUPPORTED_EVENT_TYPE_METRIC = "_dd.appsec.unsupported_event_type";
+
   // Carries the detected trigger type from processRequestStart to processResponseData within the
   // same Lambda invocation. Cleared in processRequestEnd.
   private static final ThreadLocal<LambdaTriggerType> CURRENT_TRIGGER_TYPE = new ThreadLocal<>();
@@ -66,9 +72,13 @@ public class LambdaAppSecHandler {
    * gateway callbacks on the parsed event, and, for recognised HTTP triggers, applies the HTTP tags
    * to the returned context so they land on the invocation span at creation.
    *
+   * <p>Invocations whose trigger is not an HTTP one are skipped entirely, as in the Python and
+   * Node.js Lambda tracers; {@link #processRequestEnd(AgentSpan)} marks them on the span instead.
+   *
    * @param event the Lambda event object
    * @return a {@link TagContext} carrying the AppSec request context and the HTTP tags, or null if
-   *     AppSec is disabled, the event is not a parseable payload, or processing fails
+   *     AppSec is disabled, the trigger is not HTTP, the event is not a parseable payload, or
+   *     processing fails
    */
   public static AgentSpanContext processRequestStart(Object event) {
     if (!ActiveSubsystems.APPSEC_ACTIVE) {
@@ -91,6 +101,10 @@ public class LambdaAppSecHandler {
         return null;
       }
       CURRENT_TRIGGER_TYPE.set(eventData.triggerType);
+      if (!eventData.triggerType.isHttp()) {
+        log.debug("Trigger type {} is not HTTP, skipping AppSec processing", eventData.triggerType);
+        return null;
+      }
       // v2 payloads carry the request line verbatim; the others expose the path and a decoded
       // parameter map only, so the query string has to be rebuilt from them
       String fullPath = eventData.rawUri;
@@ -100,7 +114,7 @@ public class LambdaAppSecHandler {
       LambdaURIDataAdapter uriAdapter =
           new LambdaURIDataAdapter(fullPath, eventData.headers, eventData.host);
       AgentSpanContext context = processAppSecRequestData(eventData, uriAdapter);
-      if (context instanceof TagContext && eventData.triggerType.isHttp()) {
+      if (context instanceof TagContext) {
         applyHttpTags((TagContext) context, eventData, uriAdapter);
       }
       return context;
@@ -112,14 +126,25 @@ public class LambdaAppSecHandler {
 
   /**
    * Invokes the requestEnded gateway callback to add AppSec data to the span, propagates the
-   * sampling decision of trace-tagging rules, and clears the per-invocation state.
+   * sampling decision of trace-tagging rules, and clears the per-invocation state. Invocations
+   * skipped by {@link #processRequestStart(Object)} because their trigger is not HTTP are marked
+   * with {@value #UNSUPPORTED_EVENT_TYPE_METRIC} instead.
    *
    * @param span the current span
    */
   public static void processRequestEnd(AgentSpan span) {
+    LambdaTriggerType triggerType = CURRENT_TRIGGER_TYPE.get();
     CURRENT_TRIGGER_TYPE.remove();
 
     if (!ActiveSubsystems.APPSEC_ACTIVE || span == null) {
+      return;
+    }
+
+    // A null trigger type means processRequestStart never ran for this invocation, which is not an
+    // HTTP request either. Both cases are reported the same way, and nothing below applies since
+    // no AppSec request context was created.
+    if (triggerType == null || !triggerType.isHttp()) {
+      span.setMetric(UNSUPPORTED_EVENT_TYPE_METRIC, 1);
       return;
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
@@ -132,7 +132,7 @@ public class LambdaAppSecHandler {
     LambdaTriggerType triggerType = CURRENT_TRIGGER_TYPE.get();
     CURRENT_TRIGGER_TYPE.remove();
 
-    if (!ActiveSubsystems.APPSEC_ACTIVE || span == null) {
+if (triggerType==null || !ActiveSubsystems.APPSEC_ACTIVE || span == null)  {
       return;
     }
 

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
@@ -94,8 +94,9 @@ final class LambdaEventParser {
         case ALB_MULTI_VALUE:
           return extractAlbData(event, triggerType);
         default:
-          log.debug("Unknown trigger type, attempting generic extraction");
-          return extractGenericData(event);
+          // Unsupported trigger: AppSec skips the invocation entirely, so there is nothing to
+          // extract. The trigger type is carried by the caller, not by this result.
+          return LambdaRequestData.EMPTY;
       }
     } catch (Exception e) {
       log.debug("Failed to parse event data from JSON", e);
@@ -444,69 +445,6 @@ final class LambdaEventParser {
         null);
   }
 
-  /** Generic data extraction for unknown trigger types (fallback) */
-  private static LambdaRequestData extractGenericData(Map<String, Object> event) {
-    Map<String, String> headers = extractHeadersWithCookies(event);
-    Map<String, String> pathParameters = extractPathParameters(event.get("pathParameters"));
-    Map<String, List<String>> queryParameters =
-        extractQueryParameters(event.get("queryStringParameters"));
-    Object body = extractBody(event);
-
-    String method = null;
-    String path = null;
-    String sourceIp = null;
-
-    // Try to extract from requestContext if available
-    Object requestContextObj = event.get("requestContext");
-    if (requestContextObj instanceof Map) {
-      Map<?, ?> requestContext = (Map<?, ?>) requestContextObj;
-
-      Object httpObj = requestContext.get("http");
-      if (httpObj instanceof Map) {
-        Map<?, ?> http = (Map<?, ?>) httpObj;
-        method = (String) http.get("method");
-        path = (String) http.get("path");
-        sourceIp = (String) http.get("sourceIp");
-      } else {
-        Object methodObj = requestContext.get("httpMethod");
-        if (methodObj != null) {
-          method = String.valueOf(methodObj);
-        }
-
-        Object identityObj = requestContext.get("identity");
-        if (identityObj instanceof Map) {
-          Map<?, ?> identity = (Map<?, ?>) identityObj;
-          sourceIp = (String) identity.get("sourceIp");
-        }
-      }
-    }
-
-    // Try root level fields
-    if (method == null) {
-      Object methodObj = event.get("httpMethod");
-      if (methodObj != null) {
-        method = String.valueOf(methodObj);
-      }
-    }
-    if (path == null) {
-      Object pathObj = event.get("path");
-      if (pathObj != null) {
-        path = String.valueOf(pathObj);
-      }
-    }
-
-    return new LambdaRequestData(
-        headers,
-        method,
-        path,
-        sourceIp,
-        null,
-        LambdaTriggerType.UNKNOWN,
-        pathParameters,
-        queryParameters,
-        body);
-  }
-
   /**
    * Looks a header up in a map produced by {@link #extractHeaders}, whose keys are already
    * lowercased, so {@code lowerCaseName} must be lowercase for a match.
@@ -790,8 +728,22 @@ final class LambdaEventParser {
     LAMBDA_URL, // Lambda Function URL
     UNKNOWN; // Unknown or unsupported trigger
 
+    /**
+     * Whitelist rather than {@code != UNKNOWN} so a trigger type added later defaults to non-HTTP,
+     * and therefore to being skipped by AppSec, until it is deliberately listed here.
+     */
     boolean isHttp() {
-      return this != UNKNOWN;
+      switch (this) {
+        case API_GATEWAY_V1_REST:
+        case API_GATEWAY_V2_HTTP:
+        case API_GATEWAY_V2_WEBSOCKET:
+        case ALB:
+        case ALB_MULTI_VALUE:
+        case LAMBDA_URL:
+          return true;
+        default:
+          return false;
+      }
     }
   }
 

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import datadog.trace.api.Config;
@@ -136,6 +137,27 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   void processRequestStartReturnsNullForMalformedJson() {
     ByteArrayInputStream event = createInputStream("{invalid json");
     assertNull(LambdaAppSecHandler.processRequestStart(event));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void processRequestStartSkipsAppSecForNonHttpTrigger() {
+    String sqsEvent =
+        "{\"Records\": [{\"eventSource\": \"aws:sqs\", \"body\": \"hello\","
+            + " \"messageAttributes\": {}}]}";
+    ByteArrayInputStream event = createInputStream(sqsEvent);
+
+    Supplier<Flow<Object>> requestStartedCallback = mock(Supplier.class);
+    CallbackProvider mockCallbackProvider = mock(CallbackProvider.class);
+    when(mockCallbackProvider.getCallback(EVENTS.requestStarted()))
+        .thenReturn(requestStartedCallback);
+    AgentTracer.TracerAPI mockTracer = mock(AgentTracer.TracerAPI.class);
+    when(mockTracer.getCallbackProvider(RequestContextSlot.APPSEC))
+        .thenReturn(mockCallbackProvider);
+    AgentTracer.forceRegister(mockTracer);
+
+    assertNull(LambdaAppSecHandler.processRequestStart(event));
+    verifyNoInteractions(requestStartedCallback);
   }
 
   @Test
@@ -903,47 +925,11 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   }
 
   // ============================================================================
-  // Generic Data Extraction Tests
+  // Partial Payload Extraction Tests
   // ============================================================================
 
   @Test
-  void extractsDataFromUnknownTriggerTypeUsingGenericExtraction() {
-    String eventJson =
-        "{"
-            + "\"path\": \"/generic/path\","
-            + "\"httpMethod\": \"PATCH\","
-            + "\"headers\": {\"x-custom-header\": \"generic-value\"},"
-            + "\"unknownField\": \"should be ignored\","
-            + "\"requestContext\": {\"identity\": {\"sourceIp\": \"203.0.113.1\"}}"
-            + "}";
-    ByteArrayInputStream event = createInputStream(eventJson);
-
-    String[] capturedMethod = {null};
-    String[] capturedPath = {null};
-    Map<String, String> capturedHeaders = new HashMap<>();
-    String[] capturedSourceIp = {null};
-
-    setupMockCallbacks(
-        new Callbacks()
-            .onMethodUri(
-                (method, uri) -> {
-                  capturedMethod[0] = method;
-                  capturedPath[0] = uri.path();
-                })
-            .onHeader(capturedHeaders::put)
-            .onSocketAddress((ip, port) -> capturedSourceIp[0] = ip));
-
-    AgentSpanContext result = LambdaAppSecHandler.processRequestStart(event);
-
-    assertNotNull(result);
-    assertEquals("PATCH", capturedMethod[0]);
-    assertEquals("/generic/path", capturedPath[0]);
-    assertEquals("generic-value", capturedHeaders.get("x-custom-header"));
-    assertEquals("203.0.113.1", capturedSourceIp[0]);
-  }
-
-  @Test
-  void extractsDataFromUnknownTriggerWithHttpInRequestContext() {
+  void extractsDataFromLambdaUrlWithHttpInRequestContext() {
     String eventJson =
         "{"
             + "\"requestContext\": {"
@@ -974,7 +960,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   }
 
   @Test
-  void genericExtractionUsesHttpMethodFromRequestContext() {
+  void extractsHttpMethodFromRequestContextOfApiGatewayV1Payload() {
     String eventJson =
         "{\"path\": \"/ctx-method\", \"requestContext\": {\"httpMethod\": \"DELETE\"}}";
     ByteArrayInputStream event = createInputStream(eventJson);
@@ -1059,6 +1045,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processRequestEndDoesNothingWhenSpanHasNoRequestContext() {
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     AgentSpan span = mock(AgentSpan.class);
     when(span.getRequestContext()).thenReturn(null);
     LambdaAppSecHandler.processRequestEnd(span);
@@ -1068,6 +1055,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   @Test
   @SuppressWarnings("unchecked")
   void processRequestEndInvokesCallbackAndSkipsAsmTagsWhenNotManuallyKept() {
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     AppSecContext mockAppSecContext = mock(AppSecContext.class);
     when(mockAppSecContext.isManuallyKept()).thenReturn(false);
     TraceSegment mockTraceSegment = mock(TraceSegment.class);
@@ -1097,6 +1085,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   void processRequestEndHandlesNullRequestEndedCallbackGracefully() {
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     RequestContext mockRequestContext = mock(RequestContext.class);
     AgentSpan span = mock(AgentSpan.class);
     when(span.getRequestContext()).thenReturn(mockRequestContext);
@@ -1115,6 +1104,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   @Test
   @SuppressWarnings("unchecked")
   void processRequestEndSetsAsmKeepTagWhenAppSecContextIsManuallyKept() {
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     AppSecContext manuallyKeptCtx = mock(AppSecContext.class);
     when(manuallyKeptCtx.isManuallyKept()).thenReturn(true);
 
@@ -1143,6 +1133,75 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
     verify(requestEndedCallback).apply(mockRequestContext, span);
     verify(mockTraceSegment).setTagTop(Tags.ASM_KEEP, true);
     verify(mockTraceSegment).setTagTop(Tags.PROPAGATED_TRACE_SOURCE, ProductTraceSource.ASM);
+  }
+
+  @Test
+  void processRequestEndSetsUnsupportedEventTypeMetricForNonHttpTrigger() {
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.UNKNOWN);
+    AgentSpan span = mock(AgentSpan.class);
+
+    LambdaAppSecHandler.processRequestEnd(span);
+
+    verify(span).setMetric("_dd.appsec.unsupported_event_type", 1);
+    verifyNoMoreInteractions(span);
+  }
+
+  @Test
+  void processRequestEndSetsUnsupportedEventTypeMetricWhenNoTriggerTypeWasRecorded() {
+    AgentSpan span = mock(AgentSpan.class);
+
+    LambdaAppSecHandler.processRequestEnd(span);
+
+    verify(span).setMetric("_dd.appsec.unsupported_event_type", 1);
+    verifyNoMoreInteractions(span);
+  }
+
+  @Test
+  void processRequestEndSetsNoUnsupportedEventTypeMetricWhenAppSecIsDisabled() {
+    ActiveSubsystems.APPSEC_ACTIVE = false;
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.UNKNOWN);
+    AgentSpan span = mock(AgentSpan.class);
+
+    LambdaAppSecHandler.processRequestEnd(span);
+
+    verifyNoInteractions(span);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void processRequestEndSetsNoUnsupportedEventTypeMetricForHttpTrigger() {
+    LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
+    RequestContext mockRequestContext = mock(RequestContext.class);
+    when(mockRequestContext.getTraceSegment()).thenReturn(mock(TraceSegment.class));
+    AgentSpan span = mock(AgentSpan.class);
+    when(span.getRequestContext()).thenReturn(mockRequestContext);
+
+    BiFunction<RequestContext, IGSpanInfo, Flow<Void>> requestEndedCallback =
+        mock(BiFunction.class);
+    when(requestEndedCallback.apply(any(), any())).thenReturn(new Flow.ResultFlow<>(null));
+    CallbackProvider mockCallbackProvider = mock(CallbackProvider.class);
+    when(mockCallbackProvider.getCallback(EVENTS.requestEnded())).thenReturn(requestEndedCallback);
+    AgentTracer.TracerAPI mockTracer = mock(AgentTracer.TracerAPI.class);
+    when(mockTracer.getCallbackProvider(RequestContextSlot.APPSEC))
+        .thenReturn(mockCallbackProvider);
+    AgentTracer.forceRegister(mockTracer);
+
+    LambdaAppSecHandler.processRequestEnd(span);
+
+    verify(requestEndedCallback).apply(mockRequestContext, span);
+    verify(span, never()).setMetric(anyString(), anyInt());
+  }
+
+  @Test
+  void processRequestEndSetsUnsupportedEventTypeMetricAfterAnUnparseablePayload() {
+    ByteArrayInputStream event = createInputStream("{invalid json");
+    assertNull(LambdaAppSecHandler.processRequestStart(event));
+
+    AgentSpan span = mock(AgentSpan.class);
+    LambdaAppSecHandler.processRequestEnd(span);
+
+    verify(span).setMetric("_dd.appsec.unsupported_event_type", 1);
+    verifyNoMoreInteractions(span);
   }
 
   // ============================================================================
@@ -2234,16 +2293,6 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
     assertEquals("GET", tags.get(Tags.HTTP_METHOD));
     assertEquals("https://lb-123.eu-west-1.elb.amazonaws.com/alb", tags.get(Tags.HTTP_URL));
     assertEquals("alb-agent", tags.get(Tags.HTTP_USER_AGENT));
-  }
-
-  @Test
-  void appliesNoHttpTagsForNonHttpEvent() {
-    setupMockCallbacks(new Callbacks());
-    AgentSpanContext context =
-        LambdaAppSecHandler.processRequestStart(
-            createInputStream("{\"Records\": [{\"eventSource\": \"aws:sqs\", \"body\": \"hi\"}]}"));
-
-    assertTrue(tagsOf(context).isEmpty());
   }
 
   @Test

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
@@ -1147,13 +1147,13 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   }
 
   @Test
-  void processRequestEndSetsUnsupportedEventTypeMetricWhenNoTriggerTypeWasRecorded() {
+  void processRequestEndSetsNoUnsupportedEventTypeMetricWhenNoTriggerTypeWasRecorded() {
+    // AppSec was inactive at request start and enabled mid-invocation
     AgentSpan span = mock(AgentSpan.class);
 
     LambdaAppSecHandler.processRequestEnd(span);
 
-    verify(span).setMetric("_dd.appsec.unsupported_event_type", 1);
-    verifyNoMoreInteractions(span);
+    verify(span, never()).setMetric(anyString(), anyInt());
   }
 
   @Test

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaEventParserTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaEventParserTest.java
@@ -270,13 +270,11 @@ class LambdaEventParserTest {
   // ============================================================================
 
   @Test
-  void nonHttpEventHasNoHostOrRoute() {
-    LambdaRequestData data =
-        parseEvent("{\"Records\": [{\"eventSource\": \"aws:sqs\", \"body\": \"hello\"}]}");
-
-    assertEquals(LambdaTriggerType.UNKNOWN, data.triggerType);
-    assertNull(data.host);
-    assertNull(data.route);
+  void nonHttpEventIsNotExtracted() {
+    // AppSec skips non-HTTP triggers entirely, so nothing is extracted from their payload
+    assertSame(
+        LambdaRequestData.EMPTY,
+        parseEvent("{\"Records\": [{\"eventSource\": \"aws:sqs\", \"body\": \"hello\"}]}"));
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do

Emits `_dd.appsec.unsupported_event_type` for Lambda requests that are not HTTP/HTTP-like requests.

- `LambdaAppSecHandler.processRequestStart` now returns early (with a debug log) for any trigger the parser does not recognise as HTTP, so no WAF request callback fires and no AppSec request context is created.
- `LambdaAppSecHandler.processRequestEnd` sets the numeric span metric `_dd.appsec.unsupported_event_type = 1` on those invocations, so the span explicitly reports that AppSec did not process it. The metric is only emitted when AppSec is active.
- `LambdaEventParser.isHttp()` becomes an explicit whitelist of the five HTTP trigger types, so any trigger type added later defaults to non-HTTP until it is deliberately listed.
- `LambdaEventParser.extractGenericData` (~60 lines) is removed: with the skip in place, its result was never consumed. `parseEvent`'s default branch now returns `LambdaRequestData.EMPTY`.

# Motivation

Before this change, an unrecognised Lambda event was still fed to the WAF on whatever `method` / `path` / `headers` could be scraped from an arbitrary payload — best-effort scanning of data that is not an HTTP request. `dd-trace-py` (`_processor.py`, via `datadog_lambda/asm.py`) and `datadog-lambda-js` (`src/appsec/index.ts`) both skip AppSec entirely in that case and mark the span with `_dd.appsec.unsupported_event_type`. The metric is tracer-side only; the Lambda extension does not emit it.

system-tests `Test_AppSecEventSpanTags::test_custom_span_tags` (scenario `appsec_lambda_default`) treats the metric as the sanctioned opt-out: a `serverless` span carrying it is exempted from the `_dd.appsec.enabled` / `_dd.runtime_family` assertions.

# Additional Notes

- The metric is written at request end rather than request start because `processRequestStart` runs before the invocation span exists, and a value carried through `TagContext` would land in `meta` as a string rather than in `metrics`.
- A genuinely-HTTP event whose shape `detectTriggerType` fails to recognise now loses best-effort coverage instead of degrading to it — matching Python and JS, and making the span state honest.
- One pre-existing test expectation changed: `responseCallbacksSkipNonApiGatewayResponseForNonHttpEvent` asserted `appSecEnded` for a non-HTTP event; with the skip there is no request context to end.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

