### PR TITLE
Add muzzle test source files

### DIFF
--- a/.gitlab/collect-result/ResultCollector.java
+++ b/.gitlab/collect-result/ResultCollector.java
@@ -50,9 +50,13 @@ final class ResultCollector {
     var targetXml = resultsDir.resolve(aggregatedName);
     System.out.print("- " + toUnixString(sourceXml) + " as " + aggregatedName);
 
-    var sourceFile = sourceFileResolver.resolve(sourceXml);
     var report = JUnitReport.parse(sourceXml);
-    var reportChangedBeforeFinalStatus = report.addFileAttribute(sourceFile);
+    var reportChangedBeforeFinalStatus = false;
+    // Muzzle tests are synthetic and already carry their instrumentation module as the source.
+    if (!isMuzzleResult(sourceXml)) {
+      reportChangedBeforeFinalStatus =
+          report.addFileAttribute(sourceFileResolver.resolve(sourceXml));
+    }
     // Before normalization: retried attempts are matched on raw classname#name (see
     // JUnitReport#tagRetriedAttempts) so distinct tests sharing a normalized name are not collapsed.
     report.tagRetriedAttempts();
@@ -121,6 +125,11 @@ final class ResultCollector {
   private static String fileName(Path path) {
     var fileName = path.getFileName();
     return fileName == null ? "" : fileName.toString();
+  }
+
+  private static boolean isMuzzleResult(Path sourceXml) {
+    var parent = sourceXml.getParent();
+    return parent != null && "muzzle".equals(fileName(parent));
   }
 
   static String toUnixString(Path path) {

--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/muzzle/MuzzlePlugin.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/muzzle/MuzzlePlugin.kt
@@ -134,6 +134,11 @@ class MuzzlePlugin : Plugin<Project> {
 
       val timingTask = project.tasks.register<MuzzleEndTask>("muzzle-end") {
         startTimeMs.set(startTime)
+        sourceFile.set(
+          project.projectDir
+            .relativeTo(project.rootProject.projectDir)
+            .invariantSeparatorsPath
+        )
         muzzleResultFiles.from(muzzleReportTasks.map { it.flatMap { task -> task.result } })
       }
       // last muzzle task to run

--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/muzzle/tasks/MuzzleEndTask.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/muzzle/tasks/MuzzleEndTask.kt
@@ -17,6 +17,9 @@ abstract class MuzzleEndTask : AbstractMuzzleTask() {
   @get:Input
   abstract val startTimeMs: Property<Long>
 
+  @get:Input
+  abstract val sourceFile: Property<String>
+
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val muzzleResultFiles: ConfigurableFileCollection
@@ -69,6 +72,7 @@ abstract class MuzzleEndTask : AbstractMuzzleTask() {
     return MuzzleJUnitReport(
       suiteName = project.path,
       module = project.path,
+      sourceFile = sourceFile.get(),
       className = "muzzle.${project.pathSlug}",
       durationSeconds = seconds,
       testCases = testCases
@@ -84,6 +88,7 @@ abstract class MuzzleEndTask : AbstractMuzzleTask() {
         writeCharacters("\n")
         writeStartElement("testsuite")
         writeAttribute("name", report.suiteName)
+        writeAttribute("file", report.sourceFile)
         writeAttribute("tests", report.testCases.size.toString())
         writeAttribute("failures", report.failures.toString())
         writeAttribute("errors", "0")
@@ -148,6 +153,7 @@ abstract class MuzzleEndTask : AbstractMuzzleTask() {
   private data class MuzzleJUnitReport(
     val suiteName: String,
     val module: String,
+    val sourceFile: String,
     val className: String,
     val durationSeconds: Double,
     val testCases: List<MuzzleJUnitCase>

--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/muzzle/tasks/MuzzleEndTask.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/muzzle/tasks/MuzzleEndTask.kt
@@ -88,7 +88,6 @@ abstract class MuzzleEndTask : AbstractMuzzleTask() {
         writeCharacters("\n")
         writeStartElement("testsuite")
         writeAttribute("name", report.suiteName)
-        writeAttribute("file", report.sourceFile)
         writeAttribute("tests", report.testCases.size.toString())
         writeAttribute("failures", report.failures.toString())
         writeAttribute("errors", "0")
@@ -113,6 +112,7 @@ abstract class MuzzleEndTask : AbstractMuzzleTask() {
           writeStartElement("testcase")
           writeAttribute("classname", report.className)
           writeAttribute("name", testCase.name)
+          writeAttribute("file", report.sourceFile)
           writeAttribute("time", "0")
           if (testCase.failureMessage != null) {
             writeCharacters("\n")

--- a/buildSrc/src/test/kotlin/datadog/gradle/plugin/muzzle/MuzzlePluginFunctionalTest.kt
+++ b/buildSrc/src/test/kotlin/datadog/gradle/plugin/muzzle/MuzzlePluginFunctionalTest.kt
@@ -85,11 +85,11 @@ class MuzzlePluginFunctionalTest : MuzzlePluginTestFixture() {
     val suite = report.documentElement
     assertThat(suite.tagName).isEqualTo("testsuite")
     assertThat(suite.getAttribute("name")).isEqualTo(":dd-java-agent:instrumentation:demo")
-    assertThat(suite.getAttribute("file")).isEqualTo("dd-java-agent/instrumentation/demo")
     assertThat(suite.getAttribute("tests")).isEqualTo("1")
     assertThat(suite.getAttribute("failures")).isEqualTo("0")
 
     val passCase = findTestCase(report, "muzzle-AssertPass-core-jdk")
+    assertThat(passCase.getAttribute("file")).isEqualTo("dd-java-agent/instrumentation/demo")
     assertThat(passCase.getElementsByTagName("failure").length).isEqualTo(0)
   }
 

--- a/buildSrc/src/test/kotlin/datadog/gradle/plugin/muzzle/MuzzlePluginFunctionalTest.kt
+++ b/buildSrc/src/test/kotlin/datadog/gradle/plugin/muzzle/MuzzlePluginFunctionalTest.kt
@@ -85,6 +85,7 @@ class MuzzlePluginFunctionalTest : MuzzlePluginTestFixture() {
     val suite = report.documentElement
     assertThat(suite.tagName).isEqualTo("testsuite")
     assertThat(suite.getAttribute("name")).isEqualTo(":dd-java-agent:instrumentation:demo")
+    assertThat(suite.getAttribute("file")).isEqualTo("dd-java-agent/instrumentation/demo")
     assertThat(suite.getAttribute("tests")).isEqualTo("1")
     assertThat(suite.getAttribute("failures")).isEqualTo("0")
 

--- a/buildSrc/src/test/kotlin/datadog/gradle/plugin/muzzle/tasks/MuzzleEndTaskTest.kt
+++ b/buildSrc/src/test/kotlin/datadog/gradle/plugin/muzzle/tasks/MuzzleEndTaskTest.kt
@@ -78,8 +78,10 @@ class MuzzleEndTaskTest {
   }
 
   @Test
-  fun `junit report contains project source path`() {
-    assertThat(junitDoc.documentElement.getAttribute("file"))
+  fun `junit testcases contain project source path`() {
+    assertThat(findTestCaseByName(junitDoc, "muzzle-pass").getAttribute("file"))
+      .isEqualTo("lettuce-5.0")
+    assertThat(findTestCaseByName(junitDoc, "muzzle-fail").getAttribute("file"))
       .isEqualTo("lettuce-5.0")
   }
 

--- a/buildSrc/src/test/kotlin/datadog/gradle/plugin/muzzle/tasks/MuzzleEndTaskTest.kt
+++ b/buildSrc/src/test/kotlin/datadog/gradle/plugin/muzzle/tasks/MuzzleEndTaskTest.kt
@@ -48,6 +48,7 @@ class MuzzleEndTaskTest {
 
     val task = project.tasks.register<MuzzleEndTask>("muzzle-end").get().apply {
       startTimeMs.set(System.currentTimeMillis() - 1_000)
+      sourceFile.set("lettuce-5.0")
       muzzleResultFiles.from(passReportPath.toFile(), failReportPath.toFile())
     }
 
@@ -74,6 +75,12 @@ class MuzzleEndTaskTest {
     assertThat(suite.getAttribute("failures")).isEqualTo("1")
     assertThat(suite.getAttribute("errors")).isEqualTo("0")
     assertThat(suite.getAttribute("skipped")).isEqualTo("0")
+  }
+
+  @Test
+  fun `junit report contains project source path`() {
+    assertThat(junitDoc.documentElement.getAttribute("file"))
+      .isEqualTo("lettuce-5.0")
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do

Add test source files for Muzzle tests for CI/CD Optimization reporting reasons

# Motivation

Currently Muzzle tests are listed with UNKNOWN as their test source file in CI/CD Optimization ([example](https://app.datadoghq.com/ci/ci-cd/explorer?query=test_level%3Atest%20%40git.repository.id_v2%3Agithub.com%2Fdatadog%2Fdd-trace-java%20%40git.branch%3Amaster%20%40test.source.file%3AUNKNOWN&agg_m=count&agg_m_source=base&agg_t=count&bits_chat_id=3b4ed21b-e59e-47d2-83e3-9e32c37831e6&ci_cd_explorer_tab=tests&citest_explorer_sort=%40test.source.file%2Casc&cols=%40test.status%2Ctimestamp%2C%40test.suite%2C%40test.name%2C%40duration%2C%40test.service%2C%40git.branch%2C%40test.codeowners%2C%40test.source.file&currentTab=overview&eventStack=&fromUser=false&refresh_mode=sliding&start=1787239962774&end=1787326362774&paused=false)). Instead, assign their proper source file so that related dependent metrics such as codeowners are correct as well.

# Additional Notes

We can see the results in CI Optimization here:
* SHA without working test source files: https://app.datadoghq.com/ci/ci-cd/explorer?query=test_level%3Atest%20%40git.repository.id_v2%3Agithub.com%2Fdatadog%2Fdd-trace-java%20%40git.branch%3Asarahchen6%2Fadd-muzzle-test-sourcefiles%20%40git.commit.sha%3Af6f49b2b7d11239ccc16fede27d774069fc96dd8%20%40test.name%3Amuzzle%2A&agg_m=count&agg_m_source=base&agg_t=count&ci_cd_explorer_tab=tests&citest_explorer_sort=%40test.source.file%2Casc&cols=%40test.status%2Ctimestamp%2C%40test.suite%2C%40test.name%2C%40duration%2C%40test.service%2C%40git.branch%2C%40test.codeowners%2C%40test.source.file&currentTab=overview&eventStack=&fromUser=false&refresh_mode=sliding&start=1787246271997&end=1787332671997&paused=false
* SHA with working test source files: https://app.datadoghq.com/ci/ci-cd/explorer?query=test_level%3Atest%20%40git.repository.id_v2%3Agithub.com%2Fdatadog%2Fdd-trace-java%20%40git.branch%3Asarahchen6%2Fadd-muzzle-test-sourcefiles%20%40git.commit.sha%3Acd2d2cc0d000126f4412dd5ae71356e5fc06b376%20%40test.name%3Amuzzle%2A&agg_m=count&agg_m_source=base&agg_t=count&ci_cd_explorer_tab=tests&citest_explorer_sort=%40test.source.file%2Casc&cols=%40test.status%2Ctimestamp%2C%40test.suite%2C%40test.name%2C%40duration%2C%40test.service%2C%40git.branch%2C%40test.codeowners%2C%40test.source.file&currentTab=overview&eventStack=&fromUser=false&refresh_mode=sliding&start=1787252005430&end=1787338405430&paused=false
* Final SHA in the commit history: https://app.datadoghq.com/ci/ci-cd/explorer?query=test_level%3Atest%20%40git.repository.id_v2%3Agithub.com%2Fdatadog%2Fdd-trace-java%20%40git.branch%3Asarahchen6%2Fadd-muzzle-test-sourcefiles%20%40git.commit.sha%3Aa19bdfd1a0074029405d5ec94db6cbdd5c038075%20%40test.name%3Amuzzle%2A&agg_m=count&agg_m_source=base&agg_t=count&ci_cd_explorer_tab=tests&citest_explorer_sort=%40test.source.file%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40test.suite%2C%40test.name%2C%40duration%2C%40test.service%2C%40git.branch%2C%40test.codeowners%2C%40test.source.file&currentTab=overview&eventStack=&fromUser=false&refresh_mode=sliding&start=1787075756002&end=1787680556002&paused=false

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
