### PR TITLE
Fix Flaky annotation for JUnit5 forked tests

### DIFF
--- a/buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts
+++ b/buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts
@@ -55,7 +55,7 @@ tasks.withType<Test>().configureEach {
 
   // Split up tests that want to run forked in their own separate JVM for generated tasks
   if (name.startsWith("forkedTest") || name.endsWith("ForkedTest")) {
-    useJUnitPlatform()
+    // useJUnitPlatform()
     setExcludes(emptyList())
     setIncludes(listOf("**/*ForkedTest*"))
     forkEvery = 1

--- a/buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts
+++ b/buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts
@@ -55,7 +55,7 @@ tasks.withType<Test>().configureEach {
 
   // Split up tests that want to run forked in their own separate JVM for generated tasks
   if (name.startsWith("forkedTest") || name.endsWith("ForkedTest")) {
-    // useJUnitPlatform()
+    useJUnitPlatform()
     setExcludes(emptyList())
     setIncludes(listOf("**/*ForkedTest*"))
     forkEvery = 1

--- a/buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts
+++ b/buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts
@@ -2,7 +2,6 @@ import org.gradle.api.plugins.jvm.JvmTestSuite
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.api.tasks.testing.Test
-import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions
 import org.gradle.kotlin.dsl.develocity
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.withType
@@ -104,7 +103,7 @@ tasks.named("check") {
 
 tasks.withType<Test>().configureEach {
   // Flaky tests management for JUnit 5
-  (options as? JUnitPlatformOptions)?.apply {
+  useJUnitPlatform {
     if (skipFlakyTestsProvider.isPresent) {
       excludeTags("flaky")
     } else if (runFlakyTestsProvider.isPresent) {

--- a/buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts
+++ b/buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts
@@ -2,6 +2,7 @@ import org.gradle.api.plugins.jvm.JvmTestSuite
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions
 import org.gradle.kotlin.dsl.develocity
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.withType
@@ -54,6 +55,7 @@ tasks.withType<Test>().configureEach {
 
   // Split up tests that want to run forked in their own separate JVM for generated tasks
   if (name.startsWith("forkedTest") || name.endsWith("ForkedTest")) {
+    useJUnitPlatform()
     setExcludes(emptyList())
     setIncludes(listOf("**/*ForkedTest*"))
     forkEvery = 1
@@ -103,7 +105,7 @@ tasks.named("check") {
 
 tasks.withType<Test>().configureEach {
   // Flaky tests management for JUnit 5
-  useJUnitPlatform {
+  (options as? JUnitPlatformOptions)?.apply {
     if (skipFlakyTestsProvider.isPresent) {
       excludeTags("flaky")
     } else if (runFlakyTestsProvider.isPresent) {

--- a/dd-trace-core/src/test/java/datadog/trace/core/scopemanager/IterationSpansForkedTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/scopemanager/IterationSpansForkedTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import datadog.metrics.api.statsd.StatsDClient;
@@ -16,7 +15,6 @@ import datadog.trace.core.CoreTracer;
 import datadog.trace.core.DDCoreJavaSpecification;
 import datadog.trace.core.DDSpan;
 import datadog.trace.test.junit.utils.config.WithConfig;
-import datadog.trace.test.util.Flaky;
 import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -40,14 +38,6 @@ class IterationSpansForkedTest extends DDCoreJavaSpecification {
   @AfterEach
   void cleanup() throws Exception {
     tracer.close();
-  }
-
-  @Flaky("Temporary verification that flaky JUnit 5 tests are excluded from forkedTest")
-  @Test
-  void flakyMarkerIsHonoredForForkedTests() {
-    if ("false".equals(System.getProperty("run.flaky.tests"))) {
-      fail("Flaky test was executed even though -PskipFlakyTests was specified");
-    }
   }
 
   @Test

--- a/dd-trace-core/src/test/java/datadog/trace/core/scopemanager/IterationSpansForkedTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/scopemanager/IterationSpansForkedTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import datadog.metrics.api.statsd.StatsDClient;
@@ -15,6 +16,7 @@ import datadog.trace.core.CoreTracer;
 import datadog.trace.core.DDCoreJavaSpecification;
 import datadog.trace.core.DDSpan;
 import datadog.trace.test.junit.utils.config.WithConfig;
+import datadog.trace.test.util.Flaky;
 import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -38,6 +40,14 @@ class IterationSpansForkedTest extends DDCoreJavaSpecification {
   @AfterEach
   void cleanup() throws Exception {
     tracer.close();
+  }
+
+  @Flaky("Temporary verification that flaky JUnit 5 tests are excluded from forkedTest")
+  @Test
+  void flakyMarkerIsHonoredForForkedTests() {
+    if ("false".equals(System.getProperty("run.flaky.tests"))) {
+      fail("Flaky test was executed even though -PskipFlakyTests was specified");
+    }
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do

Fix `@Flaky` annotation that is not working on JUnit 5 forked tests by triggering `useJUnitPlatform()` for forked tests before the `@Flaky` annotation is assessed here: https://github.com/DataDog/dd-trace-java/blob/master/buildSrc/src/main/kotlin/dd-trace-java.configure-tests.gradle.kts#L107

# Motivation

`@Flaky`-annotated forked tests should only run flaky test jobs

# Additional Notes

I tested this fix with a flaky-annotated failing test in `dd-trace-core/src/test/java/datadog/trace/core/scopemanager/IterationSpansForkedTest.java`.

* Flaky forked test with no fix fails: 0b43e2b0c91943fce6ae3d98d39d808e3e272306, [CI/CD Explorer](https://app.datadoghq.com/ci/ci-cd/explorer?query=test_level%3Atest%20%40test.service%3Add-trace-java%20%40ci.pipeline.id%3A132500935%20%40test.name%3AflakyMarkerIsHonoredForForkedTests%2A&agg_m=count&agg_m_source=base&agg_t=count&ci_cd_explorer_tab=tests&currentTab=overview&eventStack=&fromUser=false&refresh_mode=sliding&repository=dd-trace-java&taskExecutionId=1974056661&taskId=gitlab&start=1786744605516&end=1787349405516&paused=false), [test example that failed](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/jobs/1974056665)
* Flaky forked test with fix succeeds: d2643208dbb2125df08841668201b3f851906807, [CI/CD Explorer](https://app.datadoghq.com/ci/ci-cd/explorer?query=test_level%3Atest%20%40test.service%3Add-trace-java%20%40ci.pipeline.id%3A132509895%20%40test.name%3AflakyMarkerIsHonoredForForkedTests%2A&agg_m=count&agg_m_source=base&agg_t=count&ci_cd_explorer_tab=tests&currentTab=overview&eventStack=&fromUser=false&refresh_mode=sliding&repository=dd-trace-java&taskExecutionId=1974056661&taskId=gitlab&start=1786744605516&end=1787349405516&paused=false), [same test example that passes](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/jobs/1974172277)

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
