### PR TITLE
Remove unused Spring Boot Gradle script

### DIFF
--- a/gradle/spring-boot-plugin.gradle
+++ b/gradle/spring-boot-plugin.gradle
@@ -1,5 +1,0 @@
-// Spring Boot Gradle plugin pulls in JUnit Jupiter and JUnit Platform dependencies.
-// Depending on the version of the plugin these dependencies may not be compatible with the Spock version that is used in the tracer.
-// To ensure compatibility the versions are set explicitly here.
-ext['junit-jupiter.version'] = libs.versions.junit5.get()
-ext['junit-platform.version'] = libs.versions.junit.platform.get()


### PR DESCRIPTION
# What Does This Do

Removes an unused Spring Boot Gradle script.

# Motivation

The script has no in-tree consumers.

# Additional Notes

None.
