### PR TITLE
Prevent duplicate Feature Flagging runtimes

### DIFF
--- a/products/feature-flagging/feature-flagging-agent/src/main/java/com/datadog/featureflag/FeatureFlaggingSystem.java
+++ b/products/feature-flagging/feature-flagging-agent/src/main/java/com/datadog/featureflag/FeatureFlaggingSystem.java
@@ -6,6 +6,7 @@ import static datadog.trace.api.featureflag.config.FeatureFlaggingConfig.CONFIGU
 import datadog.communication.ddagent.SharedCommunicationObjects;
 import datadog.trace.api.Config;
 import datadog.trace.api.featureflag.FeatureFlaggingGateway;
+import datadog.trace.api.featureflag.FeatureFlaggingGateway.RuntimeMode;
 import datadog.trace.api.featureflag.config.FeatureFlaggingConfig;
 import datadog.trace.api.featureflag.flagevaluation.FlagEvaluationWriter;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -80,6 +81,12 @@ public class FeatureFlaggingSystem {
       final SharedCommunicationObjects sco,
       final Config config,
       final SystemInitializer systemInitializer) {
+    if (!FeatureFlaggingGateway.claimRuntime(RuntimeMode.AGENT)) {
+      LOGGER.debug(
+          "Feature Flagging agent runtime not started because {} already owns the subsystem",
+          FeatureFlaggingGateway.activeRuntime());
+      return;
+    }
     try {
       systemInitializer.initialize(sco, config);
     } catch (final RuntimeException | Error e) {
@@ -180,6 +187,7 @@ public class FeatureFlaggingSystem {
     SPAN_ENRICHMENT_WRITER = null;
     EXPOSURE_WRITER = null;
     CONFIG_SERVICE = null;
+    FeatureFlaggingGateway.releaseRuntime(RuntimeMode.AGENT);
     if (activationListener != null) {
       FeatureFlaggingGateway.removeActivationListener(activationListener);
     }

--- a/products/feature-flagging/feature-flagging-agent/src/test/java/com/datadog/featureflag/FeatureFlaggingSystemTest.java
+++ b/products/feature-flagging/feature-flagging-agent/src/test/java/com/datadog/featureflag/FeatureFlaggingSystemTest.java
@@ -28,6 +28,7 @@ import datadog.remoteconfig.ConfigurationPoller;
 import datadog.remoteconfig.Product;
 import datadog.trace.api.Config;
 import datadog.trace.api.featureflag.FeatureFlaggingGateway;
+import datadog.trace.api.featureflag.FeatureFlaggingGateway.RuntimeMode;
 import datadog.trace.api.featureflag.config.FeatureFlaggingConfig;
 import datadog.trace.api.featureflag.flagevaluation.FlagEvaluationWriter;
 import datadog.trace.test.junit.utils.config.WithConfig;
@@ -86,6 +87,25 @@ class FeatureFlaggingSystemTest {
 
     verify(systemInitializer).initialize(eq(sharedCommunicationObjects), any(Config.class));
     assertFalse(FeatureFlaggingSystem.isAwaitingApplicationActivation());
+    assertSame(RuntimeMode.AGENT, FeatureFlaggingGateway.activeRuntime());
+  }
+
+  @Test
+  @WithConfig(key = FEATURE_FLAGS_CONFIGURATION_SOURCE, value = "agentless")
+  void agentlessActivationDoesNotStartWhenStandaloneRuntimeOwnsTheProcess() {
+    final SharedCommunicationObjects sharedCommunicationObjects = sharedCommunicationObjects();
+    final FeatureFlaggingSystem.SystemInitializer systemInitializer =
+        mock(FeatureFlaggingSystem.SystemInitializer.class);
+    assertTrue(FeatureFlaggingGateway.claimRuntime(RuntimeMode.STANDALONE));
+    try {
+      FeatureFlaggingSystem.start(sharedCommunicationObjects, systemInitializer);
+      FeatureFlaggingGateway.activate();
+
+      verifyNoInteractions(systemInitializer);
+      assertSame(RuntimeMode.STANDALONE, FeatureFlaggingGateway.activeRuntime());
+    } finally {
+      FeatureFlaggingGateway.releaseRuntime(RuntimeMode.STANDALONE);
+    }
   }
 
   @Test
@@ -170,6 +190,7 @@ class FeatureFlaggingSystemTest {
     FeatureFlaggingSystem.stop();
     assertFalse(FeatureFlaggingGateway.isFlagEvaluationEnqueueEnabled());
     assertNull(FeatureFlaggingGateway.getFlagEvalWriter());
+    assertNull(FeatureFlaggingGateway.activeRuntime());
     // stop() is idempotent: a second call must be a safe no-op.
     FeatureFlaggingSystem.stop();
 

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/FeatureFlaggingGateway.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/FeatureFlaggingGateway.java
@@ -89,8 +89,7 @@ public abstract class FeatureFlaggingGateway {
    */
   public static boolean claimRuntime(final RuntimeMode runtime) {
     Objects.requireNonNull(runtime, "runtime");
-    final RuntimeMode active = ACTIVE_RUNTIME.get();
-    return active == runtime || (active == null && ACTIVE_RUNTIME.compareAndSet(null, runtime));
+    return ACTIVE_RUNTIME.compareAndSet(null, runtime) || ACTIVE_RUNTIME.get() == runtime;
   }
 
   /** Releases process-wide ownership when {@code runtime} is the current owner. */

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/FeatureFlaggingGateway.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/FeatureFlaggingGateway.java
@@ -4,11 +4,17 @@ import datadog.trace.api.featureflag.exposure.ExposureEvent;
 import datadog.trace.api.featureflag.flagevaluation.FlagEvaluationWriter;
 import datadog.trace.api.featureflag.ufc.v1.ServerConfiguration;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 public abstract class FeatureFlaggingGateway {
+
+  public enum RuntimeMode {
+    AGENT,
+    STANDALONE
+  }
 
   public interface ConfigListener extends Consumer<ServerConfiguration> {}
 
@@ -28,6 +34,8 @@ public abstract class FeatureFlaggingGateway {
 
   private static final AtomicReference<ServerConfiguration> CURRENT_CONFIG =
       new AtomicReference<>();
+
+  private static final AtomicReference<RuntimeMode> ACTIVE_RUNTIME = new AtomicReference<>();
 
   /**
    * The active EVP flagevaluation writer. Registered by {@code FlagEvaluationWriterImpl.start()}
@@ -70,6 +78,29 @@ public abstract class FeatureFlaggingGateway {
   /** Signals that application code initialized the Datadog OpenFeature provider. */
   public static void activate() {
     ACTIVATION_LISTENERS.forEach(ActivationListener::activate);
+  }
+
+  /**
+   * Claims process-wide ownership of Feature Flagging configuration and event delivery.
+   *
+   * <p>The claim is idempotent for the current owner. A different runtime must not start while an
+   * owner is active because doing so would create duplicate configuration pollers and duplicate
+   * exposure or evaluation delivery.
+   */
+  public static boolean claimRuntime(final RuntimeMode runtime) {
+    Objects.requireNonNull(runtime, "runtime");
+    final RuntimeMode active = ACTIVE_RUNTIME.get();
+    return active == runtime || (active == null && ACTIVE_RUNTIME.compareAndSet(null, runtime));
+  }
+
+  /** Releases process-wide ownership when {@code runtime} is the current owner. */
+  public static void releaseRuntime(final RuntimeMode runtime) {
+    ACTIVE_RUNTIME.compareAndSet(runtime, null);
+  }
+
+  /** Returns the runtime currently responsible for configuration and event delivery. */
+  public static RuntimeMode activeRuntime() {
+    return ACTIVE_RUNTIME.get();
   }
 
   public static void addExposureListener(final ExposureListener listener) {

--- a/products/feature-flagging/feature-flagging-bootstrap/src/test/java/datadog/trace/api/featureflag/FeatureFlaggingGatewayTest.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/test/java/datadog/trace/api/featureflag/FeatureFlaggingGatewayTest.java
@@ -1,5 +1,10 @@
 package datadog.trace.api.featureflag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -41,6 +46,8 @@ class FeatureFlaggingGatewayTest {
     FeatureFlaggingGateway.removeSpanEnrichmentListener(spanEnrichmentListener);
     FeatureFlaggingGateway.setFlagEvalWriter(null);
     FeatureFlaggingGateway.setFlagEvaluationEnqueueEnabled(true);
+    FeatureFlaggingGateway.releaseRuntime(FeatureFlaggingGateway.RuntimeMode.AGENT);
+    FeatureFlaggingGateway.releaseRuntime(FeatureFlaggingGateway.RuntimeMode.STANDALONE);
   }
 
   @Test
@@ -51,6 +58,30 @@ class FeatureFlaggingGatewayTest {
 
     verify(activationListener).activate();
     verifyNoMoreInteractions(activationListener);
+  }
+
+  @Test
+  void runtimeOwnershipIsExclusiveAndIdempotent() {
+    assertNull(FeatureFlaggingGateway.activeRuntime());
+
+    assertTrue(FeatureFlaggingGateway.claimRuntime(FeatureFlaggingGateway.RuntimeMode.STANDALONE));
+    assertTrue(FeatureFlaggingGateway.claimRuntime(FeatureFlaggingGateway.RuntimeMode.STANDALONE));
+    assertFalse(FeatureFlaggingGateway.claimRuntime(FeatureFlaggingGateway.RuntimeMode.AGENT));
+    assertEquals(
+        FeatureFlaggingGateway.RuntimeMode.STANDALONE, FeatureFlaggingGateway.activeRuntime());
+
+    FeatureFlaggingGateway.releaseRuntime(FeatureFlaggingGateway.RuntimeMode.AGENT);
+    assertEquals(
+        FeatureFlaggingGateway.RuntimeMode.STANDALONE, FeatureFlaggingGateway.activeRuntime());
+
+    FeatureFlaggingGateway.releaseRuntime(FeatureFlaggingGateway.RuntimeMode.STANDALONE);
+    assertNull(FeatureFlaggingGateway.activeRuntime());
+    assertTrue(FeatureFlaggingGateway.claimRuntime(FeatureFlaggingGateway.RuntimeMode.AGENT));
+  }
+
+  @Test
+  void runtimeOwnershipRejectsNull() {
+    assertThrows(NullPointerException.class, () -> FeatureFlaggingGateway.claimRuntime(null));
   }
 
   @Test


### PR DESCRIPTION
## Motivation

Java Feature Flags is gaining two supported installation surfaces: a standalone dd-openfeature runtime and an agent-integrated runtime used by SSI. Without explicit process-wide ownership, both surfaces can start configuration polling and event delivery in the same JVM, producing duplicate requests and duplicate telemetry for customers who combine the library with the Java agent.

## Changes

The Feature Flagging gateway now records which runtime owns configuration and event delivery. Claims are exclusive and idempotent for the current owner. The agent system claims ownership immediately before initialization and releases it during shutdown, while declining to start when the standalone runtime already owns the process.

The focused gateway and agent-system tests cover exclusive claims, idempotency, release behavior, and the agentless activation path when standalone ownership already exists.

## Decisions

Ownership lives in the bootstrap gateway because it is the one process-wide object shared by the provider and agent integration. This PR intentionally does not add the standalone runtime yet; it establishes the invariant needed by the next PR in the stack. A runtime may retry its own claim, but a different runtime cannot replace the active owner.

Validation: ./gradlew :products:feature-flagging:feature-flagging-bootstrap:test :products:feature-flagging:feature-flagging-agent:test :products:feature-flagging:feature-flagging-bootstrap:spotlessCheck :products:feature-flagging:feature-flagging-agent:spotlessCheck