### PR TITLE
Stop flagging JAX-RS/Spring MVC spans as errors when the exception maps to a non-5xx response

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ConfiguredResponseStatusExceptions.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ConfiguredResponseStatusExceptions.java
@@ -1,0 +1,60 @@
+package datadog.trace.bootstrap.instrumentation.decorator;
+
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.ClassHierarchyIterable;
+import java.util.Map;
+
+/**
+ * Lets users teach the tracer about their own, framework-agnostic exception types via {@code
+ * trace.response-status.exceptions} ({@code DD_TRACE_RESPONSE_STATUS_EXCEPTIONS}): a list of {@code
+ * fully.qualified.ExceptionClass#accessorMethod} entries. When a configured exception (or a
+ * subclass of one) is thrown from a request handler, the named no-arg accessor is invoked
+ * reflectively and its numeric return value is used as the HTTP status for deciding whether the
+ * span should be flagged as an error, instead of unconditionally marking it as an error.
+ *
+ * <p>Only ever reflects on classes/methods the user explicitly named, unlike a generic heuristic
+ * that would probe arbitrary exceptions for common accessor names and risk silently clearing a
+ * genuine error whose exception happens to have a same-named, unrelated method.
+ */
+public final class ConfiguredResponseStatusExceptions {
+
+  public static Integer extractStatus(final Throwable throwable) {
+    Map<String, String> accessors = Config.get().getResponseStatusExceptionAccessors();
+    if (accessors.isEmpty()) {
+      return null;
+    }
+    Throwable current = throwable;
+    for (int depth = 0; current != null && depth < 5; depth++, current = current.getCause()) {
+      for (Class<?> type : new ClassHierarchyIterable(current.getClass())) {
+        String methodName = accessors.get(type.getName());
+        if (methodName != null) {
+          Integer status = invoke(current, methodName);
+          if (status != null) {
+            return status;
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  private static Integer invoke(final Throwable throwable, final String methodName) {
+    try {
+      Object result = throwable.getClass().getMethod(methodName).invoke(throwable);
+      if (result instanceof Number) {
+        int status = ((Number) result).intValue();
+        // Guard against sentinel values (e.g. -1 for "unknown") reflectively returned by a
+        // misconfigured accessor: an out-of-range status would otherwise throw when later used
+        // to index into Config#getHttpServerErrorStatuses, aborting normal error handling.
+        if (status >= 100 && status <= 599) {
+          return status;
+        }
+      }
+    } catch (Throwable ignored) {
+      // misconfigured entry (wrong method name, non-numeric return, etc.) -- fall through
+    }
+    return null;
+  }
+
+  private ConfiguredResponseStatusExceptions() {}
+}

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ConfiguredResponseStatusExceptions.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/ConfiguredResponseStatusExceptions.java
@@ -24,7 +24,9 @@ public final class ConfiguredResponseStatusExceptions {
       return null;
     }
     Throwable current = throwable;
-    for (int depth = 0; current != null && depth < 5; depth++, current = current.getCause()) {
+    for (int depth = 0;
+        current != null && depth < MappedExceptionStatus.MAX_CAUSE_CHAIN_DEPTH;
+        depth++, current = current.getCause()) {
       for (Class<?> type : new ClassHierarchyIterable(current.getClass())) {
         String methodName = accessors.get(type.getName());
         if (methodName != null) {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/MappedExceptionStatus.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/decorator/MappedExceptionStatus.java
@@ -1,0 +1,38 @@
+package datadog.trace.bootstrap.instrumentation.decorator;
+
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+
+/**
+ * Shared tail of {@code doOnError} for HTTP server decorators that map an exception to a status
+ * (via {@code @ResponseStatus}, {@code ResponseStatusException}/{@code ErrorResponse}, {@code
+ * WebApplicationException}, or a configured accessor via {@link
+ * ConfiguredResponseStatusExceptions}) instead of unconditionally flagging the span as an error.
+ */
+public final class MappedExceptionStatus {
+
+  // Cause chains are walked no deeper than this when looking for a mapped status, to bound the
+  // cost of a long chain and avoid an unbounded loop if a cause chain is ever cyclic.
+  public static final int MAX_CAUSE_CHAIN_DEPTH = 5;
+
+  private MappedExceptionStatus() {}
+
+  /**
+   * If {@code status} is a valid HTTP status, flags {@code span} as an error only if it is one of
+   * the configured "server error" statuses, and returns true. Returns false, without touching the
+   * span, if {@code status} is null or out of range so the caller can fall back to its default
+   * error handling.
+   */
+  public static boolean flagIfPresent(
+      final AgentSpan span,
+      final Throwable throwable,
+      final byte errorPriority,
+      final Integer status) {
+    if (status == null || status < 100 || status > 599) {
+      return false;
+    }
+    span.addThrowable(throwable, errorPriority);
+    span.setError(Config.get().getHttpServerErrorStatuses().get(status), errorPriority);
+    return true;
+  }
+}

--- a/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsDecorator.java
@@ -12,6 +12,7 @@ import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
+import datadog.trace.bootstrap.instrumentation.decorator.ConfiguredResponseStatusExceptions;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.WebApplicationException;
@@ -62,6 +63,9 @@ public class JakartaRsAnnotationsDecorator extends BaseDecorator {
     // an error from the caller's point of view (e.g. a 404 NotFoundException), even though a Java
     // exception was thrown to get there.
     Integer status = extractResponseStatus(throwable);
+    if (status == null) {
+      status = ConfiguredResponseStatusExceptions.extractStatus(throwable);
+    }
     if (status != null) {
       span.addThrowable(throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
       span.setError(

--- a/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsDecorator.java
@@ -2,16 +2,19 @@ package datadog.trace.instrumentation.jakarta3;
 
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.GenericClassValue;
 import datadog.trace.api.Pair;
 import datadog.trace.bootstrap.ClassHierarchyIterable;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.WebApplicationException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Map;
@@ -51,6 +54,34 @@ public class JakartaRsAnnotationsDecorator extends BaseDecorator {
   @Override
   protected CharSequence component() {
     return JAKARTA_RS_CONTROLLER;
+  }
+
+  @Override
+  protected void doOnError(final AgentSpan span, final Throwable throwable, byte errorPriority) {
+    // If the mapped status isn't one of the configured "server error" statuses, this isn't really
+    // an error from the caller's point of view (e.g. a 404 NotFoundException), even though a Java
+    // exception was thrown to get there.
+    Integer status = extractResponseStatus(throwable);
+    if (status != null) {
+      span.addThrowable(throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
+      span.setError(
+          Config.get().getHttpServerErrorStatuses().get(status),
+          ErrorPriorities.HTTP_SERVER_DECORATOR);
+      return;
+    }
+    super.doOnError(span, throwable, errorPriority);
+  }
+
+  // Walk the cause chain looking for a WebApplicationException, which carries the response the
+  // framework will actually send.
+  private static Integer extractResponseStatus(final Throwable throwable) {
+    Throwable current = throwable;
+    for (int depth = 0; current != null && depth < 5; depth++, current = current.getCause()) {
+      if (current instanceof WebApplicationException) {
+        return ((WebApplicationException) current).getResponse().getStatus();
+      }
+    }
+    return null;
   }
 
   public void onJakartaRsSpan(

--- a/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/main/java/datadog/trace/instrumentation/jakarta3/JakartaRsAnnotationsDecorator.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.jakarta3;
 
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.GenericClassValue;
 import datadog.trace.api.Pair;
 import datadog.trace.bootstrap.ClassHierarchyIterable;
@@ -13,6 +12,7 @@ import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
 import datadog.trace.bootstrap.instrumentation.decorator.ConfiguredResponseStatusExceptions;
+import datadog.trace.bootstrap.instrumentation.decorator.MappedExceptionStatus;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.WebApplicationException;
@@ -66,11 +66,8 @@ public class JakartaRsAnnotationsDecorator extends BaseDecorator {
     if (status == null) {
       status = ConfiguredResponseStatusExceptions.extractStatus(throwable);
     }
-    if (status != null) {
-      span.addThrowable(throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
-      span.setError(
-          Config.get().getHttpServerErrorStatuses().get(status),
-          ErrorPriorities.HTTP_SERVER_DECORATOR);
+    if (MappedExceptionStatus.flagIfPresent(
+        span, throwable, ErrorPriorities.HTTP_SERVER_DECORATOR, status)) {
       return;
     }
     super.doOnError(span, throwable, errorPriority);
@@ -80,7 +77,9 @@ public class JakartaRsAnnotationsDecorator extends BaseDecorator {
   // framework will actually send.
   private static Integer extractResponseStatus(final Throwable throwable) {
     Throwable current = throwable;
-    for (int depth = 0; current != null && depth < 5; depth++, current = current.getCause()) {
+    for (int depth = 0;
+        current != null && depth < MappedExceptionStatus.MAX_CAUSE_CHAIN_DEPTH;
+        depth++, current = current.getCause()) {
       if (current instanceof WebApplicationException) {
         return ((WebApplicationException) current).getResponse().getStatus();
       }

--- a/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/test/groovy/JakartaRsAnnotations3InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/test/groovy/JakartaRsAnnotations3InstrumentationTest.groovy
@@ -253,6 +253,74 @@ class JakartaRsAnnotations3InstrumentationTest extends InstrumentationSpecificat
   }
 
 
+  def "resource method exception recognized via configured custom accessor with a non-5xx status is not flagged as an error"() {
+    setup:
+    injectSysConfig(TraceInstrumentationConfig.RESPONSE_STATUS_EXCEPTIONS, "${CustomStatusException.name}#httpCode")
+    def obj = new Jakarta() {
+        @GET
+        @Path("/custom-not-found")
+        void call() {
+          throw new CustomStatusException(404)
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    thrown(CustomStatusException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jakarta-rs.request"
+          resourceName "GET /custom-not-found"
+          spanType "web"
+          errored false
+          tags {
+            "$Tags.COMPONENT" "jakarta-rs-controller"
+            "$Tags.HTTP_ROUTE" "/custom-not-found"
+            errorTags(CustomStatusException)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "resource method exception recognized via configured custom accessor with a 5xx status is flagged as an error"() {
+    setup:
+    injectSysConfig(TraceInstrumentationConfig.RESPONSE_STATUS_EXCEPTIONS, "${CustomStatusException.name}#httpCode")
+    def obj = new Jakarta() {
+        @GET
+        @Path("/custom-internal-error")
+        void call() {
+          throw new CustomStatusException(500)
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    thrown(CustomStatusException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jakarta-rs.request"
+          resourceName "GET /custom-internal-error"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "jakarta-rs-controller"
+            "$Tags.HTTP_ROUTE" "/custom-internal-error"
+            errorTags(CustomStatusException)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
   def "no annotations has no effect"() {
     setup:
     def obj = new Jakarta() {
@@ -274,6 +342,18 @@ class JakartaRsAnnotations3InstrumentationTest extends InstrumentationSpecificat
           }
         }
       }
+    }
+  }
+
+  static class CustomStatusException extends RuntimeException {
+    private final int status
+
+    CustomStatusException(int status) {
+      this.status = status
+    }
+
+    int httpCode() {
+      return status
     }
   }
 

--- a/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/test/groovy/JakartaRsAnnotations3InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/test/groovy/JakartaRsAnnotations3InstrumentationTest.groovy
@@ -219,6 +219,49 @@ class JakartaRsAnnotations3InstrumentationTest extends InstrumentationSpecificat
     }
   }
 
+  def "resource method exception with an embedded out-of-range status falls back to normal error handling"() {
+    setup:
+    // A misbehaving custom Response reporting a negative "unknown" status must not be used to
+    // index into the configured server-error statuses.
+    def response = Stub(Response) {
+      getStatus() >> -1
+      getStatusInfo() >> Stub(Response.StatusType) {
+        getStatusCode() >> -1
+        getReasonPhrase() >> "Custom"
+        getFamily() >> Response.Status.Family.OTHER
+      }
+    }
+    def obj = new Jakarta() {
+        @GET
+        @Path("/custom-status")
+        void call() {
+          throw new WebApplicationException(response)
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    def ex = thrown(WebApplicationException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jakarta-rs.request"
+          resourceName "GET /custom-status"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "jakarta-rs-controller"
+            "$Tags.HTTP_ROUTE" "/custom-status"
+            errorTags(WebApplicationException, ex.message)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
   def "resource method with a plain exception is still flagged as an error"() {
     setup:
     def obj = new Jakarta() {

--- a/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/test/groovy/JakartaRsAnnotations3InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/rs/jakarta-rs-annotations-3.0/src/test/groovy/JakartaRsAnnotations3InstrumentationTest.groovy
@@ -11,6 +11,8 @@ import jakarta.ws.rs.PATCH
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.PUT
 import jakarta.ws.rs.Path
+import jakarta.ws.rs.WebApplicationException
+import jakarta.ws.rs.core.Response
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
@@ -139,6 +141,117 @@ class JakartaRsAnnotations3InstrumentationTest extends InstrumentationSpecificat
 
     className = JakartaRsAnnotationsDecorator.DECORATE.className(obj.class)
   }
+
+  def "resource method exception with an embedded non-5xx status is not flagged as an error"() {
+    setup:
+    // jakarta-rs-annotations-3.0's test classpath has no JAX-RS runtime implementation, so
+    // WebApplicationException's convenience constructors (which build a Response via
+    // RuntimeDelegate) can't be used here. Stub the Response instead.
+    def response = Stub(Response) {
+      getStatus() >> 404
+      getStatusInfo() >> Response.Status.NOT_FOUND
+    }
+    def obj = new Jakarta() {
+        @GET
+        @Path("/not-found")
+        void call() {
+          throw new WebApplicationException(response)
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    thrown(WebApplicationException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jakarta-rs.request"
+          resourceName "GET /not-found"
+          spanType "web"
+          errored false
+          tags {
+            "$Tags.COMPONENT" "jakarta-rs-controller"
+            "$Tags.HTTP_ROUTE" "/not-found"
+            errorTags(WebApplicationException, "HTTP 404 Not Found")
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "resource method exception with an embedded 5xx status is flagged as an error"() {
+    setup:
+    def response = Stub(Response) {
+      getStatus() >> 500
+      getStatusInfo() >> Response.Status.INTERNAL_SERVER_ERROR
+    }
+    def obj = new Jakarta() {
+        @GET
+        @Path("/internal-error")
+        void call() {
+          throw new WebApplicationException(response)
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    thrown(WebApplicationException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jakarta-rs.request"
+          resourceName "GET /internal-error"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "jakarta-rs-controller"
+            "$Tags.HTTP_ROUTE" "/internal-error"
+            errorTags(WebApplicationException, "HTTP 500 Internal Server Error")
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "resource method with a plain exception is still flagged as an error"() {
+    setup:
+    def obj = new Jakarta() {
+        @GET
+        @Path("/boom")
+        void call() {
+          throw new IllegalStateException("boom")
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    thrown(IllegalStateException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jakarta-rs.request"
+          resourceName "GET /boom"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "jakarta-rs-controller"
+            "$Tags.HTTP_ROUTE" "/boom"
+            errorTags(IllegalStateException, "boom")
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
 
   def "no annotations has no effect"() {
     setup:

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-1.1.1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-1.1.1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.jaxrs1;
 
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.GenericClassValue;
 import datadog.trace.api.Pair;
 import datadog.trace.bootstrap.ClassHierarchyIterable;
@@ -14,6 +13,7 @@ import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
 import datadog.trace.bootstrap.instrumentation.decorator.ConfiguredResponseStatusExceptions;
+import datadog.trace.bootstrap.instrumentation.decorator.MappedExceptionStatus;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Map;
@@ -54,11 +54,8 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     if (status == null) {
       status = ConfiguredResponseStatusExceptions.extractStatus(throwable);
     }
-    if (status != null) {
-      span.addThrowable(throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
-      span.setError(
-          Config.get().getHttpServerErrorStatuses().get(status),
-          ErrorPriorities.HTTP_SERVER_DECORATOR);
+    if (MappedExceptionStatus.flagIfPresent(
+        span, throwable, ErrorPriorities.HTTP_SERVER_DECORATOR, status)) {
       return;
     }
     super.doOnError(span, throwable, errorPriority);
@@ -68,7 +65,9 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
   // framework will actually send.
   private static Integer extractResponseStatus(final Throwable throwable) {
     Throwable current = throwable;
-    for (int depth = 0; current != null && depth < 5; depth++, current = current.getCause()) {
+    for (int depth = 0;
+        current != null && depth < MappedExceptionStatus.MAX_CAUSE_CHAIN_DEPTH;
+        depth++, current = current.getCause()) {
       if (current instanceof WebApplicationException) {
         return ((WebApplicationException) current).getResponse().getStatus();
       }

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-1.1.1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-1.1.1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
@@ -13,6 +13,7 @@ import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
+import datadog.trace.bootstrap.instrumentation.decorator.ConfiguredResponseStatusExceptions;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Map;
@@ -50,6 +51,9 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     // an error from the caller's point of view (e.g. a 404 NotFoundException), even though a Java
     // exception was thrown to get there.
     Integer status = extractResponseStatus(throwable);
+    if (status == null) {
+      status = ConfiguredResponseStatusExceptions.extractStatus(throwable);
+    }
     if (status != null) {
       span.addThrowable(throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
       span.setError(

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-1.1.1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-1.1.1/src/main/java/datadog/trace/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
@@ -2,10 +2,12 @@ package datadog.trace.instrumentation.jaxrs1;
 
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.GenericClassValue;
 import datadog.trace.api.Pair;
 import datadog.trace.bootstrap.ClassHierarchyIterable;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -17,6 +19,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
 
 public class JaxRsAnnotationsDecorator extends BaseDecorator {
   public static JaxRsAnnotationsDecorator DECORATE = new JaxRsAnnotationsDecorator();
@@ -39,6 +42,34 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
   @Override
   protected CharSequence component() {
     return JAX_RS_CONTROLLER;
+  }
+
+  @Override
+  protected void doOnError(final AgentSpan span, final Throwable throwable, byte errorPriority) {
+    // If the mapped status isn't one of the configured "server error" statuses, this isn't really
+    // an error from the caller's point of view (e.g. a 404 NotFoundException), even though a Java
+    // exception was thrown to get there.
+    Integer status = extractResponseStatus(throwable);
+    if (status != null) {
+      span.addThrowable(throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
+      span.setError(
+          Config.get().getHttpServerErrorStatuses().get(status),
+          ErrorPriorities.HTTP_SERVER_DECORATOR);
+      return;
+    }
+    super.doOnError(span, throwable, errorPriority);
+  }
+
+  // Walk the cause chain looking for a WebApplicationException, which carries the response the
+  // framework will actually send.
+  private static Integer extractResponseStatus(final Throwable throwable) {
+    Throwable current = throwable;
+    for (int depth = 0; current != null && depth < 5; depth++, current = current.getCause()) {
+      if (current instanceof WebApplicationException) {
+        return ((WebApplicationException) current).getResponse().getStatus();
+      }
+    }
+    return null;
   }
 
   public void onJaxRsSpan(

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-1.1.1/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-1.1.1/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
@@ -14,6 +14,8 @@ import javax.ws.rs.POST
 import javax.ws.rs.PUT
 import javax.ws.rs.Path
 import javax.ws.rs.WebApplicationException
+import javax.ws.rs.core.MultivaluedMap
+import javax.ws.rs.core.Response
 
 class JaxRsAnnotations1InstrumentationTest extends InstrumentationSpecification {
 
@@ -200,6 +202,57 @@ class JaxRsAnnotations1InstrumentationTest extends InstrumentationSpecification 
             "$Tags.COMPONENT" "jax-rs-controller"
             "$Tags.HTTP_ROUTE" "/internal-error"
             errorTags(WebApplicationException)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "resource method exception with an embedded out-of-range status falls back to normal error handling"() {
+    setup:
+    // A hand-rolled Response (e.g. from a custom implementation) reporting a negative "unknown"
+    // status must not be used to index into the configured server-error statuses.
+    def response = new Response() {
+        @Override
+        Object getEntity() {
+          return null
+        }
+
+        @Override
+        int getStatus() {
+          return -1
+        }
+
+        @Override
+        MultivaluedMap getMetadata() {
+          return null
+        }
+      }
+    def obj = new Jax() {
+        @GET
+        @Path("/custom-status")
+        void call() {
+          throw new WebApplicationException(response)
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    def ex = thrown(WebApplicationException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jax-rs.request"
+          resourceName "GET /custom-status"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "jax-rs-controller"
+            "$Tags.HTTP_ROUTE" "/custom-status"
+            errorTags(WebApplicationException, ex.message)
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-1.1.1/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-1.1.1/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
@@ -13,6 +13,7 @@ import javax.ws.rs.OPTIONS
 import javax.ws.rs.POST
 import javax.ws.rs.PUT
 import javax.ws.rs.Path
+import javax.ws.rs.WebApplicationException
 
 class JaxRsAnnotations1InstrumentationTest extends InstrumentationSpecification {
 
@@ -138,6 +139,105 @@ class JaxRsAnnotations1InstrumentationTest extends InstrumentationSpecification 
     // "GET /child/invoke"  | new JavaInterfaces.DefaultChildClassOnInterface()
 
     className = JaxRsAnnotationsDecorator.DECORATE.className(obj.class)
+  }
+
+  def "resource method exception with an embedded non-5xx status is not flagged as an error"() {
+    setup:
+    def obj = new Jax() {
+        @GET
+        @Path("/not-found")
+        void call() {
+          throw new WebApplicationException(404)
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    thrown(WebApplicationException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jax-rs.request"
+          resourceName "GET /not-found"
+          spanType "web"
+          errored false
+          tags {
+            "$Tags.COMPONENT" "jax-rs-controller"
+            "$Tags.HTTP_ROUTE" "/not-found"
+            errorTags(WebApplicationException)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "resource method exception with an embedded 5xx status is flagged as an error"() {
+    setup:
+    def obj = new Jax() {
+        @GET
+        @Path("/internal-error")
+        void call() {
+          throw new WebApplicationException(500)
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    thrown(WebApplicationException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jax-rs.request"
+          resourceName "GET /internal-error"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "jax-rs-controller"
+            "$Tags.HTTP_ROUTE" "/internal-error"
+            errorTags(WebApplicationException)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "resource method with a plain exception is still flagged as an error"() {
+    setup:
+    def obj = new Jax() {
+        @GET
+        @Path("/boom")
+        void call() {
+          throw new IllegalStateException("boom")
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    thrown(IllegalStateException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jax-rs.request"
+          resourceName "GET /boom"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "jax-rs-controller"
+            "$Tags.HTTP_ROUTE" "/boom"
+            errorTags(IllegalStateException, "boom")
+            defaultTags()
+          }
+        }
+      }
+    }
   }
 
   def "no annotations has no effect"() {

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-1.1.1/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-1.1.1/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
@@ -240,6 +240,74 @@ class JaxRsAnnotations1InstrumentationTest extends InstrumentationSpecification 
     }
   }
 
+  def "resource method exception recognized via configured custom accessor with a non-5xx status is not flagged as an error"() {
+    setup:
+    injectSysConfig(TraceInstrumentationConfig.RESPONSE_STATUS_EXCEPTIONS, "${CustomStatusException.name}#httpCode")
+    def obj = new Jax() {
+        @GET
+        @Path("/custom-not-found")
+        void call() {
+          throw new CustomStatusException(404)
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    thrown(CustomStatusException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jax-rs.request"
+          resourceName "GET /custom-not-found"
+          spanType "web"
+          errored false
+          tags {
+            "$Tags.COMPONENT" "jax-rs-controller"
+            "$Tags.HTTP_ROUTE" "/custom-not-found"
+            errorTags(CustomStatusException)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "resource method exception recognized via configured custom accessor with a 5xx status is flagged as an error"() {
+    setup:
+    injectSysConfig(TraceInstrumentationConfig.RESPONSE_STATUS_EXCEPTIONS, "${CustomStatusException.name}#httpCode")
+    def obj = new Jax() {
+        @GET
+        @Path("/custom-internal-error")
+        void call() {
+          throw new CustomStatusException(500)
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    thrown(CustomStatusException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jax-rs.request"
+          resourceName "GET /custom-internal-error"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "jax-rs-controller"
+            "$Tags.HTTP_ROUTE" "/custom-internal-error"
+            errorTags(CustomStatusException)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
   def "no annotations has no effect"() {
     setup:
     def obj = new Jax() {
@@ -261,6 +329,18 @@ class JaxRsAnnotations1InstrumentationTest extends InstrumentationSpecification 
           }
         }
       }
+    }
+  }
+
+  static class CustomStatusException extends RuntimeException {
+    private final int status
+
+    CustomStatusException(int status) {
+      this.status = status
+    }
+
+    int httpCode() {
+      return status
     }
   }
 

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
@@ -13,6 +13,7 @@ import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
+import datadog.trace.bootstrap.instrumentation.decorator.ConfiguredResponseStatusExceptions;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Map;
@@ -61,6 +62,9 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     // an error from the caller's point of view (e.g. a 404 NotFoundException), even though a Java
     // exception was thrown to get there.
     Integer status = extractResponseStatus(throwable);
+    if (status == null) {
+      status = ConfiguredResponseStatusExceptions.extractStatus(throwable);
+    }
     if (status != null) {
       span.addThrowable(throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
       span.setError(

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
@@ -2,10 +2,12 @@ package datadog.trace.instrumentation.jaxrs2;
 
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
+import datadog.trace.api.Config;
 import datadog.trace.api.GenericClassValue;
 import datadog.trace.api.Pair;
 import datadog.trace.bootstrap.ClassHierarchyIterable;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
@@ -17,6 +19,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
 
 public class JaxRsAnnotationsDecorator extends BaseDecorator {
 
@@ -50,6 +53,34 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
   @Override
   protected CharSequence component() {
     return JAX_RS_CONTROLLER;
+  }
+
+  @Override
+  protected void doOnError(final AgentSpan span, final Throwable throwable, byte errorPriority) {
+    // If the mapped status isn't one of the configured "server error" statuses, this isn't really
+    // an error from the caller's point of view (e.g. a 404 NotFoundException), even though a Java
+    // exception was thrown to get there.
+    Integer status = extractResponseStatus(throwable);
+    if (status != null) {
+      span.addThrowable(throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
+      span.setError(
+          Config.get().getHttpServerErrorStatuses().get(status),
+          ErrorPriorities.HTTP_SERVER_DECORATOR);
+      return;
+    }
+    super.doOnError(span, throwable, errorPriority);
+  }
+
+  // Walk the cause chain looking for a WebApplicationException, which carries the response the
+  // framework will actually send.
+  private static Integer extractResponseStatus(final Throwable throwable) {
+    Throwable current = throwable;
+    for (int depth = 0; current != null && depth < 5; depth++, current = current.getCause()) {
+      if (current instanceof WebApplicationException) {
+        return ((WebApplicationException) current).getResponse().getStatus();
+      }
+    }
+    return null;
   }
 
   public void onJaxRsSpan(

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/main/java/datadog/trace/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
@@ -2,7 +2,6 @@ package datadog.trace.instrumentation.jaxrs2;
 
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
-import datadog.trace.api.Config;
 import datadog.trace.api.GenericClassValue;
 import datadog.trace.api.Pair;
 import datadog.trace.bootstrap.ClassHierarchyIterable;
@@ -14,6 +13,7 @@ import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
 import datadog.trace.bootstrap.instrumentation.decorator.ConfiguredResponseStatusExceptions;
+import datadog.trace.bootstrap.instrumentation.decorator.MappedExceptionStatus;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Map;
@@ -65,11 +65,8 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     if (status == null) {
       status = ConfiguredResponseStatusExceptions.extractStatus(throwable);
     }
-    if (status != null) {
-      span.addThrowable(throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
-      span.setError(
-          Config.get().getHttpServerErrorStatuses().get(status),
-          ErrorPriorities.HTTP_SERVER_DECORATOR);
+    if (MappedExceptionStatus.flagIfPresent(
+        span, throwable, ErrorPriorities.HTTP_SERVER_DECORATOR, status)) {
       return;
     }
     super.doOnError(span, throwable, errorPriority);
@@ -79,7 +76,9 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
   // framework will actually send.
   private static Integer extractResponseStatus(final Throwable throwable) {
     Throwable current = throwable;
-    for (int depth = 0; current != null && depth < 5; depth++, current = current.getCause()) {
+    for (int depth = 0;
+        current != null && depth < MappedExceptionStatus.MAX_CAUSE_CHAIN_DEPTH;
+        depth++, current = current.getCause()) {
       if (current instanceof WebApplicationException) {
         return ((WebApplicationException) current).getResponse().getStatus();
       }

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/test/groovy/JaxRsAnnotations2InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/test/groovy/JaxRsAnnotations2InstrumentationTest.groovy
@@ -7,10 +7,12 @@ import io.dropwizard.jersey.PATCH
 import javax.ws.rs.DELETE
 import javax.ws.rs.GET
 import javax.ws.rs.HEAD
+import javax.ws.rs.NotFoundException
 import javax.ws.rs.OPTIONS
 import javax.ws.rs.POST
 import javax.ws.rs.PUT
 import javax.ws.rs.Path
+import javax.ws.rs.WebApplicationException
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
@@ -138,6 +140,105 @@ class JaxRsAnnotations2InstrumentationTest extends InstrumentationSpecification 
     //    "GET /child/invoke"         | new JavaInterfaces.DefaultChildClassOnInterface()
 
     className = JaxRsAnnotationsDecorator.DECORATE.className(obj.class)
+  }
+
+  def "resource method exception with an embedded non-5xx status is not flagged as an error"() {
+    setup:
+    def obj = new Jax() {
+        @GET
+        @Path("/not-found")
+        void call() {
+          throw new NotFoundException()
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    thrown(NotFoundException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jax-rs.request"
+          resourceName "GET /not-found"
+          spanType "web"
+          errored false
+          tags {
+            "$Tags.COMPONENT" "jax-rs-controller"
+            "$Tags.HTTP_ROUTE" "/not-found"
+            errorTags(NotFoundException, "HTTP 404 Not Found")
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "resource method exception with an embedded 5xx status is flagged as an error"() {
+    setup:
+    def obj = new Jax() {
+        @GET
+        @Path("/internal-error")
+        void call() {
+          throw new WebApplicationException(500)
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    thrown(WebApplicationException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jax-rs.request"
+          resourceName "GET /internal-error"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "jax-rs-controller"
+            "$Tags.HTTP_ROUTE" "/internal-error"
+            errorTags(WebApplicationException, "HTTP 500 Internal Server Error")
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "resource method with a plain exception is still flagged as an error"() {
+    setup:
+    def obj = new Jax() {
+        @GET
+        @Path("/boom")
+        void call() {
+          throw new IllegalStateException("boom")
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    thrown(IllegalStateException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jax-rs.request"
+          resourceName "GET /boom"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "jax-rs-controller"
+            "$Tags.HTTP_ROUTE" "/boom"
+            errorTags(IllegalStateException, "boom")
+            defaultTags()
+          }
+        }
+      }
+    }
   }
 
   def "no annotations has no effect"() {

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/test/groovy/JaxRsAnnotations2InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/test/groovy/JaxRsAnnotations2InstrumentationTest.groovy
@@ -13,6 +13,7 @@ import javax.ws.rs.POST
 import javax.ws.rs.PUT
 import javax.ws.rs.Path
 import javax.ws.rs.WebApplicationException
+import javax.ws.rs.core.Response
 
 import static datadog.trace.agent.test.utils.TraceUtils.runUnderTrace
 
@@ -201,6 +202,49 @@ class JaxRsAnnotations2InstrumentationTest extends InstrumentationSpecification 
             "$Tags.COMPONENT" "jax-rs-controller"
             "$Tags.HTTP_ROUTE" "/internal-error"
             errorTags(WebApplicationException, "HTTP 500 Internal Server Error")
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "resource method exception with an embedded out-of-range status falls back to normal error handling"() {
+    setup:
+    // A misbehaving custom Response reporting a negative "unknown" status must not be used to
+    // index into the configured server-error statuses.
+    def response = Stub(Response) {
+      getStatus() >> -1
+      getStatusInfo() >> Stub(Response.StatusType) {
+        getStatusCode() >> -1
+        getReasonPhrase() >> "Custom"
+        getFamily() >> Response.Status.Family.OTHER
+      }
+    }
+    def obj = new Jax() {
+        @GET
+        @Path("/custom-status")
+        void call() {
+          throw new WebApplicationException(response)
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    def ex = thrown(WebApplicationException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jax-rs.request"
+          resourceName "GET /custom-status"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "jax-rs-controller"
+            "$Tags.HTTP_ROUTE" "/custom-status"
+            errorTags(WebApplicationException, ex.message)
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/test/groovy/JaxRsAnnotations2InstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/rs/jax-rs/jax-rs-annotations/jax-rs-annotations-2.0/src/test/groovy/JaxRsAnnotations2InstrumentationTest.groovy
@@ -241,6 +241,74 @@ class JaxRsAnnotations2InstrumentationTest extends InstrumentationSpecification 
     }
   }
 
+  def "resource method exception recognized via configured custom accessor with a non-5xx status is not flagged as an error"() {
+    setup:
+    injectSysConfig(TraceInstrumentationConfig.RESPONSE_STATUS_EXCEPTIONS, "${CustomStatusException.name}#httpCode")
+    def obj = new Jax() {
+        @GET
+        @Path("/custom-not-found")
+        void call() {
+          throw new CustomStatusException(404)
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    thrown(CustomStatusException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jax-rs.request"
+          resourceName "GET /custom-not-found"
+          spanType "web"
+          errored false
+          tags {
+            "$Tags.COMPONENT" "jax-rs-controller"
+            "$Tags.HTTP_ROUTE" "/custom-not-found"
+            errorTags(CustomStatusException)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "resource method exception recognized via configured custom accessor with a 5xx status is flagged as an error"() {
+    setup:
+    injectSysConfig(TraceInstrumentationConfig.RESPONSE_STATUS_EXCEPTIONS, "${CustomStatusException.name}#httpCode")
+    def obj = new Jax() {
+        @GET
+        @Path("/custom-internal-error")
+        void call() {
+          throw new CustomStatusException(500)
+        }
+      }
+
+    when:
+    obj.call()
+
+    then:
+    thrown(CustomStatusException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "jax-rs.request"
+          resourceName "GET /custom-internal-error"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "jax-rs-controller"
+            "$Tags.HTTP_ROUTE" "/custom-internal-error"
+            errorTags(CustomStatusException)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
   def "no annotations has no effect"() {
     setup:
     def obj = new Jax() {
@@ -262,6 +330,18 @@ class JaxRsAnnotations2InstrumentationTest extends InstrumentationSpecification 
           }
         }
       }
+    }
+  }
+
+  static class CustomStatusException extends RuntimeException {
+    private final int status
+
+    CustomStatusException(int status) {
+      this.status = status
+    }
+
+    int httpCode() {
+      return status
     }
   }
 

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/latestDepTest/groovy/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecoratorLatestDepTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/latestDepTest/groovy/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecoratorLatestDepTest.groovy
@@ -1,0 +1,77 @@
+package datadog.trace.instrumentation.springweb
+
+import datadog.trace.agent.test.InstrumentationSpecification
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+
+import static datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator.DECORATE
+
+// ResponseStatusException was added in Spring 5.0, which is only guaranteed to be on the
+// classpath for the latestDepTest suite (this module's base test classpath is Spring 3.1). This
+// exercises the reflective ResponseStatusException handling in SpringWebHttpServerDecorator.
+class SpringWebHttpServerDecoratorLatestDepTest extends InstrumentationSpecification {
+
+  def "ResponseStatusException with a non-5xx status is not flagged as an error"() {
+    setup:
+    def testSpan = AgentTracer.startSpan("spring-web-controller", "spring.handler")
+    def scope = AgentTracer.activateSpan(testSpan)
+    DECORATE.afterStart(testSpan)
+    def throwable = new ResponseStatusException(HttpStatus.NOT_FOUND)
+
+    when:
+    DECORATE.onError(testSpan, throwable)
+    DECORATE.beforeFinish(testSpan)
+    scope.close()
+    testSpan.finish()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "spring.handler"
+          spanType "web"
+          errored false
+          tags {
+            "$Tags.COMPONENT" "spring-web-controller"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            errorTags(ResponseStatusException, throwable.message)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "ResponseStatusException with a 5xx status is flagged as an error"() {
+    setup:
+    def testSpan = AgentTracer.startSpan("spring-web-controller", "spring.handler")
+    def scope = AgentTracer.activateSpan(testSpan)
+    DECORATE.afterStart(testSpan)
+    def throwable = new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR)
+
+    when:
+    DECORATE.onError(testSpan, throwable)
+    DECORATE.beforeFinish(testSpan)
+    scope.close()
+    testSpan.finish()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "spring.handler"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "spring-web-controller"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            errorTags(ResponseStatusException, throwable.message)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -3,8 +3,11 @@ package datadog.trace.instrumentation.springweb;
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
 import datadog.context.Context;
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.ClassHierarchyIterable;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
@@ -12,7 +15,9 @@ import java.lang.reflect.Method;
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.HttpRequestHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.ModelAndView;
@@ -20,6 +25,38 @@ import org.springframework.web.servlet.mvc.Controller;
 
 public class SpringWebHttpServerDecorator
     extends HttpServerDecorator<HttpServletRequest, HttpServletRequest, HttpServletResponse, Void> {
+
+  // ResponseStatusException was added in Spring 5.0; this module also supports Spring 3.1-4.x,
+  // so it can't be referenced directly. Resolved reflectively, once, and reused.
+  private static final Method RESPONSE_STATUS_EXCEPTION_GET_STATUS =
+      findResponseStatusExceptionGetStatus();
+
+  private static Method findResponseStatusExceptionGetStatus() {
+    try {
+      Class<?> responseStatusExceptionClass =
+          Class.forName(
+              "org.springframework.web.server.ResponseStatusException",
+              false,
+              SpringWebHttpServerDecorator.class.getClassLoader());
+      return responseStatusExceptionClass.getMethod("getStatus");
+    } catch (ClassNotFoundException | NoSuchMethodException e) {
+      return null;
+    }
+  }
+
+  // ResponseStatus#code() was added in Spring 4.2 as an alias of value(); this module compiles
+  // against Spring 3.1, so it can't be referenced directly. Resolved reflectively, once, and
+  // reused. Plain reflection doesn't resolve Spring's @AliasFor, so if a caller only set code(),
+  // value() still reports its own default rather than the value mirrored from code().
+  private static final Method RESPONSE_STATUS_CODE = findResponseStatusCode();
+
+  private static Method findResponseStatusCode() {
+    try {
+      return ResponseStatus.class.getMethod("code");
+    } catch (NoSuchMethodException e) {
+      return null;
+    }
+  }
 
   private static final CharSequence SPRING_HANDLER = UTF8BytesString.create("spring.handler");
   public static final CharSequence RESPONSE_RENDER = UTF8BytesString.create("response.render");
@@ -95,6 +132,61 @@ public class SpringWebHttpServerDecorator
   @Override
   protected String getRequestHeader(final HttpServletRequest request, String key) {
     return request.getHeader(key);
+  }
+
+  @Override
+  protected void doOnError(final AgentSpan span, final Throwable throwable, byte errorPriority) {
+    // Walk the cause chain looking for a status the exception itself carries (@ResponseStatus, or
+    // a ResponseStatusException on Spring 5+). If the mapped status isn't one of the configured
+    // "server error" statuses, this isn't really an error from the caller's point of view (e.g. a
+    // 404 mapping), even though a Java exception was thrown to get there.
+    Integer status = extractResponseStatus(throwable);
+    if (status != null) {
+      span.addThrowable(throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
+      span.setError(
+          Config.get().getHttpServerErrorStatuses().get(status),
+          ErrorPriorities.HTTP_SERVER_DECORATOR);
+      return;
+    }
+    super.doOnError(span, throwable, errorPriority);
+  }
+
+  private static Integer extractResponseStatus(final Throwable throwable) {
+    Throwable current = throwable;
+    for (int depth = 0; current != null && depth < 5; depth++, current = current.getCause()) {
+      if (RESPONSE_STATUS_EXCEPTION_GET_STATUS != null
+          && RESPONSE_STATUS_EXCEPTION_GET_STATUS.getDeclaringClass().isInstance(current)) {
+        try {
+          Object httpStatus = RESPONSE_STATUS_EXCEPTION_GET_STATUS.invoke(current);
+          if (httpStatus instanceof HttpStatus) {
+            return ((HttpStatus) httpStatus).value();
+          }
+        } catch (Throwable ignored) {
+          // fall through to the @ResponseStatus check below
+        }
+      }
+      for (Class<?> type : new ClassHierarchyIterable(current.getClass())) {
+        ResponseStatus responseStatus = type.getAnnotation(ResponseStatus.class);
+        if (responseStatus != null) {
+          return responseStatusCode(responseStatus);
+        }
+      }
+    }
+    return null;
+  }
+
+  private static int responseStatusCode(final ResponseStatus responseStatus) {
+    if (RESPONSE_STATUS_CODE != null) {
+      try {
+        HttpStatus code = (HttpStatus) RESPONSE_STATUS_CODE.invoke(responseStatus);
+        if (code != HttpStatus.INTERNAL_SERVER_ERROR) {
+          return code.value();
+        }
+      } catch (Throwable ignored) {
+        // fall through to value() below
+      }
+    }
+    return responseStatus.value().value();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -10,6 +10,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.bootstrap.instrumentation.decorator.ConfiguredResponseStatusExceptions;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import java.lang.reflect.Method;
 import javax.servlet.Servlet;
@@ -141,6 +142,9 @@ public class SpringWebHttpServerDecorator
     // "server error" statuses, this isn't really an error from the caller's point of view (e.g. a
     // 404 mapping), even though a Java exception was thrown to get there.
     Integer status = extractResponseStatus(throwable);
+    if (status == null) {
+      status = ConfiguredResponseStatusExceptions.extractStatus(throwable);
+    }
     if (status != null) {
       span.addThrowable(throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
       span.setError(

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/main/java/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.springweb;
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
 import datadog.context.Context;
-import datadog.trace.api.Config;
 import datadog.trace.bootstrap.ClassHierarchyIterable;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -12,6 +11,7 @@ import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ConfiguredResponseStatusExceptions;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import datadog.trace.bootstrap.instrumentation.decorator.MappedExceptionStatus;
 import java.lang.reflect.Method;
 import javax.servlet.Servlet;
 import javax.servlet.http.HttpServletRequest;
@@ -145,11 +145,8 @@ public class SpringWebHttpServerDecorator
     if (status == null) {
       status = ConfiguredResponseStatusExceptions.extractStatus(throwable);
     }
-    if (status != null) {
-      span.addThrowable(throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
-      span.setError(
-          Config.get().getHttpServerErrorStatuses().get(status),
-          ErrorPriorities.HTTP_SERVER_DECORATOR);
+    if (MappedExceptionStatus.flagIfPresent(
+        span, throwable, ErrorPriorities.HTTP_SERVER_DECORATOR, status)) {
       return;
     }
     super.doOnError(span, throwable, errorPriority);
@@ -157,7 +154,9 @@ public class SpringWebHttpServerDecorator
 
   private static Integer extractResponseStatus(final Throwable throwable) {
     Throwable current = throwable;
-    for (int depth = 0; current != null && depth < 5; depth++, current = current.getCause()) {
+    for (int depth = 0;
+        current != null && depth < MappedExceptionStatus.MAX_CAUSE_CHAIN_DEPTH;
+        depth++, current = current.getCause()) {
       if (RESPONSE_STATUS_EXCEPTION_GET_STATUS != null
           && RESPONSE_STATUS_EXCEPTION_GET_STATUS.getDeclaringClass().isInstance(current)) {
         try {

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecoratorTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecoratorTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.springweb
 
 import datadog.trace.agent.test.InstrumentationSpecification
+import datadog.trace.api.config.TraceInstrumentationConfig
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.springframework.http.HttpStatus
@@ -25,6 +26,18 @@ class SpringWebHttpServerDecoratorTest extends InstrumentationSpecification {
   // setting only code() (rather than value()) exercises a separate code path.
   @ResponseStatus(code = HttpStatus.NOT_FOUND)
   static class CustomNotFoundExceptionUsingCodeAttribute extends RuntimeException {
+  }
+
+  static class CustomStatusException extends RuntimeException {
+    private final int status
+
+    CustomStatusException(int status) {
+      this.status = status
+    }
+
+    int httpCode() {
+      return status
+    }
   }
 
   def "exception with an embedded non-5xx status is not flagged as an error"() {
@@ -84,6 +97,104 @@ class SpringWebHttpServerDecoratorTest extends InstrumentationSpecification {
             "$Tags.COMPONENT" "spring-web-controller"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             errorTags(CustomServerErrorException)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "exception recognized via configured custom accessor with a non-5xx status is not flagged as an error"() {
+    setup:
+    injectSysConfig(TraceInstrumentationConfig.RESPONSE_STATUS_EXCEPTIONS, "${CustomStatusException.name}#httpCode")
+    def testSpan = AgentTracer.startSpan("spring-web-controller", "spring.handler")
+    def scope = AgentTracer.activateSpan(testSpan)
+    DECORATE.afterStart(testSpan)
+    def throwable = new CustomStatusException(404)
+
+    when:
+    DECORATE.onError(testSpan, throwable)
+    DECORATE.beforeFinish(testSpan)
+    scope.close()
+    testSpan.finish()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "spring.handler"
+          spanType "web"
+          errored false
+          tags {
+            "$Tags.COMPONENT" "spring-web-controller"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            errorTags(CustomStatusException)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "exception recognized via configured custom accessor with a 5xx status is flagged as an error"() {
+    setup:
+    injectSysConfig(TraceInstrumentationConfig.RESPONSE_STATUS_EXCEPTIONS, "${CustomStatusException.name}#httpCode")
+    def testSpan = AgentTracer.startSpan("spring-web-controller", "spring.handler")
+    def scope = AgentTracer.activateSpan(testSpan)
+    DECORATE.afterStart(testSpan)
+    def throwable = new CustomStatusException(500)
+
+    when:
+    DECORATE.onError(testSpan, throwable)
+    DECORATE.beforeFinish(testSpan)
+    scope.close()
+    testSpan.finish()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "spring.handler"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "spring-web-controller"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            errorTags(CustomStatusException)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "exception recognized via configured custom accessor with an out-of-range status falls back to normal error handling"() {
+    setup:
+    injectSysConfig(TraceInstrumentationConfig.RESPONSE_STATUS_EXCEPTIONS, "${CustomStatusException.name}#httpCode")
+    def testSpan = AgentTracer.startSpan("spring-web-controller", "spring.handler")
+    def scope = AgentTracer.activateSpan(testSpan)
+    DECORATE.afterStart(testSpan)
+    // -1 is a plausible "unknown status" sentinel a misconfigured accessor could return; it must
+    // not be used to index into the configured server-error statuses.
+    def throwable = new CustomStatusException(-1)
+
+    when:
+    DECORATE.onError(testSpan, throwable)
+    DECORATE.beforeFinish(testSpan)
+    scope.close()
+    testSpan.finish()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "spring.handler"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "spring-web-controller"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            errorTags(CustomStatusException)
             defaultTags()
           }
         }

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecoratorTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/src/test/groovy/datadog/trace/instrumentation/springweb/SpringWebHttpServerDecoratorTest.groovy
@@ -1,0 +1,124 @@
+package datadog.trace.instrumentation.springweb
+
+import datadog.trace.agent.test.InstrumentationSpecification
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+import static datadog.trace.instrumentation.springweb.SpringWebHttpServerDecorator.DECORATE
+
+// ResponseStatusException was added in Spring 5.0 and isn't available on this module's base
+// (Spring 3.1) test classpath. Its handling is covered separately, on the latestDepTest
+// classpath, by SpringWebHttpServerDecoratorLatestDepTest.
+class SpringWebHttpServerDecoratorTest extends InstrumentationSpecification {
+
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  static class CustomNotFoundException extends RuntimeException {
+  }
+
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  static class CustomServerErrorException extends RuntimeException {
+  }
+
+  // Spring's @AliasFor("value") on ResponseStatus#code isn't honored by plain reflection, so
+  // setting only code() (rather than value()) exercises a separate code path.
+  @ResponseStatus(code = HttpStatus.NOT_FOUND)
+  static class CustomNotFoundExceptionUsingCodeAttribute extends RuntimeException {
+  }
+
+  def "exception with an embedded non-5xx status is not flagged as an error"() {
+    setup:
+    def testSpan = AgentTracer.startSpan("spring-web-controller", "spring.handler")
+    def scope = AgentTracer.activateSpan(testSpan)
+    DECORATE.afterStart(testSpan)
+
+    when:
+    DECORATE.onError(testSpan, throwable)
+    DECORATE.beforeFinish(testSpan)
+    scope.close()
+    testSpan.finish()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "spring.handler"
+          spanType "web"
+          errored false
+          tags {
+            "$Tags.COMPONENT" "spring-web-controller"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            errorTags(throwable.class)
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    where:
+    throwable << [new CustomNotFoundException(), new CustomNotFoundExceptionUsingCodeAttribute()]
+  }
+
+  def "exception with an embedded 5xx status is flagged as an error"() {
+    setup:
+    def testSpan = AgentTracer.startSpan("spring-web-controller", "spring.handler")
+    def scope = AgentTracer.activateSpan(testSpan)
+    DECORATE.afterStart(testSpan)
+    def throwable = new CustomServerErrorException()
+
+    when:
+    DECORATE.onError(testSpan, throwable)
+    DECORATE.beforeFinish(testSpan)
+    scope.close()
+    testSpan.finish()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "spring.handler"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "spring-web-controller"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            errorTags(CustomServerErrorException)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "plain exception is still flagged as an error"() {
+    setup:
+    def testSpan = AgentTracer.startSpan("spring-web-controller", "spring.handler")
+    def scope = AgentTracer.activateSpan(testSpan)
+    DECORATE.afterStart(testSpan)
+    def throwable = new IllegalStateException("boom")
+
+    when:
+    DECORATE.onError(testSpan, throwable)
+    DECORATE.beforeFinish(testSpan)
+    scope.close()
+    testSpan.finish()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "spring.handler"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "spring-web-controller"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            errorTags(IllegalStateException, "boom")
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
@@ -3,7 +3,6 @@ package datadog.trace.instrumentation.springweb6;
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
 import datadog.context.Context;
-import datadog.trace.api.Config;
 import datadog.trace.bootstrap.ClassHierarchyIterable;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -12,6 +11,7 @@ import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.ConfiguredResponseStatusExceptions;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
+import datadog.trace.bootstrap.instrumentation.decorator.MappedExceptionStatus;
 import jakarta.servlet.Servlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -120,11 +120,8 @@ public class SpringWebHttpServerDecorator
     if (status == null) {
       status = ConfiguredResponseStatusExceptions.extractStatus(throwable);
     }
-    if (status != null) {
-      span.addThrowable(throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
-      span.setError(
-          Config.get().getHttpServerErrorStatuses().get(status),
-          ErrorPriorities.HTTP_SERVER_DECORATOR);
+    if (MappedExceptionStatus.flagIfPresent(
+        span, throwable, ErrorPriorities.HTTP_SERVER_DECORATOR, status)) {
       return;
     }
     super.doOnError(span, throwable, errorPriority);
@@ -132,7 +129,9 @@ public class SpringWebHttpServerDecorator
 
   private static Integer extractResponseStatus(final Throwable throwable) {
     Throwable current = throwable;
-    for (int depth = 0; current != null && depth < 5; depth++, current = current.getCause()) {
+    for (int depth = 0;
+        current != null && depth < MappedExceptionStatus.MAX_CAUSE_CHAIN_DEPTH;
+        depth++, current = current.getCause()) {
       if (current instanceof ErrorResponse) {
         HttpStatusCode statusCode = ((ErrorResponse) current).getStatusCode();
         if (statusCode != null) {

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
@@ -10,6 +10,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.bootstrap.instrumentation.decorator.ConfiguredResponseStatusExceptions;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
 import jakarta.servlet.Servlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -116,6 +117,9 @@ public class SpringWebHttpServerDecorator
     // error from the caller's point of view (e.g. a 404 mapping), even though a Java exception
     // was thrown to get there.
     Integer status = extractResponseStatus(throwable);
+    if (status == null) {
+      status = ConfiguredResponseStatusExceptions.extractStatus(throwable);
+    }
     if (status != null) {
       span.addThrowable(throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
       span.setError(

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/main/java17/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecorator.java
@@ -3,8 +3,11 @@ package datadog.trace.instrumentation.springweb6;
 import static datadog.trace.bootstrap.instrumentation.decorator.http.HttpResourceDecorator.HTTP_RESOURCE_DECORATOR;
 
 import datadog.context.Context;
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.ClassHierarchyIterable;
 import datadog.trace.bootstrap.instrumentation.api.AgentPropagation;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.ErrorPriorities;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import datadog.trace.bootstrap.instrumentation.decorator.HttpServerDecorator;
@@ -12,7 +15,11 @@ import jakarta.servlet.Servlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.lang.reflect.Method;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.HttpRequestHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.ModelAndView;
@@ -99,6 +106,54 @@ public class SpringWebHttpServerDecorator
   @Override
   protected int status(final HttpServletResponse httpServletResponse) {
     return httpServletResponse.getStatus();
+  }
+
+  @Override
+  protected void doOnError(final AgentSpan span, final Throwable throwable, byte errorPriority) {
+    // Walk the cause chain looking for a status the exception itself carries (@ResponseStatus,
+    // ResponseStatusException, or any other ErrorResponse such as NoResourceFoundException). If
+    // the mapped status isn't one of the configured "server error" statuses, this isn't really an
+    // error from the caller's point of view (e.g. a 404 mapping), even though a Java exception
+    // was thrown to get there.
+    Integer status = extractResponseStatus(throwable);
+    if (status != null) {
+      span.addThrowable(throwable, ErrorPriorities.HTTP_SERVER_DECORATOR);
+      span.setError(
+          Config.get().getHttpServerErrorStatuses().get(status),
+          ErrorPriorities.HTTP_SERVER_DECORATOR);
+      return;
+    }
+    super.doOnError(span, throwable, errorPriority);
+  }
+
+  private static Integer extractResponseStatus(final Throwable throwable) {
+    Throwable current = throwable;
+    for (int depth = 0; current != null && depth < 5; depth++, current = current.getCause()) {
+      if (current instanceof ErrorResponse) {
+        HttpStatusCode statusCode = ((ErrorResponse) current).getStatusCode();
+        if (statusCode != null) {
+          return statusCode.value();
+        }
+      }
+      for (Class<?> type : new ClassHierarchyIterable(current.getClass())) {
+        ResponseStatus responseStatus = type.getAnnotation(ResponseStatus.class);
+        if (responseStatus != null) {
+          return responseStatusCode(responseStatus);
+        }
+      }
+    }
+    return null;
+  }
+
+  private static int responseStatusCode(final ResponseStatus responseStatus) {
+    // value() and code() are @AliasFor each other, but plain reflection doesn't resolve
+    // @AliasFor: if a caller only set code(), value() still reports its own default rather than
+    // the value mirrored from code(). Prefer code() whenever it was explicitly set.
+    HttpStatus code = responseStatus.code();
+    if (code != HttpStatus.INTERNAL_SERVER_ERROR) {
+      return code.value();
+    }
+    return responseStatus.value().value();
   }
 
   @Override

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecoratorTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecoratorTest.groovy
@@ -1,0 +1,134 @@
+package datadog.trace.instrumentation.springweb6
+
+import datadog.trace.agent.test.InstrumentationSpecification
+import datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import datadog.trace.bootstrap.instrumentation.api.Tags
+import org.springframework.http.HttpStatus
+import org.springframework.web.ErrorResponseException
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.server.ResponseStatusException
+
+import static datadog.trace.instrumentation.springweb6.SpringWebHttpServerDecorator.DECORATE
+
+class SpringWebHttpServerDecoratorTest extends InstrumentationSpecification {
+
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  static class CustomNotFoundException extends RuntimeException {
+  }
+
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  static class CustomServerErrorException extends RuntimeException {
+  }
+
+  // Spring's @AliasFor("value") on ResponseStatus#code isn't honored by plain reflection, so
+  // setting only code() (rather than value()) exercises a separate code path.
+  @ResponseStatus(code = HttpStatus.NOT_FOUND)
+  static class CustomNotFoundExceptionUsingCodeAttribute extends RuntimeException {
+  }
+
+  def "exception with an embedded non-5xx status is not flagged as an error"() {
+    setup:
+    def testSpan = AgentTracer.startSpan("spring-web-controller", "spring.handler")
+    def scope = AgentTracer.activateSpan(testSpan)
+    DECORATE.afterStart(testSpan)
+
+    when:
+    DECORATE.onError(testSpan, throwable)
+    DECORATE.beforeFinish(testSpan)
+    scope.close()
+    testSpan.finish()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "spring.handler"
+          spanType "web"
+          errored false
+          tags {
+            "$Tags.COMPONENT" "spring-web-controller"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            errorTags(throwable.class, throwable.message)
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    where:
+    throwable << [
+      new CustomNotFoundException(),
+      new CustomNotFoundExceptionUsingCodeAttribute(),
+      new ResponseStatusException(HttpStatus.NOT_FOUND),
+      new ErrorResponseException(HttpStatus.NOT_FOUND)
+    ]
+  }
+
+  def "exception with an embedded 5xx status is flagged as an error"() {
+    setup:
+    def testSpan = AgentTracer.startSpan("spring-web-controller", "spring.handler")
+    def scope = AgentTracer.activateSpan(testSpan)
+    DECORATE.afterStart(testSpan)
+
+    when:
+    DECORATE.onError(testSpan, throwable)
+    DECORATE.beforeFinish(testSpan)
+    scope.close()
+    testSpan.finish()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "spring.handler"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "spring-web-controller"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            errorTags(throwable.class, throwable.message)
+            defaultTags()
+          }
+        }
+      }
+    }
+
+    where:
+    throwable << [
+      new CustomServerErrorException(),
+      new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR),
+      new ErrorResponseException(HttpStatus.INTERNAL_SERVER_ERROR)
+    ]
+  }
+
+  def "plain exception is still flagged as an error"() {
+    setup:
+    def testSpan = AgentTracer.startSpan("spring-web-controller", "spring.handler")
+    def scope = AgentTracer.activateSpan(testSpan)
+    DECORATE.afterStart(testSpan)
+    def throwable = new IllegalStateException("boom")
+
+    when:
+    DECORATE.onError(testSpan, throwable)
+    DECORATE.beforeFinish(testSpan)
+    scope.close()
+    testSpan.finish()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "spring.handler"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "spring-web-controller"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            errorTags(IllegalStateException, "boom")
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+}

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecoratorTest.groovy
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-6.0/src/test/groovy/datadog/trace/instrumentation/springweb6/SpringWebHttpServerDecoratorTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.instrumentation.springweb6
 
 import datadog.trace.agent.test.InstrumentationSpecification
+import datadog.trace.api.config.TraceInstrumentationConfig
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import org.springframework.http.HttpStatus
@@ -24,6 +25,18 @@ class SpringWebHttpServerDecoratorTest extends InstrumentationSpecification {
   // setting only code() (rather than value()) exercises a separate code path.
   @ResponseStatus(code = HttpStatus.NOT_FOUND)
   static class CustomNotFoundExceptionUsingCodeAttribute extends RuntimeException {
+  }
+
+  static class CustomStatusException extends RuntimeException {
+    private final int status
+
+    CustomStatusException(int status) {
+      this.status = status
+    }
+
+    int httpCode() {
+      return status
+    }
   }
 
   def "exception with an embedded non-5xx status is not flagged as an error"() {
@@ -99,6 +112,70 @@ class SpringWebHttpServerDecoratorTest extends InstrumentationSpecification {
       new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR),
       new ErrorResponseException(HttpStatus.INTERNAL_SERVER_ERROR)
     ]
+  }
+
+  def "exception recognized via configured custom accessor with a non-5xx status is not flagged as an error"() {
+    setup:
+    injectSysConfig(TraceInstrumentationConfig.RESPONSE_STATUS_EXCEPTIONS, "${CustomStatusException.name}#httpCode")
+    def testSpan = AgentTracer.startSpan("spring-web-controller", "spring.handler")
+    def scope = AgentTracer.activateSpan(testSpan)
+    DECORATE.afterStart(testSpan)
+    def throwable = new CustomStatusException(404)
+
+    when:
+    DECORATE.onError(testSpan, throwable)
+    DECORATE.beforeFinish(testSpan)
+    scope.close()
+    testSpan.finish()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "spring.handler"
+          spanType "web"
+          errored false
+          tags {
+            "$Tags.COMPONENT" "spring-web-controller"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            errorTags(CustomStatusException)
+            defaultTags()
+          }
+        }
+      }
+    }
+  }
+
+  def "exception recognized via configured custom accessor with a 5xx status is flagged as an error"() {
+    setup:
+    injectSysConfig(TraceInstrumentationConfig.RESPONSE_STATUS_EXCEPTIONS, "${CustomStatusException.name}#httpCode")
+    def testSpan = AgentTracer.startSpan("spring-web-controller", "spring.handler")
+    def scope = AgentTracer.activateSpan(testSpan)
+    DECORATE.afterStart(testSpan)
+    def throwable = new CustomStatusException(500)
+
+    when:
+    DECORATE.onError(testSpan, throwable)
+    DECORATE.beforeFinish(testSpan)
+    scope.close()
+    testSpan.finish()
+
+    then:
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "spring.handler"
+          spanType "web"
+          errored true
+          tags {
+            "$Tags.COMPONENT" "spring-web-controller"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            errorTags(CustomStatusException)
+            defaultTags()
+          }
+        }
+      }
+    }
   }
 
   def "plain exception is still flagged as an error"() {

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -198,6 +198,15 @@ public final class TraceInstrumentationConfig {
       "trace.jax-rs.exception-as-error.enabled";
   public static final String JAX_RS_ADDITIONAL_ANNOTATIONS = "trace.jax-rs.additional.annotations";
 
+  /**
+   * Comma-separated list of {@code fully.qualified.ExceptionClass#accessorMethod} entries. When a
+   * JAX-RS/Spring MVC handler throws an exception matching one of these entries (or a subclass of
+   * one), the named no-arg accessor method is invoked reflectively and its numeric return value is
+   * used as the HTTP status for deciding whether the span should be flagged as an error, instead of
+   * unconditionally marking it as an error.
+   */
+  public static final String RESPONSE_STATUS_EXCEPTIONS = "trace.response-status.exceptions";
+
   /** If set, the instrumentation will set its resource name on the local root too. */
   public static final String AXIS_PROMOTE_RESOURCE_NAME = "trace.axis.promote.resource-name";
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -624,6 +624,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGA
 import static datadog.trace.api.config.TraceInstrumentationConfig.RABBIT_PROPAGATION_DISABLED_QUEUES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESILIENCE4J_MEASURED_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESILIENCE4J_TAG_METRICS_ENABLED;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RESPONSE_STATUS_EXCEPTIONS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ASYNC_TIMEOUT_ERROR;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_PRINCIPAL_ENABLED;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERVLET_ROOT_CONTEXT_SERVICE_NAME;
@@ -1304,6 +1305,8 @@ public class Config {
   private final Set<String> jmsPropagationDisabledTopics;
   private final Set<String> jmsPropagationDisabledQueues;
   private final int jmsUnacknowledgedMaxAge;
+
+  private final Map<String, String> responseStatusExceptionAccessors;
 
   private final boolean rabbitPropagationEnabled;
   private final Set<String> rabbitPropagationDisabledQueues;
@@ -3097,6 +3100,8 @@ public class Config {
         tryMakeImmutableSet(configProvider.getList(JMS_PROPAGATION_DISABLED_QUEUES));
     jmsUnacknowledgedMaxAge = configProvider.getInteger(JMS_UNACKNOWLEDGED_MAX_AGE, 3600);
 
+    responseStatusExceptionAccessors = configProvider.getMergedMap(RESPONSE_STATUS_EXCEPTIONS, '#');
+
     rabbitPropagationEnabled = isPropagationEnabled(true, "rabbit", "rabbitmq");
     rabbitPropagationDisabledQueues =
         tryMakeImmutableSet(configProvider.getList(RABBIT_PROPAGATION_DISABLED_QUEUES));
@@ -3688,6 +3693,10 @@ public class Config {
 
   public Map<String, String> getResponseHeaderTags() {
     return responseHeaderTags;
+  }
+
+  public Map<String, String> getResponseStatusExceptionAccessors() {
+    return responseStatusExceptionAccessors;
   }
 
   public boolean isRequestHeaderTagsCommaAllowed() {
@@ -6809,6 +6818,8 @@ public class Config {
         + jmsPropagationDisabledTopics
         + ", jmsPropagationDisabledQueues="
         + jmsPropagationDisabledQueues
+        + ", responseStatusExceptionAccessors="
+        + responseStatusExceptionAccessors
         + ", rabbitPropagationEnabled="
         + rabbitPropagationEnabled
         + ", rabbitPropagationDisabledQueues="

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -101,6 +101,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 import static datadog.trace.api.config.TraceInstrumentationConfig.DB_CLIENT_HOST_SPLIT_BY_INSTANCE_TYPE_SUFFIX
 import static datadog.trace.api.config.TraceInstrumentationConfig.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN
+import static datadog.trace.api.config.TraceInstrumentationConfig.RESPONSE_STATUS_EXCEPTIONS
 import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ENABLED
 import static datadog.trace.api.config.TracerConfig.AGENT_HOST
@@ -1520,6 +1521,29 @@ class ConfigTest extends DDSpecification {
     ": : : : "                                                    | [:]
     "::::"                                                        | [:]
     "kEy1 :value1  \t keY2:  value2"                              | [:]
+    // spotless:on
+  }
+
+  def "verify response status exceptions config on tracer"() {
+    setup:
+    System.setProperty(PREFIX + RESPONSE_STATUS_EXCEPTIONS, propString)
+    def props = new Properties()
+    props.setProperty(RESPONSE_STATUS_EXCEPTIONS, propString)
+
+    when:
+    def config = new Config()
+    def propConfig = Config.get(props)
+
+    then:
+    config.responseStatusExceptionAccessors == expected
+    propConfig.responseStatusExceptionAccessors == expected
+
+    where:
+    // spotless:off
+    propString                                                              | expected
+    ""                                                                      | [:]
+    "some.pkg.MyException#httpCode"                                        | ["some.pkg.MyException": "httpCode"]
+    "some.pkg.MyException#httpCode,other.pkg.OtherException#getStatusCode" | ["some.pkg.MyException": "httpCode", "other.pkg.OtherException": "getStatusCode"]
     // spotless:on
   }
 

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -9577,6 +9577,14 @@
         "aliases": []
       }
     ],
+    "DD_TRACE_RESPONSE_STATUS_EXCEPTIONS": [
+      {
+        "version": "A",
+        "type": "map",
+        "default": null,
+        "aliases": []
+      }
+    ],
     "DD_TRACE_RESTEASY_ENABLED": [
       {
         "version": "A",


### PR DESCRIPTION
# What Does This Do
  - JAX-RS/Jakarta-RS: when a resource method throws a `WebApplicationException` (or a
    subclass, e.g. `NotFoundException`), the `jax-rs.request`/`jakarta-rs.request` span's
    error flag is now decided from the status embedded in the exception's `Response`,
    instead of unconditionally being marked as an error.
  - Spring MVC: same idea for `@ResponseStatus`, `ResponseStatusException`, and (Spring 6+)
    `ErrorResponse` (e.g. `NoResourceFoundException`) on the `spring-web-controller` span.
  - In both cases, the status is checked against the same "server error status" set already
    used for the root HTTP span (`DD_TRACE_HTTP_SERVER_ERROR_STATUSES`), so behavior stays
    consistent with whatever a user has already configured there.
  - Adds an opt-in `DD_TRACE_RESPONSE_STATUS_EXCEPTIONS` / `trace.response-status.exceptions`
    config for exceptions that don't follow any of the above conventions - a comma-separated
    list of `fully.qualified.ExceptionClass#accessorMethod` entries. When a thrown exception
    (or a subclass of one) matches, the named no-arg accessor is invoked reflectively and its
    numeric return value is used the same way. This is opt-in and precise on purpose: it only
    ever reflects on classes/methods a user explicitly named, rather than guessing at common
    accessor names across arbitrary exceptions (which risks silently clearing a genuine error).

# Motivation
  JAX-RS and Spring MVC commonly signal a non-2xx response by throwing an exception that the
  framework's own exception-mapping machinery turns into a normal HTTP response (e.g. a 404).
  The tracer was flagging the resource/controller span as an error unconditionally whenever
  such an exception was thrown, even though the actual HTTP response was a routine non-5xx -
  flooding error tracking with non-actionable "errors" for expected control flow. The root
  span was never affected by this (it already reflects the real status code correctly), which
  is why this showed up as a healthy root span next to an errored child span.

  Solves #7141
  Solves #7288

# Additional Notes
  - No new default behavior for exceptions that don't carry a recognizable status - they're
    still flagged as errors as before.
  - Public docs for the new `DD_TRACE_RESPONSE_STATUS_EXCEPTIONS` config will need a follow-up
    update in the Datadog docs site.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

