### PR TITLE
Preserve context when the same task instance is submitted twice

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
@@ -71,7 +71,17 @@ public class AdviceUtils {
     return (span == null || span.isValid()) && isAsyncPropagationEnabled();
   }
 
-  public static <T> void capture(ContextStore<T, State> contextStore, T task) {
+  /**
+   * Captures the current context into the task's {@link State}.
+   *
+   * <p>A {@link State} holds a single continuation, so if the same task instance is submitted again
+   * while an earlier submission is still pending, the second capture cannot be stored. Callers that
+   * are able to give the submission its own carrier should use the return value to detect that and
+   * do so; callers with no such option may ignore it.
+   *
+   * @return {@code true} if the slot was already taken and this capture was dropped
+   */
+  public static <T> boolean capture(ContextStore<T, State> contextStore, T task) {
     Context context = Context.current();
     if (shouldCapture(context)) {
       State state = contextStore.get(task);
@@ -79,7 +89,8 @@ public class AdviceUtils {
         state = State.FACTORY.create();
         contextStore.put(task, state);
       }
-      state.captureAndSetContinuation(context);
+      return !state.captureAndSetContinuation(context);
     }
+    return false;
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/TPEHelper.java
@@ -63,10 +63,16 @@ public final class TPEHelper {
         && PROPAGATE.get(executor.getClass());
   }
 
-  public static void capture(ContextStore<Runnable, State> contextStore, Runnable task) {
+  /**
+   * @return {@code true} if this task instance already had a pending continuation, so this
+   *     submission's context was dropped and needs its own carrier. See {@link
+   *     AdviceUtils#capture}.
+   */
+  public static boolean capture(ContextStore<Runnable, State> contextStore, Runnable task) {
     if (task != null && !exclude(RUNNABLE, task)) {
-      AdviceUtils.capture(contextStore, task);
+      return AdviceUtils.capture(contextStore, task);
     }
+    return false;
   }
 
   public static ContextScope startScope(ContextStore<Runnable, State> contextStore, Runnable task) {

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/executor/ThreadPoolExecutorInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/executor/ThreadPoolExecutorInstrumentation.java
@@ -106,8 +106,13 @@ public final class ThreadPoolExecutorInstrumentation
       if (TPEHelper.shouldPropagate(tpe)) {
         if (TPEHelper.useWrapping(task)) {
           task = Wrapper.wrap(task);
+        } else if (TPEHelper.capture(
+            InstrumentationContext.get(Runnable.class, State.class), task)) {
+          // This same instance is already queued with a pending continuation, and its single State
+          // slot cannot hold ours as well. Fall back to wrapping so this submission carries its own
+          // context instead of silently running under the root context.
+          task = Wrapper.wrap(task);
         } else {
-          TPEHelper.capture(InstrumentationContext.get(Runnable.class, State.class), task);
           // queue time needs to be handled separately because there are RunnableFutures which are
           // excluded as
           // Runnables but it is not until now that they will be put on the executor's queue

--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/test/java/executor/ReusedTaskContextPropagationTest.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/test/java/executor/ReusedTaskContextPropagationTest.java
@@ -1,0 +1,169 @@
+package executor;
+
+import static datadog.trace.agent.test.assertions.SpanMatcher.span;
+import static datadog.trace.agent.test.assertions.TraceAssertions.SORT_BY_START_TIME;
+import static datadog.trace.agent.test.assertions.TraceMatcher.trace;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activeSpan;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.agent.test.AbstractInstrumentationTest;
+import datadog.trace.agent.test.assertions.TraceMatcher;
+import datadog.trace.api.Trace;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Context propagation when the <em>same</em> task instance is submitted more than once.
+ *
+ * <p>The non-wrapping {@link java.util.concurrent.ThreadPoolExecutor} path stores the captured
+ * context in a {@code State} attached to the task instance, and a {@code State} holds a single
+ * continuation. So when a task instance is submitted again while an earlier submission is still
+ * queued, the two submissions compete for one slot. Every submission must still run under the
+ * parent it was submitted from.
+ */
+public class ReusedTaskContextPropagationTest extends AbstractInstrumentationTest {
+
+  /** Records which span is active when the task body runs, in execution order. */
+  static final class ParentRecorder {
+    final List<String> parents = new CopyOnWriteArrayList<>();
+    final CountDownLatch ran;
+
+    ParentRecorder(int expectedRuns) {
+      this.ran = new CountDownLatch(expectedRuns);
+    }
+
+    void record() {
+      AgentSpan span = activeSpan();
+      parents.add(span == null ? "<none>" : String.valueOf(span.getOperationName()));
+      child();
+      ran.countDown();
+    }
+
+    @Trace(operationName = "child")
+    void child() {}
+  }
+
+  /** A plain named class, the shape most application tasks take. */
+  static final class NamedTask implements Runnable {
+    private final ParentRecorder recorder;
+
+    NamedTask(ParentRecorder recorder) {
+      this.recorder = recorder;
+    }
+
+    @Override
+    public void run() {
+      recorder.record();
+    }
+  }
+
+  @Test
+  void namedClassInstanceQueuedTwiceUnderDifferentParents() throws Exception {
+    ParentRecorder recorder = new ParentRecorder(2);
+    assertBothParentsPropagate(new NamedTask(recorder), recorder);
+  }
+
+  @Test
+  void anonymousInnerClassInstanceQueuedTwiceUnderDifferentParents() throws Exception {
+    ParentRecorder recorder = new ParentRecorder(2);
+    Runnable task =
+        new Runnable() {
+          @Override
+          public void run() {
+            recorder.record();
+          }
+        };
+    assertBothParentsPropagate(task, recorder);
+  }
+
+  @Test
+  void lambdaInstanceQueuedTwiceUnderDifferentParents() throws Exception {
+    ParentRecorder recorder = new ParentRecorder(2);
+    assertBothParentsPropagate(recorder::record, recorder);
+  }
+
+  /**
+   * Sequential reuse: the first submission completes before the second is made, so the single slot
+   * is free again and no fallback is needed.
+   */
+  @Test
+  void sameInstanceReusedSequentiallyUnderDifferentParents() throws Exception {
+    ParentRecorder recorder = new ParentRecorder(2);
+    Runnable task = new NamedTask(recorder);
+    ExecutorService pool = Executors.newSingleThreadExecutor();
+    try {
+      submitUnderParentA(pool, task);
+      submitUnderParentB(pool, task);
+      assertTrue(recorder.ran.await(20, TimeUnit.SECONDS), "task did not run twice");
+      assertEquals(Arrays.asList("parentA", "parentB"), recorder.parents);
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+
+  /**
+   * Queues both submissions of {@code task} behind a blocked worker, then asserts each execution
+   * ran under the parent it was submitted from.
+   */
+  private void assertBothParentsPropagate(Runnable task, ParentRecorder recorder) throws Exception {
+    ExecutorService pool = Executors.newSingleThreadExecutor();
+    try {
+      CountDownLatch release = new CountDownLatch(1);
+      CountDownLatch workerBusy = new CountDownLatch(1);
+      pool.execute(
+          new Runnable() {
+            @Override
+            public void run() {
+              workerBusy.countDown();
+              try {
+                release.await(20, TimeUnit.SECONDS);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            }
+          });
+      assertTrue(
+          workerBusy.await(20, TimeUnit.SECONDS), "worker never picked up the blocking task");
+
+      // Both submissions are now queued, so both compete for the task's single State slot.
+      submitUnderParentA(pool, task);
+      submitUnderParentB(pool, task);
+
+      release.countDown();
+      assertTrue(recorder.ran.await(20, TimeUnit.SECONDS), "task did not run twice");
+
+      assertEquals(Arrays.asList("parentA", "parentB"), recorder.parents);
+      // each submission keeps its own trace, with the task's span parented correctly
+      assertTraces(
+          SORT_BY_START_TIME,
+          trace(
+              TraceMatcher.SORT_BY_START_TIME,
+              span().root().operationName("parentA"),
+              span().childOfPrevious().operationName("child")),
+          trace(
+              TraceMatcher.SORT_BY_START_TIME,
+              span().root().operationName("parentB"),
+              span().childOfPrevious().operationName("child")));
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+
+  @Trace(operationName = "parentA")
+  void submitUnderParentA(ExecutorService pool, Runnable task) {
+    pool.execute(task);
+  }
+
+  @Trace(operationName = "parentB")
+  void submitUnderParentB(ExecutorService pool, Runnable task) {
+    pool.execute(task);
+  }
+}


### PR DESCRIPTION
# What Does This Do

The non-wrapping `ThreadPoolExecutor` path (the default) stores the captured context in a `State` attached to the task instance, and a State holds a single continuation. So when the same Runnable instance is submitted again while an earlier submission is still queued, the second capture is dropped and that execution runs under the root context, losing the parent.

`AdviceUtils.capture` now reports that conflict, and the `execute` advice falls back to wrapping for the losing submission so it carries its own context.

Affected every reused named class and anonymous inner class; JVM lambdas were accidentally safe already, since they are always wrapped. Only the `ThreadPoolExecutor` path is fixed here: ForkJoin tasks cannot be wrapped (since no field injected)

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
