### PR TITLE
Add additional collection classes as unsafe

### DIFF
--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
@@ -214,6 +214,7 @@ public class WellKnownClasses {
           Arrays.asList(
               // Maps with synchronized methods can lead to deadlock
               "java.util.Hashtable",
+              "java.util.Properties",
               "java.util.Collections$SynchronizedMap",
               "java.util.Collections$SynchronizedSortedMap",
               "java.util.Collections$SynchronizedNavigableMap"));
@@ -226,8 +227,6 @@ public class WellKnownClasses {
           "it.unimi.dsi.fastutil.", // fastutil
           "org.agrona.collections." // Agrona
           );
-
-  private static final String SYNCHRONIZED_WRAPPER_PREFIX = "java.util.Collections$Synchronized";
 
   /**
    * @return true if type is a final class and toString implementation is well known and side effect

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/main/java/datadog/trace/bootstrap/debugger/util/WellKnownClasses.java
@@ -196,6 +196,28 @@ public class WellKnownClasses {
           "org.agrona.collections." // Agrona
           );
 
+  private static final Set<String> UNSAFE_COLLECTION_CLASSES =
+      new HashSet<>(
+          Arrays.asList(
+              // Collection with synchronized methods can lead to deadlock
+              "java.util.Stack",
+              "java.util.Vector",
+              "java.util.Collections$SynchronizedSet",
+              "java.util.Collections$SynchronizedCollection",
+              "java.util.Collections$SynchronizedSortedSet",
+              "java.util.Collections$SynchronizedNavigableSet",
+              "java.util.Collections$SynchronizedList",
+              "java.util.Collections$SynchronizedRandomAccessList"));
+
+  private static final Set<String> UNSAFE_MAP_CLASSES =
+      new HashSet<>(
+          Arrays.asList(
+              // Maps with synchronized methods can lead to deadlock
+              "java.util.Hashtable",
+              "java.util.Collections$SynchronizedMap",
+              "java.util.Collections$SynchronizedSortedMap",
+              "java.util.Collections$SynchronizedNavigableMap"));
+
   private static final List<String> SAFE_MAP_PACKAGES =
       Arrays.asList(
           "java.", // JDK base module
@@ -228,19 +250,20 @@ public class WellKnownClasses {
    * @return true if collection implementation is safe to call (only in-memory and lock free)
    */
   public static boolean isSafe(Collection<?> collection) {
-    return isSafe(collection.getClass().getTypeName(), SAFE_COLLECTION_PACKAGES);
+    return isSafe(
+        collection.getClass().getTypeName(), SAFE_COLLECTION_PACKAGES, UNSAFE_COLLECTION_CLASSES);
   }
 
   /**
    * @return true if map implementation is safe to call (only in-memory and lock free)
    */
   public static boolean isSafe(Map<?, ?> map) {
-    return isSafe(map.getClass().getTypeName(), SAFE_MAP_PACKAGES);
+    return isSafe(map.getClass().getTypeName(), SAFE_MAP_PACKAGES, UNSAFE_MAP_CLASSES);
   }
 
-  private static boolean isSafe(String className, List<String> safePackages) {
-    // synchronized wrappers lock on their mutex: calling them can deadlock the instrumented thread
-    if (className.startsWith(SYNCHRONIZED_WRAPPER_PREFIX)) {
+  private static boolean isSafe(
+      String className, List<String> safePackages, Set<String> unsafeClasses) {
+    if (unsafeClasses.contains(className)) {
       return false;
     }
     for (String safePackage : safePackages) {

--- a/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/util/WellKnownClassesTest.java
+++ b/dd-java-agent/agent-debugger/debugger-bootstrap/src/test/java/datadog/trace/bootstrap/debugger/util/WellKnownClassesTest.java
@@ -7,9 +7,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Hashtable;
 import java.util.LinkedList;
+import java.util.Properties;
+import java.util.Stack;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +21,10 @@ class WellKnownClassesTest {
 
   @Test
   public void synchronizedWrappersAreNotSafe() {
+    assertFalse(WellKnownClasses.isSafe(new Vector<>()));
+    assertFalse(WellKnownClasses.isSafe(new Stack<>()));
+    assertFalse(WellKnownClasses.isSafe(new Hashtable<>()));
+    assertFalse(WellKnownClasses.isSafe(new Properties()));
     assertFalse(WellKnownClasses.isSafe(Collections.synchronizedCollection(new ArrayList<>())));
     assertFalse(WellKnownClasses.isSafe(Collections.synchronizedList(new ArrayList<>())));
     assertFalse(WellKnownClasses.isSafe(Collections.synchronizedList(new LinkedList<>())));


### PR DESCRIPTION
# What Does This Do
Stack, Vector and Hashtable are also unsafe collection and map classes because they have synchronized methods
use set to match exactly the class name instead of prefixes

# Motivation
follow up on #12106 

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [DEBUG-5947]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-5947]: https://datadoghq.atlassian.net/browse/DEBUG-5947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ