### PR TITLE
feat(feature-flags): support updated FFE fixtures

### DIFF
--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -454,9 +454,9 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
   }
 
   private static boolean matchesShard(final Shard shard, final String targetingKey) {
-    final long assignedShard = getShard(shard.salt, targetingKey, shard.totalShards);
+    final long assignedShard = getShard(shard.salt, targetingKey, shard.unsignedTotalShards());
     for (final ShardRange range : shard.ranges) {
-      if (assignedShard >= range.start && assignedShard < range.end) {
+      if (assignedShard >= range.unsignedStart() && assignedShard < range.unsignedEnd()) {
         return true;
       }
     }

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -173,18 +173,11 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
       final Flag flag = config.flags.get(key);
       if (flag == null) {
         if (config.invalidFlags != null && config.invalidFlags.containsKey(key)) {
-          if ("invalid_semver_comparand".equals(config.invalidFlags.get(key))) {
-            return error(
-                defaultValue,
-                ErrorCode.PARSE_ERROR,
-                "invalid configuration for flag " + key,
-                observeFullEvaluationData);
-          }
-          return ProviderEvaluation.<T>builder()
-              .value(defaultValue)
-              .reason(Reason.DEFAULT.name())
-              .flagMetadata(consentMetadata(observeFullEvaluationData))
-              .build();
+          return error(
+              defaultValue,
+              ErrorCode.PARSE_ERROR,
+              "invalid configuration for flag " + key,
+              observeFullEvaluationData);
         }
         return error(defaultValue, ErrorCode.FLAG_NOT_FOUND, null, observeFullEvaluationData);
       }
@@ -461,7 +454,7 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
   }
 
   private static boolean matchesShard(final Shard shard, final String targetingKey) {
-    final int assignedShard = getShard(shard.salt, targetingKey, shard.totalShards);
+    final long assignedShard = getShard(shard.salt, targetingKey, shard.totalShards);
     for (final ShardRange range : shard.ranges) {
       if (assignedShard >= range.start && assignedShard < range.end) {
         return true;
@@ -470,12 +463,13 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
     return false;
   }
 
-  private static int getShard(final String salt, final String targetingKey, final int totalShards) {
+  private static long getShard(
+      final String salt, final String targetingKey, final long totalShards) {
     final String hashKey = salt + "-" + targetingKey;
     final String md5Hash = getMD5Hash(hashKey);
     final String first8Chars = md5Hash.substring(0, Math.min(8, md5Hash.length()));
     final long intFromHash = Long.parseLong(first8Chars, 16);
-    return (int) (intFromHash % totalShards);
+    return intFromHash % totalShards;
   }
 
   private static String getMD5Hash(final String input) {

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -33,6 +33,8 @@ import datadog.trace.api.featureflag.ufc.v1.Flag;
 import datadog.trace.api.featureflag.ufc.v1.ParsedSemver;
 import datadog.trace.api.featureflag.ufc.v1.Rule;
 import datadog.trace.api.featureflag.ufc.v1.ServerConfiguration;
+import datadog.trace.api.featureflag.ufc.v1.Shard;
+import datadog.trace.api.featureflag.ufc.v1.ShardRange;
 import datadog.trace.api.featureflag.ufc.v1.Split;
 import datadog.trace.api.featureflag.ufc.v1.ValueType;
 import datadog.trace.api.featureflag.ufc.v1.Variant;
@@ -550,7 +552,7 @@ public class DDEvaluatorTest {
       Arguments.of(ConditionOperator.SEMVER_EQ, "1.0.0+linux", "1.0.0+darwin", true),
       // Invalid attribute does not match
       Arguments.of(ConditionOperator.SEMVER_NEQ, "not-a-version", "1.0.0", false),
-      Arguments.of(ConditionOperator.SEMVER_GTE, "1.2", "1.0.0", false),
+      Arguments.of(ConditionOperator.SEMVER_GTE, "1.2", "1.0.0", true),
       Arguments.of(ConditionOperator.SEMVER_GTE, "v1.2.3", "1.0.0", false),
       Arguments.of(ConditionOperator.SEMVER_GTE, "18446744073709551616.0.0", "1.0.0", false),
       // Non-string attribute does not match
@@ -886,7 +888,7 @@ public class DDEvaluatorTest {
       if (flag.allocations == null) {
         continue;
       }
-      boolean invalid = false;
+      boolean invalid = hasInvalidStructure(flag);
       for (final Allocation allocation : flag.allocations) {
         if (allocation.rules == null) {
           continue;
@@ -925,7 +927,7 @@ public class DDEvaluatorTest {
       }
       if (invalid) {
         flagsToRemove.put(flagKey, flag);
-        invalidFlags.put(flagKey, "invalid_semver_comparand");
+        invalidFlags.put(flagKey, "invalid_flag");
       }
     }
     for (final String flagKey : flagsToRemove.keySet()) {
@@ -934,6 +936,59 @@ public class DDEvaluatorTest {
     if (!invalidFlags.isEmpty()) {
       config.invalidFlags = invalidFlags;
     }
+  }
+
+  private static boolean hasInvalidStructure(final Flag flag) {
+    for (final Allocation allocation : flag.allocations) {
+      if (allocation == null) {
+        return true;
+      }
+      if (allocation.splits != null) {
+        for (final Split split : allocation.splits) {
+          if (split == null || split.shards == null) {
+            return true;
+          }
+          for (final Shard shard : split.shards) {
+            if (shard == null
+                || shard.totalShards <= 0
+                || shard.totalShards > 0xFFFFFFFFL
+                || shard.ranges == null) {
+              return true;
+            }
+            for (final ShardRange range : shard.ranges) {
+              if (range == null || range.start < 0 || range.end < 0) {
+                return true;
+              }
+            }
+          }
+        }
+      }
+      if (allocation.rules != null) {
+        for (final Rule rule : allocation.rules) {
+          if (rule.conditions == null) {
+            continue;
+          }
+          for (final ConditionConfiguration condition : rule.conditions) {
+            if (condition == null || condition.operator == null) {
+              return true;
+            }
+            if ((condition.operator == ConditionOperator.IS_NULL
+                    && !(condition.value instanceof Boolean))
+                || ((condition.operator == ConditionOperator.ONE_OF
+                        || condition.operator == ConditionOperator.NOT_ONE_OF)
+                    && !(condition.value instanceof Iterable))
+                || ((condition.operator == ConditionOperator.GTE
+                        || condition.operator == ConditionOperator.GT
+                        || condition.operator == ConditionOperator.LTE
+                        || condition.operator == ConditionOperator.LT)
+                    && !(condition.value instanceof Number))) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+    return false;
   }
 
   private static List<FixtureCase> canonicalTestCases() throws IOException {
@@ -1079,10 +1134,10 @@ public class DDEvaluatorTest {
         final Object rawFlag = reader.readJsonValue();
         try {
           final Flag flag = flagAdapter.fromJsonValue(rawFlag);
-          if (flag != null) {
-            validateFlag(flagKey, flag);
-            flags.put(flagKey, flag);
+          if (flag == null || hasInvalidStructure(flag)) {
+            throw new IllegalArgumentException("flag \"" + flagKey + "\" could not be parsed");
           }
+          flags.put(flagKey, flag);
         } catch (JsonDataException | IllegalArgumentException ignored) {
           INVALID_FLAGS_HOLDER.get().put(flagKey, "invalid_flag");
           // A malformed flag must not prevent valid flags in the same configuration from loading.

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -59,6 +59,8 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -999,7 +1001,10 @@ public class DDEvaluatorTest {
                         || condition.operator == ConditionOperator.GT
                         || condition.operator == ConditionOperator.LTE
                         || condition.operator == ConditionOperator.LT)
-                    && !(condition.value instanceof Number))) {
+                    && !(condition.value instanceof Number))
+                || ((condition.operator == ConditionOperator.MATCHES
+                        || condition.operator == ConditionOperator.NOT_MATCHES)
+                    && !isValidRegex(condition.value))) {
               return true;
             }
           }
@@ -1007,6 +1012,28 @@ public class DDEvaluatorTest {
       }
     }
     return false;
+  }
+
+  private static boolean isValidRegex(final Object value) {
+    if (!(value instanceof String)) {
+      return false;
+    }
+    try {
+      Pattern.compile(normalizeRegex((String) value));
+      return true;
+    } catch (final PatternSyntaxException ignored) {
+      return false;
+    }
+  }
+
+  private static String normalizeRegex(final String regex) {
+    return regex
+        .replace("[:alnum:]", "\\p{Alnum}")
+        .replace("[:alpha:]", "\\p{Alpha}")
+        .replace("[:digit:]", "\\p{Digit}")
+        .replace("[:lower:]", "\\p{Lower}")
+        .replace("[:upper:]", "\\p{Upper}")
+        .replace("[:space:]", "\\p{Space}");
   }
 
   private static List<FixtureCase> canonicalTestCases() throws IOException {

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -894,7 +894,12 @@ public class DDEvaluatorTest {
       if (flag.allocations == null) {
         continue;
       }
-      boolean invalid = hasInvalidStructure(flag);
+      if (hasInvalidStructure(flag)) {
+        flagsToRemove.put(flagKey, flag);
+        invalidFlags.put(flagKey, "invalid_flag");
+        continue;
+      }
+      boolean invalid = false;
       for (final Allocation allocation : flag.allocations) {
         if (allocation.rules == null) {
           continue;
@@ -964,7 +969,9 @@ public class DDEvaluatorTest {
             for (final ShardRange range : shard.ranges) {
               if (range == null
                   || range.unsignedStart() > 0xFFFFFFFFL
-                  || range.unsignedEnd() > 0xFFFFFFFFL) {
+                  || range.unsignedEnd() > 0xFFFFFFFFL
+                  || range.unsignedStart() >= range.unsignedEnd()
+                  || range.unsignedEnd() > shard.unsignedTotalShards()) {
                 return true;
               }
             }
@@ -973,8 +980,11 @@ public class DDEvaluatorTest {
       }
       if (allocation.rules != null) {
         for (final Rule rule : allocation.rules) {
-          if (rule == null || rule.conditions == null) {
+          if (rule == null) {
             return true;
+          }
+          if (rule.conditions == null) {
+            continue;
           }
           for (final ConditionConfiguration condition : rule.conditions) {
             if (condition == null || condition.operator == null) {

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -61,6 +61,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -71,7 +73,11 @@ public class DDEvaluatorTest {
   private static final String CANONICAL_FIXTURE_PATH =
       "dd-smoke-tests/openfeature/src/test/resources/ffe-system-test-data";
   private static final Moshi MOSHI =
-      new Moshi.Builder().add(Date.class, new DateAdapter()).add(FlagMapAdapter.FACTORY).build();
+      new Moshi.Builder()
+          .add(Date.class, new DateAdapter())
+          .add(Shard.class, new UnsignedShardAdapter())
+          .add(FlagMapAdapter.FACTORY)
+          .build();
   private static final JsonAdapter<ServerConfiguration> CONFIG_ADAPTER =
       MOSHI.adapter(ServerConfiguration.class);
   private static final Type FIXTURE_LIST_TYPE =
@@ -950,17 +956,15 @@ public class DDEvaluatorTest {
           }
           for (final Shard shard : split.shards) {
             if (shard == null
-                || shard.totalShards <= 0
-                || shard.totalShards > 0xFFFFFFFFL
+                || shard.unsignedTotalShards() == 0
+                || shard.unsignedTotalShards() > 0xFFFFFFFFL
                 || shard.ranges == null) {
               return true;
             }
             for (final ShardRange range : shard.ranges) {
               if (range == null
-                  || range.start < 0
-                  || range.start > 0xFFFFFFFFL
-                  || range.end < 0
-                  || range.end > 0xFFFFFFFFL) {
+                  || range.unsignedStart() > 0xFFFFFFFFL
+                  || range.unsignedEnd() > 0xFFFFFFFFL) {
                 return true;
               }
             }
@@ -1105,6 +1109,61 @@ public class DDEvaluatorTest {
     String errorCode;
     String variant;
     Map<String, Object> flagMetadata = emptyMap();
+  }
+
+  /**
+   * Parses unsigned 32-bit shard values into their binary-compatible {@code int} representation.
+   */
+  private static final class UnsignedShardAdapter extends JsonAdapter<Shard> {
+    @Nullable
+    @Override
+    @SuppressWarnings("unchecked")
+    public Shard fromJson(@Nonnull final JsonReader reader) throws IOException {
+      final Object rawShard = reader.readJsonValue();
+      if (rawShard == null) {
+        return null;
+      }
+      if (!(rawShard instanceof Map)) {
+        throw new JsonDataException("Shard must be an object");
+      }
+      final Map<String, Object> shard = (Map<String, Object>) rawShard;
+      final Object rawRanges = shard.get("ranges");
+      if (!(rawRanges instanceof List)) {
+        throw new JsonDataException("Shard ranges must be an array");
+      }
+      final List<ShardRange> ranges = new ArrayList<>();
+      for (final Object rawRange : (List<?>) rawRanges) {
+        if (!(rawRange instanceof Map)) {
+          throw new JsonDataException("Shard range must be an object");
+        }
+        final Map<String, Object> range = (Map<String, Object>) rawRange;
+        ranges.add(
+            new ShardRange(
+                unsignedInt(range.get("start"), "start"), unsignedInt(range.get("end"), "end")));
+      }
+      final Object rawSalt = shard.get("salt");
+      return new Shard(
+          rawSalt == null ? null : String.valueOf(rawSalt),
+          ranges,
+          unsignedInt(shard.get("totalShards"), "totalShards"));
+    }
+
+    @Override
+    public void toJson(@Nonnull final JsonWriter writer, @Nullable final Shard value) {
+      throw new UnsupportedOperationException("Reading only adapter");
+    }
+
+    private static int unsignedInt(final Object rawValue, final String field) {
+      if (!(rawValue instanceof Number)) {
+        throw new JsonDataException(field + " must be an unsigned 32-bit integer");
+      }
+      final Number number = (Number) rawValue;
+      final long value = number.longValue();
+      if (number.doubleValue() != value || value < 0 || value > 0xFFFFFFFFL) {
+        throw new JsonDataException(field + " must be an unsigned 32-bit integer");
+      }
+      return (int) value;
+    }
   }
 
   /** Reads the flags map with per-flag failure isolation, matching the production parser. */

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -894,7 +894,7 @@ public class DDEvaluatorTest {
           continue;
         }
         for (final Rule rule : allocation.rules) {
-          if (rule.conditions == null) {
+          if (rule == null || rule.conditions == null) {
             continue;
           }
           for (final ConditionConfiguration condition : rule.conditions) {
@@ -956,7 +956,11 @@ public class DDEvaluatorTest {
               return true;
             }
             for (final ShardRange range : shard.ranges) {
-              if (range == null || range.start < 0 || range.end < 0) {
+              if (range == null
+                  || range.start < 0
+                  || range.start > 0xFFFFFFFFL
+                  || range.end < 0
+                  || range.end > 0xFFFFFFFFL) {
                 return true;
               }
             }
@@ -965,8 +969,8 @@ public class DDEvaluatorTest {
       }
       if (allocation.rules != null) {
         for (final Rule rule : allocation.rules) {
-          if (rule.conditions == null) {
-            continue;
+          if (rule == null || rule.conditions == null) {
+            return true;
           }
           for (final ConditionConfiguration condition : rule.conditions) {
             if (condition == null || condition.operator == null) {

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemver.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemver.java
@@ -1,5 +1,7 @@
 package datadog.trace.api.featureflag.ufc.v1;
 
+import java.util.Arrays;
+
 /**
  * ParsedSemver is the language-neutral representation of the SemVer subset used by FFE. Owning this
  * parser and comparator keeps behavior consistent across SDKs and lets configuration preprocessing
@@ -15,15 +17,11 @@ public final class ParsedSemver {
   /** Sentinel returned by {@link #parse(String)} when the input is not a valid semantic version. */
   public static final ParsedSemver INVALID = null;
 
-  private final long major; // unsigned
-  private final long minor; // unsigned
-  private final long patch; // unsigned
+  private final long[] core; // unsigned, with omitted minor and patch normalized to zero
   private final String prerelease;
 
-  ParsedSemver(final long major, final long minor, final long patch, final String prerelease) {
-    this.major = major;
-    this.minor = minor;
-    this.patch = patch;
+  ParsedSemver(final long[] core, final String prerelease) {
+    this.core = core;
     this.prerelease = prerelease;
   }
 
@@ -35,45 +33,32 @@ public final class ParsedSemver {
    *     version
    */
   public static ParsedSemver parse(final String version) {
-    // Parse major
-    final long[] majorResult = parseCoreIdentifier(version, 0);
-    if (majorResult == null) {
-      return INVALID;
+    long[] parsedCore = new long[3];
+    int coreSize = 0;
+    int next = 0;
+    while (true) {
+      final long[] component = parseCoreIdentifier(version, next);
+      if (component == null) {
+        return INVALID;
+      }
+      if (coreSize == parsedCore.length) {
+        parsedCore = Arrays.copyOf(parsedCore, parsedCore.length * 2);
+      }
+      parsedCore[coreSize++] = component[0];
+      next = (int) component[1];
+      if (next == version.length() || version.charAt(next) != '.') {
+        break;
+      }
+      next++;
     }
-    final long major = majorResult[0];
-    int next = (int) majorResult[1];
-    if (next >= version.length() || version.charAt(next) != '.') {
-      return INVALID;
-    }
-
-    // Parse minor
-    final long[] minorResult = parseCoreIdentifier(version, next + 1);
-    if (minorResult == null) {
-      return INVALID;
-    }
-    final long minor = minorResult[0];
-    next = (int) minorResult[1];
-    if (next >= version.length() || version.charAt(next) != '.') {
-      return INVALID;
-    }
-
-    // Parse patch
-    final long[] patchResult = parseCoreIdentifier(version, next + 1);
-    if (patchResult == null) {
-      return INVALID;
-    }
-    final long patch = patchResult[0];
-    next = (int) patchResult[1];
-
-    final ParsedSemver parsed = new ParsedSemver(major, minor, patch, "");
+    final long[] core = Arrays.copyOf(parsedCore, Math.max(3, coreSize));
     if (next == version.length()) {
-      return parsed;
+      return new ParsedSemver(core, "");
     }
 
-    // Parse prerelease and/or build metadata
+    // Parse prerelease and/or build metadata.
     String remainder = version.substring(next);
     String prerelease = "";
-
     if (remainder.charAt(0) == '-') {
       remainder = remainder.substring(1);
       final int buildStart = remainder.indexOf('+');
@@ -81,10 +66,8 @@ public final class ParsedSemver {
         if (!validSemverIdentifiers(remainder, false)) {
           return INVALID;
         }
-        prerelease = remainder;
-        return new ParsedSemver(major, minor, patch, prerelease);
+        return new ParsedSemver(core, remainder);
       }
-
       prerelease = remainder.substring(0, buildStart);
       if (!validSemverIdentifiers(prerelease, false)) {
         return INVALID;
@@ -95,11 +78,10 @@ public final class ParsedSemver {
     } else {
       return INVALID;
     }
-
     if (!validSemverIdentifiers(remainder, true)) {
       return INVALID;
     }
-    return new ParsedSemver(major, minor, patch, prerelease);
+    return new ParsedSemver(core, prerelease);
   }
 
   /**
@@ -111,17 +93,14 @@ public final class ParsedSemver {
    *     {@code right}, zero if they have equal precedence
    */
   public static int compare(final ParsedSemver left, final ParsedSemver right) {
-    int cmp = Long.compareUnsigned(left.major, right.major);
-    if (cmp != 0) {
-      return cmp;
-    }
-    cmp = Long.compareUnsigned(left.minor, right.minor);
-    if (cmp != 0) {
-      return cmp;
-    }
-    cmp = Long.compareUnsigned(left.patch, right.patch);
-    if (cmp != 0) {
-      return cmp;
+    final int coreLength = Math.max(left.core.length, right.core.length);
+    for (int i = 0; i < coreLength; i++) {
+      final long leftComponent = i < left.core.length ? left.core[i] : 0;
+      final long rightComponent = i < right.core.length ? right.core[i] : 0;
+      final int cmp = Long.compareUnsigned(leftComponent, rightComponent);
+      if (cmp != 0) {
+        return cmp;
+      }
     }
     return comparePrerelease(left.prerelease, right.prerelease);
   }
@@ -269,15 +248,15 @@ public final class ParsedSemver {
   // --- Accessors for testing ---
 
   long getMajor() {
-    return major;
+    return core[0];
   }
 
   long getMinor() {
-    return minor;
+    return core[1];
   }
 
   long getPatch() {
-    return patch;
+    return core[2];
   }
 
   String getPrerelease() {
@@ -293,23 +272,23 @@ public final class ParsedSemver {
       return false;
     }
     final ParsedSemver that = (ParsedSemver) o;
-    return major == that.major
-        && minor == that.minor
-        && patch == that.patch
-        && prerelease.equals(that.prerelease);
+    return Arrays.equals(core, that.core) && prerelease.equals(that.prerelease);
   }
 
   @Override
   public int hashCode() {
-    int result = Long.hashCode(major);
-    result = 31 * result + Long.hashCode(minor);
-    result = 31 * result + Long.hashCode(patch);
-    result = 31 * result + prerelease.hashCode();
-    return result;
+    return 31 * Arrays.hashCode(core) + prerelease.hashCode();
   }
 
   @Override
   public String toString() {
-    return major + "." + minor + "." + patch + (prerelease.isEmpty() ? "" : "-" + prerelease);
+    final StringBuilder value = new StringBuilder();
+    for (int i = 0; i < core.length; i++) {
+      if (i > 0) {
+        value.append('.');
+      }
+      value.append(Long.toUnsignedString(core[i]));
+    }
+    return value.append(prerelease.isEmpty() ? "" : "-" + prerelease).toString();
   }
 }

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemver.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemver.java
@@ -1,7 +1,5 @@
 package datadog.trace.api.featureflag.ufc.v1;
 
-import java.util.Arrays;
-
 /**
  * ParsedSemver is the language-neutral representation of the SemVer subset used by FFE. Owning this
  * parser and comparator keeps behavior consistent across SDKs and lets configuration preprocessing
@@ -17,11 +15,30 @@ public final class ParsedSemver {
   /** Sentinel returned by {@link #parse(String)} when the input is not a valid semantic version. */
   public static final ParsedSemver INVALID = null;
 
-  private final long[] core; // unsigned, with omitted minor and patch normalized to zero
+  private static final int MAX_CORE_PARTS = 5;
+
+  private final long major; // unsigned
+  private final long minor; // unsigned
+  private final long patch; // unsigned
+  private final long fourth; // unsigned
+  private final long fifth; // unsigned
+  private final int coreLength;
   private final String prerelease;
 
-  ParsedSemver(final long[] core, final String prerelease) {
-    this.core = core;
+  ParsedSemver(
+      final long major,
+      final long minor,
+      final long patch,
+      final long fourth,
+      final long fifth,
+      final int coreLength,
+      final String prerelease) {
+    this.major = major;
+    this.minor = minor;
+    this.patch = patch;
+    this.fourth = fourth;
+    this.fifth = fifth;
+    this.coreLength = coreLength;
     this.prerelease = prerelease;
   }
 
@@ -33,27 +50,55 @@ public final class ParsedSemver {
    *     version
    */
   public static ParsedSemver parse(final String version) {
-    long[] parsedCore = new long[3];
+    long major = 0;
+    long minor = 0;
+    long patch = 0;
+    long fourth = 0;
+    long fifth = 0;
     int coreSize = 0;
     int next = 0;
     while (true) {
-      final long[] component = parseCoreIdentifier(version, next);
-      if (component == null) {
+      final int end = coreIdentifierEnd(version, next);
+      if (end == -1) {
         return INVALID;
       }
-      if (coreSize == parsedCore.length) {
-        parsedCore = Arrays.copyOf(parsedCore, parsedCore.length * 2);
+      final long component;
+      try {
+        component = Long.parseUnsignedLong(version.substring(next, end));
+      } catch (final NumberFormatException e) {
+        return INVALID; // overflow
       }
-      parsedCore[coreSize++] = component[0];
-      next = (int) component[1];
+      switch (coreSize++) {
+        case 0:
+          major = component;
+          break;
+        case 1:
+          minor = component;
+          break;
+        case 2:
+          patch = component;
+          break;
+        case 3:
+          fourth = component;
+          break;
+        case 4:
+          fifth = component;
+          break;
+        default:
+          return INVALID;
+      }
+      next = end;
       if (next == version.length() || version.charAt(next) != '.') {
         break;
       }
+      if (coreSize == MAX_CORE_PARTS) {
+        return INVALID;
+      }
       next++;
     }
-    final long[] core = Arrays.copyOf(parsedCore, Math.max(3, coreSize));
+    final int coreLength = Math.max(3, coreSize);
     if (next == version.length()) {
-      return new ParsedSemver(core, "");
+      return new ParsedSemver(major, minor, patch, fourth, fifth, coreLength, "");
     }
 
     // Parse prerelease and/or build metadata.
@@ -66,7 +111,7 @@ public final class ParsedSemver {
         if (!validSemverIdentifiers(remainder, false)) {
           return INVALID;
         }
-        return new ParsedSemver(core, remainder);
+        return new ParsedSemver(major, minor, patch, fourth, fifth, coreLength, remainder);
       }
       prerelease = remainder.substring(0, buildStart);
       if (!validSemverIdentifiers(prerelease, false)) {
@@ -81,7 +126,7 @@ public final class ParsedSemver {
     if (!validSemverIdentifiers(remainder, true)) {
       return INVALID;
     }
-    return new ParsedSemver(core, prerelease);
+    return new ParsedSemver(major, minor, patch, fourth, fifth, coreLength, prerelease);
   }
 
   /**
@@ -93,11 +138,9 @@ public final class ParsedSemver {
    *     {@code right}, zero if they have equal precedence
    */
   public static int compare(final ParsedSemver left, final ParsedSemver right) {
-    final int coreLength = Math.max(left.core.length, right.core.length);
+    final int coreLength = Math.max(left.coreLength, right.coreLength);
     for (int i = 0; i < coreLength; i++) {
-      final long leftComponent = i < left.core.length ? left.core[i] : 0;
-      final long rightComponent = i < right.core.length ? right.core[i] : 0;
-      final int cmp = Long.compareUnsigned(leftComponent, rightComponent);
+      final int cmp = Long.compareUnsigned(left.coreComponent(i), right.coreComponent(i));
       if (cmp != 0) {
         return cmp;
       }
@@ -106,28 +149,38 @@ public final class ParsedSemver {
   }
 
   /**
-   * Parses a core version identifier (major, minor, or patch). Enforces the unsigned 64-bit bound
-   * without accepting leading zeros (except for the value zero itself).
-   *
-   * @return a two-element array {@code {value, nextIndex}}, or {@code null} on failure
+   * Finds the end of a core version identifier (major, minor, or patch), rejecting leading zeros
+   * except for the value zero itself.
    */
-  private static long[] parseCoreIdentifier(final String version, final int start) {
+  private static int coreIdentifierEnd(final String version, final int start) {
     if (start >= version.length() || !isASCIIDigit(version.charAt(start))) {
-      return null;
+      return -1;
     }
     if (version.charAt(start) == '0') {
-      return new long[] {0, start + 1};
+      return start + 1;
     }
 
     int end = start;
     while (end < version.length() && isASCIIDigit(version.charAt(end))) {
       end++;
     }
-    try {
-      final long value = Long.parseUnsignedLong(version.substring(start, end));
-      return new long[] {value, end};
-    } catch (final NumberFormatException e) {
-      return null; // overflow
+    return end;
+  }
+
+  private long coreComponent(final int index) {
+    switch (index) {
+      case 0:
+        return major;
+      case 1:
+        return minor;
+      case 2:
+        return patch;
+      case 3:
+        return fourth;
+      case 4:
+        return fifth;
+      default:
+        return 0;
     }
   }
 
@@ -248,15 +301,15 @@ public final class ParsedSemver {
   // --- Accessors for testing ---
 
   long getMajor() {
-    return core[0];
+    return major;
   }
 
   long getMinor() {
-    return core[1];
+    return minor;
   }
 
   long getPatch() {
-    return core[2];
+    return patch;
   }
 
   String getPrerelease() {
@@ -272,22 +325,34 @@ public final class ParsedSemver {
       return false;
     }
     final ParsedSemver that = (ParsedSemver) o;
-    return Arrays.equals(core, that.core) && prerelease.equals(that.prerelease);
+    return major == that.major
+        && minor == that.minor
+        && patch == that.patch
+        && fourth == that.fourth
+        && fifth == that.fifth
+        && coreLength == that.coreLength
+        && prerelease.equals(that.prerelease);
   }
 
   @Override
   public int hashCode() {
-    return 31 * Arrays.hashCode(core) + prerelease.hashCode();
+    int result = Long.hashCode(major);
+    result = 31 * result + Long.hashCode(minor);
+    result = 31 * result + Long.hashCode(patch);
+    result = 31 * result + Long.hashCode(fourth);
+    result = 31 * result + Long.hashCode(fifth);
+    result = 31 * result + coreLength;
+    return 31 * result + prerelease.hashCode();
   }
 
   @Override
   public String toString() {
     final StringBuilder value = new StringBuilder();
-    for (int i = 0; i < core.length; i++) {
+    for (int i = 0; i < coreLength; i++) {
       if (i > 0) {
         value.append('.');
       }
-      value.append(Long.toUnsignedString(core[i]));
+      value.append(Long.toUnsignedString(coreComponent(i)));
     }
     return value.append(prerelease.isEmpty() ? "" : "-" + prerelease).toString();
   }

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/Shard.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/Shard.java
@@ -13,6 +13,10 @@ public class Shard {
     this.totalShards = totalShards;
   }
 
+  /**
+   * Returns {@link #totalShards} as the unsigned 32-bit value used in FFE configurations. The
+   * {@code int}-backed field remains public for compatibility with existing UFC model consumers.
+   */
   public long unsignedTotalShards() {
     return Integer.toUnsignedLong(totalShards);
   }

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/Shard.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/Shard.java
@@ -5,11 +5,15 @@ import java.util.List;
 public class Shard {
   public final String salt;
   public final List<ShardRange> ranges;
-  public final long totalShards;
+  public final int totalShards;
 
-  public Shard(final String salt, final List<ShardRange> ranges, final long totalShards) {
+  public Shard(final String salt, final List<ShardRange> ranges, final int totalShards) {
     this.salt = salt;
     this.ranges = ranges;
     this.totalShards = totalShards;
+  }
+
+  public long unsignedTotalShards() {
+    return Integer.toUnsignedLong(totalShards);
   }
 }

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/Shard.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/Shard.java
@@ -5,9 +5,9 @@ import java.util.List;
 public class Shard {
   public final String salt;
   public final List<ShardRange> ranges;
-  public final int totalShards;
+  public final long totalShards;
 
-  public Shard(final String salt, final List<ShardRange> ranges, final int totalShards) {
+  public Shard(final String salt, final List<ShardRange> ranges, final long totalShards) {
     this.salt = salt;
     this.ranges = ranges;
     this.totalShards = totalShards;

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ShardRange.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ShardRange.java
@@ -1,10 +1,10 @@
 package datadog.trace.api.featureflag.ufc.v1;
 
 public class ShardRange {
-  public final int start;
-  public final int end;
+  public final long start;
+  public final long end;
 
-  public ShardRange(final int start, final int end) {
+  public ShardRange(final long start, final long end) {
     this.start = start;
     this.end = end;
   }

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ShardRange.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ShardRange.java
@@ -1,11 +1,19 @@
 package datadog.trace.api.featureflag.ufc.v1;
 
 public class ShardRange {
-  public final long start;
-  public final long end;
+  public final int start;
+  public final int end;
 
-  public ShardRange(final long start, final long end) {
+  public ShardRange(final int start, final int end) {
     this.start = start;
     this.end = end;
+  }
+
+  public long unsignedStart() {
+    return Integer.toUnsignedLong(start);
+  }
+
+  public long unsignedEnd() {
+    return Integer.toUnsignedLong(end);
   }
 }

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ShardRange.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ShardRange.java
@@ -9,10 +9,18 @@ public class ShardRange {
     this.end = end;
   }
 
+  /**
+   * Returns {@link #start} as the unsigned 32-bit value used in FFE configurations. The {@code
+   * int}-backed field remains public for compatibility with existing UFC model consumers.
+   */
   public long unsignedStart() {
     return Integer.toUnsignedLong(start);
   }
 
+  /**
+   * Returns {@link #end} as the unsigned 32-bit value used in FFE configurations. The {@code
+   * int}-backed field remains public for compatibility with existing UFC model consumers.
+   */
   public long unsignedEnd() {
     return Integer.toUnsignedLong(end);
   }

--- a/products/feature-flagging/feature-flagging-bootstrap/src/test/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemverTest.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/test/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemverTest.java
@@ -50,9 +50,6 @@ class ParsedSemverTest {
     return Stream.of(
         "",
         "x",
-        "1",
-        "1.2",
-        "1.2.3.4",
         "v1.2.3",
         "01.2.3",
         "1.02.3",
@@ -94,6 +91,16 @@ class ParsedSemverTest {
     "1.1.0",
     "2.0.0",
   };
+
+  @Test
+  void normalizesMissingCorePartsAndComparesExtendedCoreParts() {
+    assertEquals(0, ParsedSemver.compare(ParsedSemver.parse("18"), ParsedSemver.parse("18.0.0")));
+    assertEquals(0, ParsedSemver.compare(ParsedSemver.parse("18.0"), ParsedSemver.parse("18.0.0")));
+    assertTrue(
+        ParsedSemver.compare(ParsedSemver.parse("18.0.0.0"), ParsedSemver.parse("17.0.0")) > 0);
+    assertTrue(
+        ParsedSemver.compare(ParsedSemver.parse("18.0.0.0.0"), ParsedSemver.parse("17.0.0")) > 0);
+  }
 
   @Test
   void testCompareSemverOrdering() {

--- a/products/feature-flagging/feature-flagging-bootstrap/src/test/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemverTest.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/test/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemverTest.java
@@ -96,6 +96,14 @@ class ParsedSemverTest {
   void normalizesMissingCorePartsAndComparesExtendedCoreParts() {
     assertEquals(0, ParsedSemver.compare(ParsedSemver.parse("18"), ParsedSemver.parse("18.0.0")));
     assertEquals(0, ParsedSemver.compare(ParsedSemver.parse("18.0"), ParsedSemver.parse("18.0.0")));
+    assertEquals(
+        0, ParsedSemver.compare(ParsedSemver.parse("1.2.3"), ParsedSemver.parse("1.2.3.0")));
+    assertEquals(
+        0, ParsedSemver.compare(ParsedSemver.parse("1.2.3"), ParsedSemver.parse("1.2.3.0.0")));
+    assertTrue(
+        ParsedSemver.compare(ParsedSemver.parse("1.2.3.4"), ParsedSemver.parse("1.2.3.5")) < 0);
+    assertTrue(
+        ParsedSemver.compare(ParsedSemver.parse("1.2.3.4.5"), ParsedSemver.parse("1.2.3.4.6")) < 0);
     assertTrue(
         ParsedSemver.compare(ParsedSemver.parse("18.0.0.0"), ParsedSemver.parse("17.0.0")) > 0);
     assertTrue(

--- a/products/feature-flagging/feature-flagging-bootstrap/src/test/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemverTest.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/test/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemverTest.java
@@ -64,6 +64,7 @@ class ParsedSemverTest {
         "1.2.3-01",
         "1.2.3-alpha_1",
         "1.2.3-alpha+build+other",
+        "1.2.3.4.5.6",
         "1.2.3-α",
         " 1.2.3",
         "1.2.3 ");

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
@@ -28,6 +28,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import okio.BufferedSource;
@@ -169,6 +171,17 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
                 throw invalidConditionOperand(flagKey, condition.operator);
               }
               break;
+            case MATCHES:
+            case NOT_MATCHES:
+              if (!(value instanceof String)) {
+                throw invalidConditionOperand(flagKey, condition.operator);
+              }
+              try {
+                Pattern.compile(normalizeRegex((String) value));
+              } catch (final PatternSyntaxException ignored) {
+                throw invalidConditionOperand(flagKey, condition.operator);
+              }
+              break;
             default:
               break;
           }
@@ -181,6 +194,16 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
       final String flagKey, final ConditionOperator operator) {
     return new InvalidFlagException(
         "flag \"" + flagKey + "\" has an invalid operand for operator \"" + operator + "\"");
+  }
+
+  private static String normalizeRegex(final String regex) {
+    return regex
+        .replace("[:alnum:]", "\\p{Alnum}")
+        .replace("[:alpha:]", "\\p{Alpha}")
+        .replace("[:digit:]", "\\p{Digit}")
+        .replace("[:lower:]", "\\p{Lower}")
+        .replace("[:upper:]", "\\p{Upper}")
+        .replace("[:space:]", "\\p{Space}");
   }
 
   /**
@@ -326,8 +349,8 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
   }
 
   /**
-   * Preserves the binary-compatible {@code int} representation of shard values while accepting
-   * their unsigned 32-bit JSON form.
+   * Preserves the existing public {@code int}-backed UFC model fields while accepting their
+   * unsigned 32-bit JSON form.
    */
   static final class ShardAdapter extends JsonAdapter<Shard> {
 

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
@@ -116,8 +116,11 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
           if (shard == null || shard.unsignedTotalShards() == 0 || shard.ranges == null) {
             throw new InvalidFlagException("flag \"" + flagKey + "\" contains an invalid shard");
           }
+          final long totalShards = shard.unsignedTotalShards();
           for (final ShardRange range : shard.ranges) {
-            if (range == null) {
+            if (range == null
+                || range.unsignedStart() >= range.unsignedEnd()
+                || range.unsignedEnd() > totalShards) {
               throw new InvalidFlagException(
                   "flag \"" + flagKey + "\" contains an invalid shard range");
             }

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
@@ -40,6 +40,7 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
 
   static final String INVALID_FLAG = "invalid_flag";
   static final String INVALID_SEMVER_COMPARAND = "invalid_semver_comparand";
+  private static final long MAX_UNSIGNED_INT = 0xFFFFFFFFL;
 
   /**
    * Side-channel for tracking flags that failed semver comparand validation during parsing. Cleared
@@ -117,7 +118,11 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
             throw new InvalidFlagException("flag \"" + flagKey + "\" contains an invalid shard");
           }
           for (final ShardRange range : shard.ranges) {
-            if (range == null || range.start < 0 || range.end < 0) {
+            if (range == null
+                || range.start < 0
+                || range.start > MAX_UNSIGNED_INT
+                || range.end < 0
+                || range.end > MAX_UNSIGNED_INT) {
               throw new InvalidFlagException(
                   "flag \"" + flagKey + "\" contains an invalid shard range");
             }
@@ -135,6 +140,9 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
         continue;
       }
       for (final Rule rule : allocation.rules) {
+        if (rule == null) {
+          throw new InvalidFlagException("flag \"" + flagKey + "\" contains a null rule");
+        }
         if (rule.conditions == null) {
           continue;
         }
@@ -191,7 +199,7 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
         continue;
       }
       for (final Rule rule : allocation.rules) {
-        if (rule.conditions == null) {
+        if (rule == null || rule.conditions == null) {
           continue;
         }
         for (final ConditionConfiguration condition : rule.conditions) {

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
@@ -9,10 +9,13 @@ import com.squareup.moshi.Types;
 import datadog.remoteconfig.ConfigurationDeserializer;
 import datadog.trace.api.featureflag.ufc.v1.Allocation;
 import datadog.trace.api.featureflag.ufc.v1.ConditionConfiguration;
+import datadog.trace.api.featureflag.ufc.v1.ConditionOperator;
 import datadog.trace.api.featureflag.ufc.v1.Flag;
 import datadog.trace.api.featureflag.ufc.v1.ParsedSemver;
 import datadog.trace.api.featureflag.ufc.v1.Rule;
 import datadog.trace.api.featureflag.ufc.v1.ServerConfiguration;
+import datadog.trace.api.featureflag.ufc.v1.Shard;
+import datadog.trace.api.featureflag.ufc.v1.ShardRange;
 import datadog.trace.api.featureflag.ufc.v1.Split;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -89,23 +92,89 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
     reader.peek();
   }
 
-  /** Validates the required nested UFC fields and SemVer comparands for a flag. */
+  /** Validates the required nested UFC fields and condition operands for a flag. */
   private static void validateFlag(final String flagKey, final Flag flag) {
     if (flag.allocations == null) {
       return;
     }
     for (final Allocation allocation : flag.allocations) {
-      if (allocation == null || allocation.splits == null) {
+      if (allocation == null) {
+        throw new InvalidFlagException("flag \"" + flagKey + "\" contains a null allocation");
+      }
+      if (allocation.splits == null) {
         continue;
       }
       for (final Split split : allocation.splits) {
-        if (split != null && split.shards == null) {
+        if (split == null || split.shards == null) {
           throw new InvalidFlagException(
               "flag \"" + flagKey + "\" contains a split with missing shards");
         }
+        for (final Shard shard : split.shards) {
+          if (shard == null
+              || shard.totalShards <= 0
+              || shard.totalShards > 0xFFFFFFFFL
+              || shard.ranges == null) {
+            throw new InvalidFlagException("flag \"" + flagKey + "\" contains an invalid shard");
+          }
+          for (final ShardRange range : shard.ranges) {
+            if (range == null || range.start < 0 || range.end < 0) {
+              throw new InvalidFlagException(
+                  "flag \"" + flagKey + "\" contains an invalid shard range");
+            }
+          }
+        }
       }
     }
+    validateConditionOperands(flagKey, flag);
     validateAndCacheSemverComparands(flagKey, flag);
+  }
+
+  private static void validateConditionOperands(final String flagKey, final Flag flag) {
+    for (final Allocation allocation : flag.allocations) {
+      if (allocation.rules == null) {
+        continue;
+      }
+      for (final Rule rule : allocation.rules) {
+        if (rule.conditions == null) {
+          continue;
+        }
+        for (final ConditionConfiguration condition : rule.conditions) {
+          if (condition == null || condition.operator == null) {
+            throw new InvalidFlagException("flag \"" + flagKey + "\" contains an unknown operator");
+          }
+          final Object value = condition.value;
+          switch (condition.operator) {
+            case IS_NULL:
+              if (!(value instanceof Boolean)) {
+                throw invalidConditionOperand(flagKey, condition.operator);
+              }
+              break;
+            case ONE_OF:
+            case NOT_ONE_OF:
+              if (!(value instanceof Iterable)) {
+                throw invalidConditionOperand(flagKey, condition.operator);
+              }
+              break;
+            case GTE:
+            case GT:
+            case LTE:
+            case LT:
+              if (!(value instanceof Number)) {
+                throw invalidConditionOperand(flagKey, condition.operator);
+              }
+              break;
+            default:
+              break;
+          }
+        }
+      }
+    }
+  }
+
+  private static InvalidFlagException invalidConditionOperand(
+      final String flagKey, final ConditionOperator operator) {
+    return new InvalidFlagException(
+        "flag \"" + flagKey + "\" has an invalid operand for operator \"" + operator + "\"");
   }
 
   /**
@@ -223,10 +292,11 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
         final Object rawFlag = reader.readJsonValue();
         try {
           final Flag flag = flagAdapter.fromJsonValue(rawFlag);
-          if (flag != null) {
-            validateFlag(flagKey, flag);
-            flags.put(flagKey, flag);
+          if (flag == null) {
+            throw new InvalidFlagException("flag \"" + flagKey + "\" could not be parsed");
           }
+          validateFlag(flagKey, flag);
+          flags.put(flagKey, flag);
         } catch (JsonDataException | IllegalArgumentException error) {
           INVALID_FLAGS_HOLDER.get().put(flagKey, INVALID_FLAG);
           if (error instanceof InvalidSemverComparandException) {

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
@@ -57,8 +57,7 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
       new Moshi.Builder()
           .add(Instant.class, new InstantAdapter())
           .add(AllocationAdapter.FACTORY)
-          .add(ShardAdapter.FACTORY)
-          .add(ShardRangeAdapter.FACTORY)
+          .add(Shard.class, new ShardAdapter())
           .add(FlagMapAdapter.FACTORY)
           .add(LenientBooleanAdapter.FACTORY)
           .build();
@@ -114,16 +113,11 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
               "flag \"" + flagKey + "\" contains a split with missing shards");
         }
         for (final Shard shard : split.shards) {
-          if (shard == null
-              || shard.unsignedTotalShards() == 0
-              || shard.unsignedTotalShards() > MAX_UNSIGNED_INT
-              || shard.ranges == null) {
+          if (shard == null || shard.unsignedTotalShards() == 0 || shard.ranges == null) {
             throw new InvalidFlagException("flag \"" + flagKey + "\" contains an invalid shard");
           }
           for (final ShardRange range : shard.ranges) {
-            if (range == null
-                || range.unsignedStart() > MAX_UNSIGNED_INT
-                || range.unsignedEnd() > MAX_UNSIGNED_INT) {
+            if (range == null) {
               throw new InvalidFlagException(
                   "flag \"" + flagKey + "\" contains an invalid shard range");
             }
@@ -334,27 +328,6 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
    */
   static final class ShardAdapter extends JsonAdapter<Shard> {
 
-    static final Factory FACTORY =
-        new Factory() {
-          @Nullable
-          @Override
-          public JsonAdapter<?> create(
-              @Nonnull final Type type,
-              @Nonnull final Set<? extends Annotation> annotations,
-              @Nonnull final Moshi moshi) {
-            if (!annotations.isEmpty() || type != Shard.class) {
-              return null;
-            }
-            return new ShardAdapter(moshi.adapter(ShardRange.class));
-          }
-        };
-
-    private final JsonAdapter<ShardRange> rangeAdapter;
-
-    ShardAdapter(final JsonAdapter<ShardRange> rangeAdapter) {
-      this.rangeAdapter = rangeAdapter;
-    }
-
     @Nullable
     @Override
     public Shard fromJson(@Nonnull final JsonReader reader) throws IOException {
@@ -378,7 +351,7 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
             ranges = new ArrayList<>();
             reader.beginArray();
             while (reader.hasNext()) {
-              ranges.add(rangeAdapter.fromJson(reader));
+              ranges.add(readRange(reader));
             }
             reader.endArray();
             break;
@@ -393,34 +366,7 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
       return new Shard(salt, ranges, totalShards);
     }
 
-    @Override
-    public void toJson(@Nonnull final JsonWriter writer, @Nullable final Shard value)
-        throws IOException {
-      throw new UnsupportedOperationException("Reading only adapter");
-    }
-  }
-
-  /** Preserves the binary-compatible {@code int} representation of unsigned shard range bounds. */
-  static final class ShardRangeAdapter extends JsonAdapter<ShardRange> {
-
-    static final Factory FACTORY =
-        new Factory() {
-          @Nullable
-          @Override
-          public JsonAdapter<?> create(
-              @Nonnull final Type type,
-              @Nonnull final Set<? extends Annotation> annotations,
-              @Nonnull final Moshi moshi) {
-            if (!annotations.isEmpty() || type != ShardRange.class) {
-              return null;
-            }
-            return new ShardRangeAdapter();
-          }
-        };
-
-    @Nullable
-    @Override
-    public ShardRange fromJson(@Nonnull final JsonReader reader) throws IOException {
+    private static ShardRange readRange(final JsonReader reader) throws IOException {
       if (reader.peek() == JsonReader.Token.NULL) {
         return reader.nextNull();
       }
@@ -444,7 +390,7 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
     }
 
     @Override
-    public void toJson(@Nonnull final JsonWriter writer, @Nullable final ShardRange value)
+    public void toJson(@Nonnull final JsonWriter writer, @Nullable final Shard value)
         throws IOException {
       throw new UnsupportedOperationException("Reading only adapter");
     }

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,6 +57,8 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
       new Moshi.Builder()
           .add(Instant.class, new InstantAdapter())
           .add(AllocationAdapter.FACTORY)
+          .add(ShardAdapter.FACTORY)
+          .add(ShardRangeAdapter.FACTORY)
           .add(FlagMapAdapter.FACTORY)
           .add(LenientBooleanAdapter.FACTORY)
           .build();
@@ -112,17 +115,15 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
         }
         for (final Shard shard : split.shards) {
           if (shard == null
-              || shard.totalShards <= 0
-              || shard.totalShards > 0xFFFFFFFFL
+              || shard.unsignedTotalShards() == 0
+              || shard.unsignedTotalShards() > MAX_UNSIGNED_INT
               || shard.ranges == null) {
             throw new InvalidFlagException("flag \"" + flagKey + "\" contains an invalid shard");
           }
           for (final ShardRange range : shard.ranges) {
             if (range == null
-                || range.start < 0
-                || range.start > MAX_UNSIGNED_INT
-                || range.end < 0
-                || range.end > MAX_UNSIGNED_INT) {
+                || range.unsignedStart() > MAX_UNSIGNED_INT
+                || range.unsignedEnd() > MAX_UNSIGNED_INT) {
               throw new InvalidFlagException(
                   "flag \"" + flagKey + "\" contains an invalid shard range");
             }
@@ -325,6 +326,137 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
         throws IOException {
       throw new UnsupportedOperationException("Reading only adapter");
     }
+  }
+
+  /**
+   * Preserves the binary-compatible {@code int} representation of shard values while accepting
+   * their unsigned 32-bit JSON form.
+   */
+  static final class ShardAdapter extends JsonAdapter<Shard> {
+
+    static final Factory FACTORY =
+        new Factory() {
+          @Nullable
+          @Override
+          public JsonAdapter<?> create(
+              @Nonnull final Type type,
+              @Nonnull final Set<? extends Annotation> annotations,
+              @Nonnull final Moshi moshi) {
+            if (!annotations.isEmpty() || type != Shard.class) {
+              return null;
+            }
+            return new ShardAdapter(moshi.adapter(ShardRange.class));
+          }
+        };
+
+    private final JsonAdapter<ShardRange> rangeAdapter;
+
+    ShardAdapter(final JsonAdapter<ShardRange> rangeAdapter) {
+      this.rangeAdapter = rangeAdapter;
+    }
+
+    @Nullable
+    @Override
+    public Shard fromJson(@Nonnull final JsonReader reader) throws IOException {
+      if (reader.peek() == JsonReader.Token.NULL) {
+        return reader.nextNull();
+      }
+      String salt = null;
+      List<ShardRange> ranges = null;
+      int totalShards = 0;
+      reader.beginObject();
+      while (reader.hasNext()) {
+        switch (reader.nextName()) {
+          case "salt":
+            salt = reader.peek() == JsonReader.Token.NULL ? reader.nextNull() : reader.nextString();
+            break;
+          case "ranges":
+            if (reader.peek() == JsonReader.Token.NULL) {
+              ranges = reader.nextNull();
+              break;
+            }
+            ranges = new ArrayList<>();
+            reader.beginArray();
+            while (reader.hasNext()) {
+              ranges.add(rangeAdapter.fromJson(reader));
+            }
+            reader.endArray();
+            break;
+          case "totalShards":
+            totalShards = readUnsignedInt(reader, "totalShards");
+            break;
+          default:
+            reader.skipValue();
+        }
+      }
+      reader.endObject();
+      return new Shard(salt, ranges, totalShards);
+    }
+
+    @Override
+    public void toJson(@Nonnull final JsonWriter writer, @Nullable final Shard value)
+        throws IOException {
+      throw new UnsupportedOperationException("Reading only adapter");
+    }
+  }
+
+  /** Preserves the binary-compatible {@code int} representation of unsigned shard range bounds. */
+  static final class ShardRangeAdapter extends JsonAdapter<ShardRange> {
+
+    static final Factory FACTORY =
+        new Factory() {
+          @Nullable
+          @Override
+          public JsonAdapter<?> create(
+              @Nonnull final Type type,
+              @Nonnull final Set<? extends Annotation> annotations,
+              @Nonnull final Moshi moshi) {
+            if (!annotations.isEmpty() || type != ShardRange.class) {
+              return null;
+            }
+            return new ShardRangeAdapter();
+          }
+        };
+
+    @Nullable
+    @Override
+    public ShardRange fromJson(@Nonnull final JsonReader reader) throws IOException {
+      if (reader.peek() == JsonReader.Token.NULL) {
+        return reader.nextNull();
+      }
+      int start = 0;
+      int end = 0;
+      reader.beginObject();
+      while (reader.hasNext()) {
+        switch (reader.nextName()) {
+          case "start":
+            start = readUnsignedInt(reader, "start");
+            break;
+          case "end":
+            end = readUnsignedInt(reader, "end");
+            break;
+          default:
+            reader.skipValue();
+        }
+      }
+      reader.endObject();
+      return new ShardRange(start, end);
+    }
+
+    @Override
+    public void toJson(@Nonnull final JsonWriter writer, @Nullable final ShardRange value)
+        throws IOException {
+      throw new UnsupportedOperationException("Reading only adapter");
+    }
+  }
+
+  private static int readUnsignedInt(final JsonReader reader, final String field)
+      throws IOException {
+    final long value = reader.nextLong();
+    if (value < 0 || value > MAX_UNSIGNED_INT) {
+      throw new JsonDataException(field + " must be an unsigned 32-bit integer");
+    }
+    return (int) value;
   }
 
   /**

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
@@ -88,6 +88,7 @@ class JsonApiUfcResponseParserTest {
                     booleanFlag(
                         "null-split",
                         ",\"allocations\":[{\"key\":\"null-split\",\"rules\":[],\"splits\":[null]}]"),
+                    booleanFlag("null-rule", allocation("null-rule", "[null]")),
                     booleanFlag("no-rules", allocation("no-rules", "")),
                     booleanFlag("no-conditions", allocation("no-conditions", "[{}]")),
                     booleanFlag(
@@ -101,12 +102,12 @@ class JsonApiUfcResponseParserTest {
                         "valid-semver",
                         allocation(
                             "valid-semver",
-                            "[{\"conditions\":[{\"attribute\":\"version\",\"operator\":\"SEMVER_EQ\",\"value\":\"1.2.3\"}]}]")),
+                            "[{\"conditions\":[{\"attribute\":\"version\",\"operator\":\"SEMVER_EQ\",\"value\":\"1.2\"}]}]")),
                     booleanFlag(
                         "invalid-semver",
                         allocation(
                             "invalid-semver",
-                            "[{\"conditions\":[{\"attribute\":\"version\",\"operator\":\"SEMVER_EQ\",\"value\":\"1.2\"}]}]")),
+                            "[{\"conditions\":[{\"attribute\":\"version\",\"operator\":\"SEMVER_EQ\",\"value\":\"1.02\"}]}]")),
                     booleanFlag(
                         "non-string-semver",
                         allocation(
@@ -117,16 +118,21 @@ class JsonApiUfcResponseParserTest {
     assertNotNull(configuration);
     assertTrue(configuration.flags.containsKey("no-allocations"));
     assertTrue(configuration.flags.containsKey("no-splits"));
-    assertTrue(configuration.flags.containsKey("null-split"));
+    assertFalse(configuration.flags.containsKey("null-split"));
+    assertFalse(configuration.flags.containsKey("null-rule"));
     assertTrue(configuration.flags.containsKey("no-rules"));
     assertTrue(configuration.flags.containsKey("no-conditions"));
-    assertTrue(configuration.flags.containsKey("no-operator"));
+    assertFalse(configuration.flags.containsKey("no-operator"));
     assertTrue(configuration.flags.containsKey("non-semver"));
     assertTrue(configuration.flags.containsKey("valid-semver"));
     assertFalse(configuration.flags.containsKey("invalid-semver"));
     assertFalse(configuration.flags.containsKey("non-string-semver"));
     assertFalse(configuration.flags.containsKey("null-flag"));
-    assertEquals(2, configuration.invalidFlags.size());
+    assertEquals(6, configuration.invalidFlags.size());
+    assertEquals("invalid_flag", configuration.invalidFlags.get("null-flag"));
+    assertEquals("invalid_flag", configuration.invalidFlags.get("null-split"));
+    assertEquals("invalid_flag", configuration.invalidFlags.get("null-rule"));
+    assertEquals("invalid_flag", configuration.invalidFlags.get("no-operator"));
     assertEquals("invalid_semver_comparand", configuration.invalidFlags.get("invalid-semver"));
     assertEquals("invalid_semver_comparand", configuration.invalidFlags.get("non-string-semver"));
 
@@ -158,6 +164,55 @@ class JsonApiUfcResponseParserTest {
     assertFalse(configuration.flags.containsKey("missing-shards"));
     assertTrue(configuration.flags.containsKey("valid-sibling"));
     assertEquals("invalid_flag", configuration.invalidFlags.get("missing-shards"));
+  }
+
+  @Test
+  void preservesUnsigned32BitShardRangeBounds() throws Exception {
+    final ServerConfiguration configuration =
+        parse(
+            wrap(
+                configWithFlags(
+                    booleanFlag(
+                        "unsigned-shard-range",
+                        ",\"allocations\":[{\"key\":\"unsigned-shard-range\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"test\",\"totalShards\":4294967295,\"ranges\":[{\"start\":2147483648,\"end\":4294967295}]}]}]}]"),
+                    booleanFlag(
+                        "overflow-shard-range",
+                        ",\"allocations\":[{\"key\":\"overflow-shard-range\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"test\",\"totalShards\":4294967295,\"ranges\":[{\"start\":0,\"end\":4294967296}]}]}]}]"),
+                    booleanFlag("valid-sibling", ""))));
+
+    assertNotNull(configuration);
+    assertTrue(configuration.flags.containsKey("unsigned-shard-range"));
+    assertEquals(
+        2147483648L,
+        configuration
+            .flags
+            .get("unsigned-shard-range")
+            .allocations
+            .get(0)
+            .splits
+            .get(0)
+            .shards
+            .get(0)
+            .ranges
+            .get(0)
+            .start);
+    assertEquals(
+        4294967295L,
+        configuration
+            .flags
+            .get("unsigned-shard-range")
+            .allocations
+            .get(0)
+            .splits
+            .get(0)
+            .shards
+            .get(0)
+            .ranges
+            .get(0)
+            .end);
+    assertFalse(configuration.flags.containsKey("overflow-shard-range"));
+    assertEquals("invalid_flag", configuration.invalidFlags.get("overflow-shard-range"));
+    assertTrue(configuration.flags.containsKey("valid-sibling"));
   }
 
   @Test

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
@@ -195,7 +195,7 @@ class JsonApiUfcResponseParserTest {
             .get(0)
             .ranges
             .get(0)
-            .start);
+            .unsignedStart());
     assertEquals(
         4294967295L,
         configuration
@@ -209,7 +209,7 @@ class JsonApiUfcResponseParserTest {
             .get(0)
             .ranges
             .get(0)
-            .end);
+            .unsignedEnd());
     assertFalse(configuration.flags.containsKey("overflow-shard-range"));
     assertEquals("invalid_flag", configuration.invalidFlags.get("overflow-shard-range"));
     assertTrue(configuration.flags.containsKey("valid-sibling"));

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
@@ -178,6 +178,12 @@ class JsonApiUfcResponseParserTest {
                     booleanFlag(
                         "overflow-shard-range",
                         ",\"allocations\":[{\"key\":\"overflow-shard-range\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"test\",\"totalShards\":4294967295,\"ranges\":[{\"start\":0,\"end\":4294967296}]}]}]}]"),
+                    booleanFlag(
+                        "out-of-bounds-shard-range",
+                        ",\"allocations\":[{\"key\":\"out-of-bounds-shard-range\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"test\",\"totalShards\":10,\"ranges\":[{\"start\":0,\"end\":4294967295}]}]}]}]"),
+                    booleanFlag(
+                        "empty-shard-range",
+                        ",\"allocations\":[{\"key\":\"empty-shard-range\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"test\",\"totalShards\":10,\"ranges\":[{\"start\":4,\"end\":4}]}]}]}]"),
                     booleanFlag("valid-sibling", ""))));
 
     assertNotNull(configuration);
@@ -212,6 +218,10 @@ class JsonApiUfcResponseParserTest {
             .unsignedEnd());
     assertFalse(configuration.flags.containsKey("overflow-shard-range"));
     assertEquals("invalid_flag", configuration.invalidFlags.get("overflow-shard-range"));
+    assertFalse(configuration.flags.containsKey("out-of-bounds-shard-range"));
+    assertEquals("invalid_flag", configuration.invalidFlags.get("out-of-bounds-shard-range"));
+    assertFalse(configuration.flags.containsKey("empty-shard-range"));
+    assertEquals("invalid_flag", configuration.invalidFlags.get("empty-shard-range"));
     assertTrue(configuration.flags.containsKey("valid-sibling"));
   }
 

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
@@ -216,6 +216,73 @@ class JsonApiUfcResponseParserTest {
   }
 
   @Test
+  void dropsFlagsWithInvalidNestedAllocationsShardsAndOperands() throws Exception {
+    final ServerConfiguration configuration =
+        parse(
+            wrap(
+                configWithFlags(
+                    booleanFlag("null-allocation", ",\"allocations\":[null]"),
+                    booleanFlag(
+                        "zero-total-shards",
+                        ",\"allocations\":[{\"key\":\"zero-total-shards\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"test\",\"totalShards\":0,\"ranges\":[]}]}]}]"),
+                    booleanFlag(
+                        "null-shard",
+                        ",\"allocations\":[{\"key\":\"null-shard\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[null]}]}]"),
+                    booleanFlag(
+                        "overflow-total-shards",
+                        ",\"allocations\":[{\"key\":\"overflow-total-shards\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"test\",\"totalShards\":4294967296,\"ranges\":[]}]}]}]"),
+                    booleanFlag(
+                        "missing-ranges",
+                        ",\"allocations\":[{\"key\":\"missing-ranges\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"test\",\"totalShards\":1}]}]}]"),
+                    booleanFlag(
+                        "invalid-is-null",
+                        allocation(
+                            "invalid-is-null",
+                            "[{\"conditions\":[{\"attribute\":\"version\",\"operator\":\"IS_NULL\",\"value\":\"true\"}]}]")),
+                    booleanFlag(
+                        "invalid-one-of",
+                        allocation(
+                            "invalid-one-of",
+                            "[{\"conditions\":[{\"attribute\":\"version\",\"operator\":\"ONE_OF\",\"value\":\"1\"}]}]")),
+                    booleanFlag(
+                        "invalid-gte",
+                        allocation(
+                            "invalid-gte",
+                            "[{\"conditions\":[{\"attribute\":\"version\",\"operator\":\"GTE\",\"value\":\"1\"}]}]")),
+                    booleanFlag(
+                        "valid-is-null",
+                        allocation(
+                            "valid-is-null",
+                            "[{\"conditions\":[{\"attribute\":\"version\",\"operator\":\"IS_NULL\",\"value\":true}]}]")),
+                    booleanFlag(
+                        "valid-one-of",
+                        allocation(
+                            "valid-one-of",
+                            "[{\"conditions\":[{\"attribute\":\"version\",\"operator\":\"ONE_OF\",\"value\":[\"1\"]}]}]")),
+                    booleanFlag(
+                        "valid-gte",
+                        allocation(
+                            "valid-gte",
+                            "[{\"conditions\":[{\"attribute\":\"version\",\"operator\":\"GTE\",\"value\":1}]}]")),
+                    booleanFlag("valid-sibling", ""))));
+
+    assertNotNull(configuration);
+    assertFalse(configuration.flags.containsKey("null-allocation"));
+    assertFalse(configuration.flags.containsKey("zero-total-shards"));
+    assertFalse(configuration.flags.containsKey("null-shard"));
+    assertFalse(configuration.flags.containsKey("overflow-total-shards"));
+    assertFalse(configuration.flags.containsKey("missing-ranges"));
+    assertFalse(configuration.flags.containsKey("invalid-is-null"));
+    assertFalse(configuration.flags.containsKey("invalid-one-of"));
+    assertFalse(configuration.flags.containsKey("invalid-gte"));
+    assertTrue(configuration.flags.containsKey("valid-is-null"));
+    assertTrue(configuration.flags.containsKey("valid-one-of"));
+    assertTrue(configuration.flags.containsKey("valid-gte"));
+    assertTrue(configuration.flags.containsKey("valid-sibling"));
+    assertEquals(8, configuration.invalidFlags.size());
+  }
+
+  @Test
   void nullAttributesAreRejectedWithoutInvokingTheFlagParser() throws Exception {
     assertNull(parse("{\"data\":{\"type\":\"universal-flag-configuration\",\"attributes\":null}}"));
   }

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
@@ -216,6 +216,27 @@ class JsonApiUfcResponseParserTest {
   }
 
   @Test
+  void acceptsUnknownShardFieldsAndDropsNullShardRanges() throws Exception {
+    final ServerConfiguration configuration =
+        parse(
+            wrap(
+                configWithFlags(
+                    booleanFlag(
+                        "unknown-shard-fields",
+                        ",\"allocations\":[{\"key\":\"unknown-shard-fields\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":null,\"totalShards\":1,\"ranges\":[{\"start\":0,\"end\":1,\"ignored\":true}],\"ignored\":true}]}]}]"),
+                    booleanFlag(
+                        "null-ranges",
+                        ",\"allocations\":[{\"key\":\"null-ranges\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"test\",\"totalShards\":1,\"ranges\":null}]}]}]"),
+                    booleanFlag("valid-sibling", ""))));
+
+    assertNotNull(configuration);
+    assertTrue(configuration.flags.containsKey("unknown-shard-fields"));
+    assertFalse(configuration.flags.containsKey("null-ranges"));
+    assertTrue(configuration.flags.containsKey("valid-sibling"));
+    assertEquals("invalid_flag", configuration.invalidFlags.get("null-ranges"));
+  }
+
+  @Test
   void dropsFlagsWithInvalidNestedAllocationsShardsAndOperands() throws Exception {
     final ServerConfiguration configuration =
         parse(

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
@@ -104,6 +104,16 @@ class JsonApiUfcResponseParserTest {
                             "valid-semver",
                             "[{\"conditions\":[{\"attribute\":\"version\",\"operator\":\"SEMVER_EQ\",\"value\":\"1.2\"}]}]")),
                     booleanFlag(
+                        "invalid-matches-regex",
+                        allocation(
+                            "invalid-matches-regex",
+                            "[{\"conditions\":[{\"attribute\":\"name\",\"operator\":\"MATCHES\",\"value\":\"[\"}]}]")),
+                    booleanFlag(
+                        "non-string-not-matches-regex",
+                        allocation(
+                            "non-string-not-matches-regex",
+                            "[{\"conditions\":[{\"attribute\":\"name\",\"operator\":\"NOT_MATCHES\",\"value\":1}]}]")),
+                    booleanFlag(
                         "invalid-semver",
                         allocation(
                             "invalid-semver",
@@ -125,14 +135,18 @@ class JsonApiUfcResponseParserTest {
     assertFalse(configuration.flags.containsKey("no-operator"));
     assertTrue(configuration.flags.containsKey("non-semver"));
     assertTrue(configuration.flags.containsKey("valid-semver"));
+    assertFalse(configuration.flags.containsKey("invalid-matches-regex"));
+    assertFalse(configuration.flags.containsKey("non-string-not-matches-regex"));
     assertFalse(configuration.flags.containsKey("invalid-semver"));
     assertFalse(configuration.flags.containsKey("non-string-semver"));
     assertFalse(configuration.flags.containsKey("null-flag"));
-    assertEquals(6, configuration.invalidFlags.size());
+    assertEquals(8, configuration.invalidFlags.size());
     assertEquals("invalid_flag", configuration.invalidFlags.get("null-flag"));
     assertEquals("invalid_flag", configuration.invalidFlags.get("null-split"));
     assertEquals("invalid_flag", configuration.invalidFlags.get("null-rule"));
     assertEquals("invalid_flag", configuration.invalidFlags.get("no-operator"));
+    assertEquals("invalid_flag", configuration.invalidFlags.get("invalid-matches-regex"));
+    assertEquals("invalid_flag", configuration.invalidFlags.get("non-string-not-matches-regex"));
     assertEquals("invalid_semver_comparand", configuration.invalidFlags.get("invalid-semver"));
     assertEquals("invalid_semver_comparand", configuration.invalidFlags.get("non-string-semver"));
 


### PR DESCRIPTION
## Summary
- Pin `ffe-system-test-data` to d9b05ae23d861228e210b9f4b7b1e5a926f88878.
- Add malformed-config isolation, validation improvements, and one-to-five-part semantic-version support.

## Validation
- `./gradlew :dd-smoke-tests:openfeature:test --no-daemon` (311 passed)
- Focused evaluator/SemVer tests and scoped Spotless checks.
- `git diff --check`

The separately hosted DataDog/system-tests suite was not run locally; the repository-local fixture runner passed.