### PR TITLE
Stabilize OpenFeature provider event tests

### DIFF
--- a/products/feature-flagging/feature-flagging-api/build.gradle.kts
+++ b/products/feature-flagging/feature-flagging-api/build.gradle.kts
@@ -52,7 +52,6 @@ dependencies {
   testImplementation(libs.bundles.junit5)
   testImplementation(libs.bundles.mockito)
   testImplementation(libs.moshi)
-  testImplementation("org.awaitility:awaitility:4.3.0")
 
   // The main source set gets the bootstrap/config types as compileOnly, so the JMH source set
   // needs them on its own compile and runtime classpath to drive the hook end to end.

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
@@ -1,12 +1,11 @@
 package datadog.trace.api.openfeature;
 
 import static datadog.trace.api.openfeature.Provider.METADATA;
-import static java.time.Duration.ofSeconds;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -39,6 +38,7 @@ import dev.openfeature.sdk.exceptions.FatalError;
 import dev.openfeature.sdk.exceptions.ProviderNotReadyError;
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -47,18 +47,13 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 public class ProviderTest {
 
-  @Captor private ArgumentCaptor<EventDetails> eventDetailsCaptor;
+  private static final long EVENT_TIMEOUT_SECONDS = 10;
 
   private ExecutorService executor;
 
@@ -77,15 +72,18 @@ public class ProviderTest {
   }
 
   @Test
-  public void testSetProvider() {
+  public void testSetProvider() throws Exception {
     final OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+    final CompletableFuture<EventDetails> readyEvent = new CompletableFuture<>();
+    api.onProviderReady(readyEvent::complete);
     api.setProvider(new Provider());
 
     final Client client = api.getClient();
     assertThat(client.getProviderState(), equalTo(ProviderState.NOT_READY));
 
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
-    await().atMost(ofSeconds(1)).until(() -> client.getProviderState() == ProviderState.READY);
+    readyEvent.get(EVENT_TIMEOUT_SECONDS, SECONDS);
+    assertThat(client.getProviderState(), equalTo(ProviderState.READY));
   }
 
   @Test
@@ -97,35 +95,29 @@ public class ProviderTest {
     assertThat(client.getProviderState(), equalTo(ProviderState.NOT_READY));
 
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
-    await().atMost(ofSeconds(1)).until(() -> client.getProviderState() == ProviderState.READY);
-    provider.get(1, SECONDS);
+    provider.get(EVENT_TIMEOUT_SECONDS, SECONDS);
+    assertThat(client.getProviderState(), equalTo(ProviderState.READY));
   }
 
   @Test
-  public void testSetProviderAndWaitTimeoutRecoversWhenConfigurationArrives() {
-    final Consumer<EventDetails> readyEvent = mock(Consumer.class);
+  public void testSetProviderAndWaitTimeoutRecoversWhenConfigurationArrives() throws Exception {
+    final CompletableFuture<EventDetails> readyEvent = new CompletableFuture<>();
     final OpenFeatureAPI api = OpenFeatureAPI.getInstance();
     final Client client = api.getClient();
-    client.on(ProviderEvent.PROVIDER_READY, readyEvent);
+    client.on(ProviderEvent.PROVIDER_READY, readyEvent::complete);
 
     assertThrows(
         ProviderNotReadyError.class,
         () -> api.setProviderAndWait(new Provider(new Options().initTimeout(10, MILLISECONDS))));
 
     assertThat(client.getProviderState(), equalTo(ProviderState.ERROR));
-    verify(readyEvent, times(0)).accept(any());
+    assertFalse(readyEvent.isDone());
 
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
 
-    await()
-        .atMost(ofSeconds(1))
-        .untilAsserted(
-            () -> {
-              assertThat(client.getProviderState(), equalTo(ProviderState.READY));
-              verify(readyEvent, times(1)).accept(eventDetailsCaptor.capture());
-              final EventDetails eventDetails = eventDetailsCaptor.getValue();
-              assertThat(eventDetails.getProviderName(), equalTo(METADATA));
-            });
+    final EventDetails eventDetails = readyEvent.get(EVENT_TIMEOUT_SECONDS, SECONDS);
+    assertThat(client.getProviderState(), equalTo(ProviderState.READY));
+    assertThat(eventDetails.getProviderName(), equalTo(METADATA));
   }
 
   @Test
@@ -266,49 +258,35 @@ public class ProviderTest {
   }
 
   @Test
-  public void testNullConfigurationAfterReadyTransitionsToErrorAndRecovers() {
+  public void testNullConfigurationAfterReadyTransitionsToErrorAndRecovers() throws Exception {
     final OpenFeatureAPI api = OpenFeatureAPI.getInstance();
-    api.setProvider(new Provider());
-    final Client client = api.getClient();
-
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
-    await().atMost(ofSeconds(1)).until(() -> client.getProviderState() == ProviderState.READY);
+    api.setProviderAndWait(new Provider());
+    final Client client = api.getClient();
+    assertThat(client.getProviderState(), equalTo(ProviderState.READY));
 
-    final Consumer<EventDetails> errorEvent = mock(Consumer.class);
-    final Consumer<EventDetails> readyEvent = mock(Consumer.class);
-    final Consumer<EventDetails> configChangedEvent = mock(Consumer.class);
-    client.on(ProviderEvent.PROVIDER_ERROR, errorEvent);
-    client.on(ProviderEvent.PROVIDER_CONFIGURATION_CHANGED, configChangedEvent);
+    final CompletableFuture<EventDetails> errorEvent = new CompletableFuture<>();
+    final CompletableFuture<EventDetails> readyEvent = new CompletableFuture<>();
+    final CompletableFuture<EventDetails> configChangedEvent = new CompletableFuture<>();
+    client.on(ProviderEvent.PROVIDER_ERROR, errorEvent::complete);
+    client.on(ProviderEvent.PROVIDER_CONFIGURATION_CHANGED, configChangedEvent::complete);
 
     FeatureFlaggingGateway.dispatch((ServerConfiguration) null);
-    await()
-        .atMost(ofSeconds(1))
-        .untilAsserted(
-            () -> {
-              assertThat(client.getProviderState(), equalTo(ProviderState.ERROR));
-              verify(errorEvent, times(1)).accept(eventDetailsCaptor.capture());
-              final EventDetails eventDetails = eventDetailsCaptor.getValue();
-              assertThat(eventDetails.getProviderName(), equalTo(METADATA));
-            });
+    final EventDetails eventDetails = errorEvent.get(EVENT_TIMEOUT_SECONDS, SECONDS);
+    assertThat(client.getProviderState(), equalTo(ProviderState.ERROR));
+    assertThat(eventDetails.getProviderName(), equalTo(METADATA));
 
     final FlagEvaluationDetails<String> evalDetails = client.getStringDetails("missing", "default");
     assertThat(evalDetails.getValue(), equalTo("default"));
     assertThat(evalDetails.getErrorCode(), equalTo(ErrorCode.PROVIDER_NOT_READY));
 
-    client.on(ProviderEvent.PROVIDER_READY, readyEvent);
+    client.on(ProviderEvent.PROVIDER_READY, readyEvent::complete);
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
-    await()
-        .atMost(ofSeconds(1))
-        .untilAsserted(
-            () -> {
-              assertThat(client.getProviderState(), equalTo(ProviderState.READY));
-              verify(readyEvent, times(1)).accept(any());
-            });
+    readyEvent.get(EVENT_TIMEOUT_SECONDS, SECONDS);
+    assertThat(client.getProviderState(), equalTo(ProviderState.READY));
 
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
-    await()
-        .atMost(ofSeconds(1))
-        .untilAsserted(() -> verify(configChangedEvent, times(1)).accept(any()));
+    configChangedEvent.get(EVENT_TIMEOUT_SECONDS, SECONDS);
   }
 
   @Test

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/ProviderTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -102,9 +103,10 @@ public class ProviderTest {
   @Test
   public void testSetProviderAndWaitTimeoutRecoversWhenConfigurationArrives() throws Exception {
     final CompletableFuture<EventDetails> readyEvent = new CompletableFuture<>();
+    final Consumer<EventDetails> readyEventHandler = completingHandler(readyEvent);
     final OpenFeatureAPI api = OpenFeatureAPI.getInstance();
     final Client client = api.getClient();
-    client.on(ProviderEvent.PROVIDER_READY, readyEvent::complete);
+    client.on(ProviderEvent.PROVIDER_READY, readyEventHandler);
 
     assertThrows(
         ProviderNotReadyError.class,
@@ -118,6 +120,7 @@ public class ProviderTest {
     final EventDetails eventDetails = readyEvent.get(EVENT_TIMEOUT_SECONDS, SECONDS);
     assertThat(client.getProviderState(), equalTo(ProviderState.READY));
     assertThat(eventDetails.getProviderName(), equalTo(METADATA));
+    verify(readyEventHandler, times(1)).accept(any());
   }
 
   @Test
@@ -268,8 +271,11 @@ public class ProviderTest {
     final CompletableFuture<EventDetails> errorEvent = new CompletableFuture<>();
     final CompletableFuture<EventDetails> readyEvent = new CompletableFuture<>();
     final CompletableFuture<EventDetails> configChangedEvent = new CompletableFuture<>();
-    client.on(ProviderEvent.PROVIDER_ERROR, errorEvent::complete);
-    client.on(ProviderEvent.PROVIDER_CONFIGURATION_CHANGED, configChangedEvent::complete);
+    final Consumer<EventDetails> errorEventHandler = completingHandler(errorEvent);
+    final Consumer<EventDetails> readyEventHandler = completingHandler(readyEvent);
+    final Consumer<EventDetails> configChangedEventHandler = completingHandler(configChangedEvent);
+    client.on(ProviderEvent.PROVIDER_ERROR, errorEventHandler);
+    client.on(ProviderEvent.PROVIDER_CONFIGURATION_CHANGED, configChangedEventHandler);
 
     FeatureFlaggingGateway.dispatch((ServerConfiguration) null);
     final EventDetails eventDetails = errorEvent.get(EVENT_TIMEOUT_SECONDS, SECONDS);
@@ -280,13 +286,16 @@ public class ProviderTest {
     assertThat(evalDetails.getValue(), equalTo("default"));
     assertThat(evalDetails.getErrorCode(), equalTo(ErrorCode.PROVIDER_NOT_READY));
 
-    client.on(ProviderEvent.PROVIDER_READY, readyEvent::complete);
+    client.on(ProviderEvent.PROVIDER_READY, readyEventHandler);
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
     readyEvent.get(EVENT_TIMEOUT_SECONDS, SECONDS);
     assertThat(client.getProviderState(), equalTo(ProviderState.READY));
 
     FeatureFlaggingGateway.dispatch(mock(ServerConfiguration.class));
     configChangedEvent.get(EVENT_TIMEOUT_SECONDS, SECONDS);
+    verify(errorEventHandler, times(1)).accept(any());
+    verify(readyEventHandler, times(1)).accept(any());
+    verify(configChangedEventHandler, times(1)).accept(any());
   }
 
   @Test
@@ -455,6 +464,20 @@ public class ProviderTest {
     stateField.setAccessible(true);
     final AtomicReference<?> state = (AtomicReference<?>) stateField.get(provider);
     return state.get().toString();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Consumer<EventDetails> completingHandler(
+      final CompletableFuture<EventDetails> event) {
+    final Consumer<EventDetails> handler = mock(Consumer.class);
+    doAnswer(
+            invocation -> {
+              event.complete(invocation.getArgument(0));
+              return null;
+            })
+        .when(handler)
+        .accept(any());
+    return handler;
   }
 
   private static FlagEvaluationWriter capturingWriter(final AtomicReference<FlagEvalEvent> ref) {


### PR DESCRIPTION
## Motivation

`ProviderTest` is marked flaky after repeated failures on `master` ARM64 CI jobs under Semeru 17 and JDK 27. The affected tests, `testSetProvider()` and `testNullConfigurationAfterReadyTransitionsToErrorAndRecovers()`, polled provider state with a one-second deadline. The configuration gateway already retains and replays the latest configuration, so the failures did not indicate a lost update; they occurred when shared-runner scheduling delayed OpenFeature's asynchronous worker or event handler past that deadline. The tests were therefore measuring executor latency rather than the provider contract.

## Changes

The asynchronous tests now complete futures from the actual OpenFeature ready, error, and configuration-changed events and assert provider state after the expected event arrives. `testSetProviderAndWait()` waits for its submitted initialization operation, while the recovery-state test preloads configuration and initializes synchronously before exercising error and recovery transitions. The ten-second future deadline remains only as hang protection, not as a polling window. Since this was the module's last Awaitility usage, the unused test dependency is removed.

## Decisions

Production code is unchanged because the live failures point to test orchestration, not a runtime provider defect. Synchronizing on semantic provider events preserves the behavior under test and gives a precise failure when an expected transition never occurs; simply increasing the Awaitility timeout would retain the scheduler-dependent race and make the suite slower to diagnose.

## Verification

- Ran `ProviderTest` successfully in 10 fresh Gradle test executions.
- Ran `ProviderTest` with JDK 17.
- Ran `ProviderTest` with JDK 25, the newest locally available toolchain and closest proxy for the observed JDK 27 failure.
- Ran all 392 `feature-flagging-api` tests.
- Ran `:products:feature-flagging:feature-flagging-api:spotlessCheck`.
