### PR TITLE
Fix span enrichment singleton initialization

### DIFF
--- a/dd-smoke-tests/openfeature/src/test/groovy/datadog/smoketest/springboot/OpenFeatureProviderSmokeTest.groovy
+++ b/dd-smoke-tests/openfeature/src/test/groovy/datadog/smoketest/springboot/OpenFeatureProviderSmokeTest.groovy
@@ -100,6 +100,9 @@ class OpenFeatureProviderSmokeTest extends AbstractServerSmokeTest {
       span.parentId == 0 &&
         span.meta['ffe_runtime_defaults'] == '{"flag-that-does-not-exist":"fallback"}'
     }
+
+    cleanup:
+    response.close()
   }
 
   void 'test open feature exposures'() {

--- a/dd-smoke-tests/openfeature/src/test/groovy/datadog/smoketest/springboot/OpenFeatureProviderSmokeTest.groovy
+++ b/dd-smoke-tests/openfeature/src/test/groovy/datadog/smoketest/springboot/OpenFeatureProviderSmokeTest.groovy
@@ -42,8 +42,14 @@ class OpenFeatureProviderSmokeTest extends AbstractServerSmokeTest {
     command.addAll(['-jar', springBootShadowJar, "--server.port=${httpPort}".toString()])
     final builder = new ProcessBuilder(command).directory(new File(buildDirectory))
     builder.environment().put('DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED', 'true')
+    builder.environment().put('DD_EXPERIMENTAL_FLAGGING_PROVIDER_SPAN_ENRICHMENT_ENABLED', 'true')
     builder.environment().put('DD_FEATURE_FLAGS_CONFIGURATION_SOURCE', 'remote_config')
     return builder
+  }
+
+  @Override
+  Closure decodedTracesCallback() {
+    return {}
   }
 
   @Override
@@ -69,6 +75,31 @@ class OpenFeatureProviderSmokeTest extends AbstractServerSmokeTest {
     decodeProducts(firstRcRequest).find { it == Product.FFE_FLAGS } != null
     final capabilities = decodeCapabilities(firstRcRequest)
     hasCapability(capabilities, Capabilities.CAPABILITY_FFE_FLAG_CONFIGURATION_RULES)
+  }
+
+  void 'test open feature evaluation enriches the request span'() {
+    setup:
+    setRemoteConfig("datadog/2/FFE_FLAGS/1/config", rcPayload)
+    final request = new Request.Builder()
+      .url("http://localhost:${httpPort}/openfeature/evaluate")
+      .post(RequestBody.create(MediaType.parse('application/json'), JsonOutput.toJson([
+        flag: 'flag-that-does-not-exist',
+        variationType: 'STRING',
+        defaultValue: 'fallback',
+        targetingKey: 'span-enrichment-smoke-test'
+      ])))
+      .build()
+
+    when:
+    final response = client.newCall(request).execute()
+
+    then:
+    response.code() == 200
+    new JsonSlurper().parse(response.body().byteStream()).value == 'fallback'
+    waitForSpan(defaultPoll) { span ->
+      span.parentId == 0 &&
+        span.meta['ffe_runtime_defaults'] == '{"flag-that-does-not-exist":"fallback"}'
+    }
   }
 
   void 'test open feature exposures'() {

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/SpanEnrichmentWriter.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/SpanEnrichmentWriter.java
@@ -5,7 +5,6 @@ import datadog.trace.api.featureflag.FeatureFlaggingGateway;
 import datadog.trace.api.featureflag.SpanEnrichmentEvent;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,14 +32,6 @@ import org.slf4j.LoggerFactory;
  *
  * <p>All work is wrapped in try/catch — enrichment must NEVER break flag evaluation.
  */
-@SuppressFBWarnings(
-    value = "SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR",
-    justification =
-        "The production path constructs the sole instance through the private no-arg constructor "
-            + "behind INSTANCE/getInstance(); the package-private constructors are deliberate "
-            + "test-only seams for injecting the root-span resolver and interceptor registrar. The "
-            + "singleton itself is required (PR #11658 review) so the single, unremovable trace "
-            + "interceptor is registered exactly once and survives subsystem start/stop.")
 public final class SpanEnrichmentWriter
     implements FeatureFlaggingGateway.SpanEnrichmentListener, AutoCloseable {
 

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/SpanEnrichmentWriter.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/SpanEnrichmentWriter.java
@@ -46,12 +46,8 @@ public final class SpanEnrichmentWriter
 
   private static final Logger log = LoggerFactory.getLogger(SpanEnrichmentWriter.class);
 
-  // The one instance used by the agent. Persisting it across FeatureFlaggingSystem start/stop keeps
-  // the single registered interceptor (and its state) alive, so a restart never re-registers.
-  private static final SpanEnrichmentWriter INSTANCE = new SpanEnrichmentWriter();
-
   public static SpanEnrichmentWriter getInstance() {
-    return INSTANCE;
+    return SingletonHolder.INSTANCE;
   }
 
   /**
@@ -84,6 +80,12 @@ public final class SpanEnrichmentWriter
 
   private static final InterceptorRegistrar DEFAULT_REGISTRAR =
       interceptor -> GlobalTracer.get().addTraceInterceptor(interceptor);
+
+  private static final class SingletonHolder {
+    // Persisting this instance across FeatureFlaggingSystem start/stop keeps the single registered
+    // interceptor (and its state) alive, so a restart never re-registers.
+    private static final SpanEnrichmentWriter INSTANCE = new SpanEnrichmentWriter();
+  }
 
   private final RootSpanResolver rootSpanResolver;
   private final InterceptorRegistrar registrar;
@@ -192,5 +194,13 @@ public final class SpanEnrichmentWriter
 
   SpanEnrichmentInterceptor interceptor() {
     return interceptor;
+  }
+
+  RootSpanResolver rootSpanResolver() {
+    return rootSpanResolver;
+  }
+
+  InterceptorRegistrar registrar() {
+    return registrar;
   }
 }

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/SpanEnrichmentWriterTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/SpanEnrichmentWriterTest.java
@@ -126,6 +126,13 @@ class SpanEnrichmentWriterTest {
   }
 
   @Test
+  void agentSingletonUsesProductionDependencies() {
+    final SpanEnrichmentWriter writer = SpanEnrichmentWriter.getInstance();
+    assertNotNull(writer.rootSpanResolver());
+    assertNotNull(writer.registrar());
+  }
+
+  @Test
   void resolveLocalRootLogic() {
     assertNull(SpanEnrichmentWriter.resolveLocalRoot(null));
 


### PR DESCRIPTION
# What Does This Do

- Initializes SpanEnrichmentWriter lazily after its production resolver and interceptor registrar.
- Adds a regression test for the production singleton dependencies.
- Adds OpenFeature smoke coverage that verifies runtime-default enrichment on a traced request.

# Motivation

Feature-flag evaluations succeed, but span enrichment silently fails because the eager singleton captures null dependencies during static initialization. The failure is visible in debug logs as:

```text
DEBUG com.datadog.featureflag.SpanEnrichmentWriter - Span-enrichment accumulation failed
NullPointerException: Cannot invoke RootSpanResolver.activeLocalRoot()
because this.rootSpanResolver is null
```

Consequently, span-enrichment events were dropped, and traces were emitted without the expected feature-flag tags.

# Additional Notes

- The existing experimental span-enrichment gate remains unchanged.
- Focused unit and OpenFeature smoke tests pass after rebasing onto master.
- Verified ingestion of traces from the dogfooding app running the Java SDK
<img width="478" height="268" alt="Screenshot 2026-08-24 at 6 56 38 AM" src="https://github.com/user-attachments/assets/cccf2386-b22c-4efe-99ea-8a452e4356d6" />

# Contributor Checklist

- Title follows the contribution guidelines.
- Component and change-type labels are assigned.
- No CODEOWNERS or public configuration documentation changes are required.

Jira ticket: [FFL-3090](https://datadoghq.atlassian.net/browse/FFL-3090)

[FFL-3090]: https://datadoghq.atlassian.net/browse/FFL-3090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
