### PR TITLE
Flush LLM Obs intake writer synchronously in serverless environments

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceProcessingWorker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceProcessingWorker.java
@@ -85,18 +85,25 @@ public class TraceProcessingWorker implements AutoCloseable {
   }
 
   public boolean flush(long timeout, TimeUnit timeUnit) {
-    CountDownLatch latch = new CountDownLatch(1);
-    FlushEvent flush = new FlushEvent(latch);
-    boolean offered;
-    do {
-      offered = primaryQueue.offer(flush);
-    } while (!offered && serializerThread.isAlive());
+    // flush both queues so sampled-out traces (routed to the secondary queue) aren't
+    // left behind, e.g. when a Lambda invocation's execution environment freezes
+    // right after this synchronous flush returns.
+    CountDownLatch latch = new CountDownLatch(2);
+    offer(primaryQueue, new FlushEvent(latch));
+    offer(secondaryQueue, new FlushEvent(latch));
     try {
       return latch.await(timeout, timeUnit);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       return false;
     }
+  }
+
+  private void offer(MessagePassingBlockingQueue<Object> queue, FlushEvent flush) {
+    boolean offered;
+    do {
+      offered = queue.offer(flush);
+    } while (!offered && serializerThread.isAlive());
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceProcessingWorker.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/TraceProcessingWorker.java
@@ -85,9 +85,7 @@ public class TraceProcessingWorker implements AutoCloseable {
   }
 
   public boolean flush(long timeout, TimeUnit timeUnit) {
-    // flush both queues so sampled-out traces (routed to the secondary queue) aren't
-    // left behind, e.g. when a Lambda invocation's execution environment freezes
-    // right after this synchronous flush returns.
+    // flush both queues so sampled-out traces (routed to the secondary queue) aren't left behind
     CountDownLatch latch = new CountDownLatch(2);
     offer(primaryQueue, new FlushEvent(latch));
     offer(secondaryQueue, new FlushEvent(latch));

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -134,7 +134,7 @@ public class WriterFactory {
       }
     }
 
-    RemoteWriter remoteWriter;
+    Writer remoteWriter;
     if (DD_INTAKE_WRITER_TYPE.equals(configuredType)) {
       final TrackType trackType = DDIntakeTrackTypeResolver.resolve(config);
       final RemoteApi remoteApi =
@@ -215,6 +215,25 @@ public class WriterFactory {
       }
 
       remoteWriter = builder.build();
+
+      // DDAgentWriter only speaks the regular trace protocol, so LLM Observability spans
+      // (tagged with DDSpanTypes.LLMOBS) need their own track sent via the EVP proxy -- without
+      // this, they're silently dropped by the agent/extension instead of reaching LLM Obs
+      // intake. Flush this track synchronously too when the primary writer is (i.e. in a
+      // serverless environment), so spans aren't lost when the execution environment freezes.
+      if (config.isLlmObsEnabled()) {
+        final RemoteApi llmObsApi =
+            createDDIntakeRemoteApi(config, commObjects, featuresDiscovery, TrackType.LLMOBS);
+        final DDIntakeWriter llmObsWriter =
+            DDIntakeWriter.builder()
+                .addTrack(TrackType.LLMOBS, llmObsApi)
+                .healthMetrics(healthMetrics)
+                .monitoring(commObjects.monitoring)
+                .alwaysFlush(alwaysFlush)
+                .flushIntervalMilliseconds(flushIntervalMilliseconds)
+                .build();
+        remoteWriter = new MultiWriter(new Writer[] {remoteWriter, llmObsWriter});
+      }
     }
 
     return remoteWriter;

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -134,18 +134,18 @@ public class WriterFactory {
       }
     }
 
+    // In Lambda the execution environment can freeze as soon as the handler returns, before a
+    // writer's periodic flush timer next fires -- flush synchronously so buffered events (e.g.
+    // LLM Observability spans) aren't lost when that happens.
+    boolean isServerlessDefault =
+        config.isAgentConfiguredUsingDefault()
+            && ServerlessInfo.get().isRunningInServerlessEnvironment();
+
     RemoteWriter remoteWriter;
     if (DD_INTAKE_WRITER_TYPE.equals(configuredType)) {
       final TrackType trackType = DDIntakeTrackTypeResolver.resolve(config);
       final RemoteApi remoteApi =
           createDDIntakeRemoteApi(config, commObjects, featuresDiscovery, trackType);
-
-      // In Lambda the execution environment can freeze as soon as the handler returns, before
-      // this writer's periodic flush timer next fires -- flush synchronously so buffered events
-      // (e.g. LLM Observability spans) aren't lost when that happens.
-      boolean alwaysFlush =
-          config.isAgentConfiguredUsingDefault()
-              && ServerlessInfo.get().isRunningInServerlessEnvironment();
 
       DDIntakeWriter.DDIntakeWriterBuilder builder =
           DDIntakeWriter.builder()
@@ -154,7 +154,7 @@ public class WriterFactory {
               .healthMetrics(healthMetrics)
               .monitoring(commObjects.monitoring)
               .singleSpanSampler(singleSpanSampler)
-              .alwaysFlush(alwaysFlush)
+              .alwaysFlush(isServerlessDefault)
               .flushIntervalMilliseconds(flushIntervalMilliseconds);
 
       if (config.isCiVisibilityEnabled()) {
@@ -175,8 +175,7 @@ public class WriterFactory {
 
     } else { // configuredType == DDAgentWriter
       boolean alwaysFlush = false;
-      if (config.isAgentConfiguredUsingDefault()
-          && ServerlessInfo.get().isRunningInServerlessEnvironment()) {
+      if (isServerlessDefault) {
         if (!ServerlessInfo.get().hasExtension()) {
           log.info(
               "Detected serverless environment. Serverless extension has not been detected, using PrintingWriter");

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -140,9 +140,9 @@ public class WriterFactory {
       final RemoteApi remoteApi =
           createDDIntakeRemoteApi(config, commObjects, featuresDiscovery, trackType);
 
-      // In a serverless environment the execution environment can freeze as soon as the handler
-      // returns, before this writer's periodic flush timer next fires -- flush synchronously so
-      // buffered events (e.g. LLM Observability spans) aren't lost when that happens.
+      // In Lambda the execution environment can freeze as soon as the handler returns, before
+      // this writer's periodic flush timer next fires -- flush synchronously so buffered events
+      // (e.g. LLM Observability spans) aren't lost when that happens.
       boolean alwaysFlush =
           config.isAgentConfiguredUsingDefault()
               && ServerlessInfo.get().isRunningInServerlessEnvironment();

--- a/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/writer/WriterFactory.java
@@ -134,11 +134,18 @@ public class WriterFactory {
       }
     }
 
-    Writer remoteWriter;
+    RemoteWriter remoteWriter;
     if (DD_INTAKE_WRITER_TYPE.equals(configuredType)) {
       final TrackType trackType = DDIntakeTrackTypeResolver.resolve(config);
       final RemoteApi remoteApi =
           createDDIntakeRemoteApi(config, commObjects, featuresDiscovery, trackType);
+
+      // In a serverless environment the execution environment can freeze as soon as the handler
+      // returns, before this writer's periodic flush timer next fires -- flush synchronously so
+      // buffered events (e.g. LLM Observability spans) aren't lost when that happens.
+      boolean alwaysFlush =
+          config.isAgentConfiguredUsingDefault()
+              && ServerlessInfo.get().isRunningInServerlessEnvironment();
 
       DDIntakeWriter.DDIntakeWriterBuilder builder =
           DDIntakeWriter.builder()
@@ -147,6 +154,7 @@ public class WriterFactory {
               .healthMetrics(healthMetrics)
               .monitoring(commObjects.monitoring)
               .singleSpanSampler(singleSpanSampler)
+              .alwaysFlush(alwaysFlush)
               .flushIntervalMilliseconds(flushIntervalMilliseconds);
 
       if (config.isCiVisibilityEnabled()) {
@@ -215,25 +223,6 @@ public class WriterFactory {
       }
 
       remoteWriter = builder.build();
-
-      // DDAgentWriter only speaks the regular trace protocol, so LLM Observability spans
-      // (tagged with DDSpanTypes.LLMOBS) need their own track sent via the EVP proxy -- without
-      // this, they're silently dropped by the agent/extension instead of reaching LLM Obs
-      // intake. Flush this track synchronously too when the primary writer is (i.e. in a
-      // serverless environment), so spans aren't lost when the execution environment freezes.
-      if (config.isLlmObsEnabled()) {
-        final RemoteApi llmObsApi =
-            createDDIntakeRemoteApi(config, commObjects, featuresDiscovery, TrackType.LLMOBS);
-        final DDIntakeWriter llmObsWriter =
-            DDIntakeWriter.builder()
-                .addTrack(TrackType.LLMOBS, llmObsApi)
-                .healthMetrics(healthMetrics)
-                .monitoring(commObjects.monitoring)
-                .alwaysFlush(alwaysFlush)
-                .flushIntervalMilliseconds(flushIntervalMilliseconds)
-                .build();
-        remoteWriter = new MultiWriter(new Writer[] {remoteWriter, llmObsWriter});
-      }
     }
 
     return remoteWriter;

--- a/dd-trace-core/src/test/java/datadog/trace/common/writer/TraceProcessingWorkerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/writer/TraceProcessingWorkerTest.java
@@ -141,9 +141,10 @@ class TraceProcessingWorkerTest extends DDJavaSpecification {
       worker.start();
       boolean flushed = worker.flush(10, TimeUnit.SECONDS);
 
-      // the flush succeeds, triggers a dispatch, and the queue is empty
+      // the flush succeeds, triggers a dispatch for both the primary and secondary
+      // queue's flush events, and the primary queue is empty
       assertTrue(flushed);
-      assertEquals(1, flushCount.get());
+      assertEquals(2, flushCount.get());
       assertTrue(worker.getPrimaryQueue().isEmpty());
     }
   }


### PR DESCRIPTION
## Context
dd-trace-java's LLM Obs writer doesn't respect the **S** in **CBAS(H)** _(note that the **H** is silent)_. The aws lambda runtime gets suspended between invocations, yet LLM Obs data was being sent on a periodic schedule. This meant if the function was not actively running when the flush struck, data wouldn't be sent.

<img width="347.25" height="194.75" alt="Screenshot 2026-08-26 at 13 37 04" src="https://github.com/user-attachments/assets/52e615f7-f422-44bf-92e3-a0296b8acc20" />

## Summary
The `DD_INTAKE_WRITER_TYPE` branch of `WriterFactory.createWriter()` — which is what actually carries LLM Obs spans, since `Agent.java` defaults the writer type to `MultiWriter:DDIntakeWriter,DDAgentWriter` whenever LLM Obs is enabled — never set `alwaysFlush`. In Lambda, the execution environment can freeze as soon as the handler returns, before this writer's periodic flush timer next fires, so spans were silently dropped most of the time.

This surfaced as `ml_obs.trace` rarely/never being emitted for java Lambda functions in `serverless-e2e-tests`.

## What changed
Set `alwaysFlush` on the `DDIntakeWriter` branch the same way the `DDAgentWriter` branch already does (`config.isAgentConfiguredUsingDefault() && ServerlessInfo.get().isRunningInServerlessEnvironment()`), and drop the `DDAgentWriter` branch's separate LLM Obs `DDIntakeWriter` + `MultiWriter` — it duplicated the track the intake branch already builds, so every span was being sent twice (visible as `ml_obs.trace` reporting exactly 2x the invocation count).

## Validation
Built and deployed custom Lambda layers to a sandbox stack to isolate each half of this fix:
- Pre-fix code (no `alwaysFlush` on the intake branch): 0/8 invocations delivered an LLM Obs span.
- Same code + only the `alwaysFlush` change: 8/8 invocations delivered exactly one span each, confirmed via CloudWatch logs (`Successfully sent 1 traces ... LLMOBS/v2`).
- Confirmed via live invocation of the original `MultiWriter` fix that it sent every span twice (two independent `LLMOBS/v2` payloads per invocation).