### PR TITLE
Fix redaction marker for log template

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/MoshiSnapshotHelper.java
@@ -49,6 +49,7 @@ public class MoshiSnapshotHelper {
   public static final String DEPTH_REASON = "depth";
   public static final String REDACTED_IDENT_REASON = "redactedIdent";
   public static final String REDACTED_TYPE_REASON = "redactedType";
+  public static final String REDACTED_STRING = "redacted";
   public static final String TYPE = "type";
   public static final String VALUE = "value";
   public static final String FIELDS = "fields";

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/StringTokenWriter.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/util/StringTokenWriter.java
@@ -1,7 +1,6 @@
 package com.datadog.debugger.util;
 
-import static com.datadog.debugger.util.MoshiSnapshotHelper.REDACTED_IDENT_REASON;
-import static com.datadog.debugger.util.MoshiSnapshotHelper.REDACTED_TYPE_REASON;
+import static com.datadog.debugger.util.MoshiSnapshotHelper.REDACTED_STRING;
 import static com.datadog.debugger.util.MoshiSnapshotHelper.TIMEOUT_REASON;
 
 import com.datadog.debugger.el.Value;
@@ -173,10 +172,10 @@ public class StringTokenWriter implements SerializerWithLimits.TokenWriter {
         sb.append(", ...");
         break;
       case REDACTED_IDENT:
-        sb.append('{').append(REDACTED_IDENT_REASON).append('}');
+        sb.append('{').append(REDACTED_STRING).append('}');
         break;
       case REDACTED_TYPE:
-        sb.append('{').append(REDACTED_TYPE_REASON).append('}');
+        sb.append('{').append(REDACTED_STRING).append('}');
         break;
       default:
         throw new RuntimeException("Unsupported NotCapturedReason: " + reason);


### PR DESCRIPTION
# What Does This Do
replace redatedIdent and redactedType to 'redacted'

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [DEBUG-5958]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-5958]: https://datadoghq.atlassian.net/browse/DEBUG-5958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ