### PR TITLE
docs: fix broken source links in instrumentation guides

### DIFF
--- a/docs/add_new_instrumentation.md
+++ b/docs/add_new_instrumentation.md
@@ -1,7 +1,7 @@
 # Add a New Instrumentation
 
 Now we will step through adding a very basic instrumentation to the trace agent. The
-existing [google-http-client instrumentation](../dd-java-agent/instrumentation/google-http-client)
+existing [google-http-client instrumentation](../dd-java-agent/instrumentation/google-http-client-1.19)
 will be used as an example.
 
 ## Clone the dd-trace-java repo
@@ -161,7 +161,7 @@ When applying multiple advices, consider using the `@AppliesOn` annotation to co
 ## Add the HeadersInjectAdapter
 
 This particular instrumentation uses
-a [HeadersInjectAdapter](../dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/HeadersInjectAdapter.java)
+a [HeadersInjectAdapter](../dd-java-agent/instrumentation/google-http-client-1.19/src/main/java/datadog/trace/instrumentation/googlehttpclient/HeadersInjectAdapter.java)
 class to assist with HTTP header injection. This is not required of all instrumentations. (
 See [InjectorAdapters](./how_instrumentations_work.md#injectadapters--custom-getterssetters)).
 
@@ -487,11 +487,11 @@ The `check` task runs `verifyAgentJarIntegrations` automatically, so CI will fai
 is out of date.
 
 All integrations must include sufficient test coverage. This HTTP client integration will include
-a [standard HTTP test class](../dd-java-agent/instrumentation/google-http-client/src/test/groovy/GoogleHttpClientTest.groovy)
+a [standard HTTP test class](../dd-java-agent/instrumentation/google-http-client-1.19/src/test/groovy/GoogleHttpClientTest.groovy)
 and
-an [async HTTP test class](../dd-java-agent/instrumentation/google-http-client/src/test/groovy/GoogleHttpClientAsyncTest.groovy).
+an [async HTTP test class](../dd-java-agent/instrumentation/google-http-client-1.19/src/test/groovy/GoogleHttpClientAsyncTest.groovy).
 Both test classes inherit
-from [HttpClientTest](../dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy)
+from [HttpClientTest](../dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy)
 which provides a testing framework used by many HTTP client integrations. (
 see [Testing](./how_instrumentations_work.md#testing))
 

--- a/docs/how_instrumentations_work.md
+++ b/docs/how_instrumentations_work.md
@@ -965,7 +965,7 @@ Implement `JavaModuleOpenProvider` when:
 Tests are written in Groovy using the [Spock framework](http://spockframework.org).
 For instrumentations, `InstrumentationSpecification` must be extended.
 For example, HTTP server frameworks use base tests which enforce consistency between different implementations
-(see [HttpServerTest](../dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy)).
+(see [HttpServerTest](../dd-java-agent/instrumentation-testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy)).
 When writing an instrumentation it is much faster to test just the instrumentation rather than build the entire project,
 for example:
 


### PR DESCRIPTION
Fixes links in the instrumentation guides that point at paths which no longer exist. Verified against the current tree on `master`.

**Current-tree links corrected**

- `dd-java-agent/instrumentation/google-http-client/` → `google-http-client-1.19/` (the module directory carries the version suffix) — 4 links in `docs/add_new_instrumentation.md`, including the bare directory link on line 4.
- `dd-java-agent/testing/` → `dd-java-agent/instrumentation-testing/` for the shared test base classes — `add_new_instrumentation.md` and `how_instrumentations_work.md`.

**Pinned-SHA links deliberately NOT changed**

Lines 191–192 link into the fixed snapshot `5307b46fe3956f0d1f09f84e1dab580af222ddc5`. That commit predates the rename, so the correct path *there* is still `google-http-client`. I verified both against raw.githubusercontent at that SHA:

| path @ 5307b46 | result |
|---|---|
| `.../instrumentation/google-http-client/...` | 200 |
| `.../instrumentation/google-http-client-1.19/...` | 404 |

My first revision wrongly rewrote those two as well, which would have broken them. Thanks to the review bot for catching it — now reverted, so historical links resolve inside their snapshot and current-tree links resolve on `master`.