### PR TITLE
Support arbitrary semver parts

### DIFF
--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -173,18 +173,11 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
       final Flag flag = config.flags.get(key);
       if (flag == null) {
         if (config.invalidFlags != null && config.invalidFlags.containsKey(key)) {
-          if ("invalid_semver_comparand".equals(config.invalidFlags.get(key))) {
-            return error(
-                defaultValue,
-                ErrorCode.PARSE_ERROR,
-                "invalid configuration for flag " + key,
-                observeFullEvaluationData);
-          }
-          return ProviderEvaluation.<T>builder()
-              .value(defaultValue)
-              .reason(Reason.DEFAULT.name())
-              .flagMetadata(consentMetadata(observeFullEvaluationData))
-              .build();
+          return error(
+              defaultValue,
+              ErrorCode.PARSE_ERROR,
+              "invalid configuration for flag " + key,
+              observeFullEvaluationData);
         }
         return error(defaultValue, ErrorCode.FLAG_NOT_FOUND, null, observeFullEvaluationData);
       }

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -463,7 +463,8 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
     return false;
   }
 
-  private static int getShard(final String salt, final String targetingKey, final int totalShards) {
+  private static int getShard(
+      final String salt, final String targetingKey, final long totalShards) {
     final String hashKey = salt + "-" + targetingKey;
     final String md5Hash = getMD5Hash(hashKey);
     final String first8Chars = md5Hash.substring(0, Math.min(8, md5Hash.length()));

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -454,7 +454,7 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
   }
 
   private static boolean matchesShard(final Shard shard, final String targetingKey) {
-    final int assignedShard = getShard(shard.salt, targetingKey, shard.totalShards);
+    final long assignedShard = getShard(shard.salt, targetingKey, shard.totalShards);
     for (final ShardRange range : shard.ranges) {
       if (assignedShard >= range.start && assignedShard < range.end) {
         return true;
@@ -463,13 +463,13 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
     return false;
   }
 
-  private static int getShard(
+  private static long getShard(
       final String salt, final String targetingKey, final long totalShards) {
     final String hashKey = salt + "-" + targetingKey;
     final String md5Hash = getMD5Hash(hashKey);
     final String first8Chars = md5Hash.substring(0, Math.min(8, md5Hash.length()));
     final long intFromHash = Long.parseLong(first8Chars, 16);
-    return (int) (intFromHash % totalShards);
+    return intFromHash % totalShards;
   }
 
   private static String getMD5Hash(final String input) {

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -454,9 +454,14 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
   }
 
   private static boolean matchesShard(final Shard shard, final String targetingKey) {
-    final long assignedShard = getShard(shard.salt, targetingKey, shard.totalShards);
+    // The bootstrap model preserves its int ABI, so UFC uint32 values are stored as raw bits.
+    // Convert before arithmetic and comparison to retain their unsigned wire semantics.
+    final long totalShards = Integer.toUnsignedLong(shard.totalShards);
+    final long assignedShard = getShard(shard.salt, targetingKey, totalShards);
     for (final ShardRange range : shard.ranges) {
-      if (assignedShard >= range.start && assignedShard < range.end) {
+      final long rangeStart = Integer.toUnsignedLong(range.start);
+      final long rangeEnd = Integer.toUnsignedLong(range.end);
+      if (assignedShard >= rangeStart && assignedShard < rangeEnd) {
         return true;
       }
     }

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -550,7 +550,7 @@ public class DDEvaluatorTest {
       Arguments.of(ConditionOperator.SEMVER_EQ, "1.0.0+linux", "1.0.0+darwin", true),
       // Invalid attribute does not match
       Arguments.of(ConditionOperator.SEMVER_NEQ, "not-a-version", "1.0.0", false),
-      Arguments.of(ConditionOperator.SEMVER_GTE, "1.2", "1.0.0", false),
+      Arguments.of(ConditionOperator.SEMVER_GTE, "1.2", "1.0.0", true),
       Arguments.of(ConditionOperator.SEMVER_GTE, "v1.2.3", "1.0.0", false),
       Arguments.of(ConditionOperator.SEMVER_GTE, "18446744073709551616.0.0", "1.0.0", false),
       // Non-string attribute does not match
@@ -610,6 +610,24 @@ public class DDEvaluatorTest {
 
     final ProviderEvaluation<Boolean> details =
         evaluator.evaluate(Boolean.class, "invalid-semver", false, semverContext("1.2.3"));
+
+    assertThat(details.getValue(), equalTo(false));
+    assertThat(details.getReason(), equalTo(ERROR.name()));
+    assertThat(details.getErrorCode(), equalTo(ErrorCode.PARSE_ERROR));
+  }
+
+  @Test
+  public void testEvaluateMalformedFlagReturnsParseError() {
+    final Map<String, Flag> flags = new HashMap<>();
+    final Map<String, String> invalidFlags = new HashMap<>();
+    invalidFlags.put("malformed-flag", "invalid_flag");
+    final ServerConfiguration config = new ServerConfiguration("", "", null, null, flags);
+    config.invalidFlags = invalidFlags;
+    final DDEvaluator evaluator = new DDEvaluator(mock(Runnable.class));
+    evaluator.accept(config);
+
+    final ProviderEvaluation<Boolean> details =
+        evaluator.evaluate(Boolean.class, "malformed-flag", false, new MutableContext());
 
     assertThat(details.getValue(), equalTo(false));
     assertThat(details.getReason(), equalTo(ERROR.name()));

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -521,6 +521,8 @@ public class DDEvaluatorTest {
       // Equal
       Arguments.of(ConditionOperator.SEMVER_EQ, "1.2.3", "1.2.3", true),
       Arguments.of(ConditionOperator.SEMVER_EQ, "1.2.4", "1.2.3", false),
+      Arguments.of(ConditionOperator.SEMVER_EQ, "1.2.3.4.5.6", "1.2.3.4.5.6", true),
+      Arguments.of(ConditionOperator.SEMVER_GT, "1.2.3.4.5.7", "1.2.3.4.5.6", true),
       // Not equal
       Arguments.of(ConditionOperator.SEMVER_NEQ, "1.2.4", "1.2.3", true),
       Arguments.of(ConditionOperator.SEMVER_NEQ, "1.2.3", "1.2.3", false),

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -71,7 +71,11 @@ public class DDEvaluatorTest {
   private static final String CANONICAL_FIXTURE_PATH =
       "dd-smoke-tests/openfeature/src/test/resources/ffe-system-test-data";
   private static final Moshi MOSHI =
-      new Moshi.Builder().add(Date.class, new DateAdapter()).add(FlagMapAdapter.FACTORY).build();
+      new Moshi.Builder()
+          .add(Date.class, new DateAdapter())
+          .add(ShardAdapter.FACTORY)
+          .add(FlagMapAdapter.FACTORY)
+          .build();
   private static final JsonAdapter<ServerConfiguration> CONFIG_ADAPTER =
       MOSHI.adapter(ServerConfiguration.class);
   private static final Type FIXTURE_LIST_TYPE =
@@ -233,11 +237,13 @@ public class DDEvaluatorTest {
   public void testEvaluateUnsignedShardRange() {
     final Map<String, Variant> variations = new HashMap<>();
     variations.put("on", new Variant("on", 1));
+    // The selected shard is above Integer.MAX_VALUE, so this test proves that evaluation uses
+    // unsigned semantics after binary-compatible int storage.
     final Shard shard =
         new Shard(
             "salt",
-            singletonList(new ShardRange(3_699_531_192L, 3_699_531_193L)),
-            MAX_UNSIGNED_INT);
+            singletonList(new ShardRange((int) 3_699_531_192L, (int) 3_699_531_193L)),
+            (int) MAX_UNSIGNED_INT);
     final Split split = new Split(singletonList(shard), "on", emptyMap(), null);
     final Allocation allocation =
         new Allocation("alloc-1", null, null, null, singletonList(split), Boolean.FALSE);
@@ -1099,6 +1105,74 @@ public class DDEvaluatorTest {
     Map<String, Object> flagMetadata = emptyMap();
   }
 
+  /**
+   * Mirrors the production parser's binary-compatible uint32 representation for fixture parsing.
+   */
+  private static final class ShardAdapter extends JsonAdapter<Shard> {
+    private static final JsonAdapter.Factory FACTORY =
+        (type, annotations, moshi) -> {
+          if (!annotations.isEmpty() || type != Shard.class) {
+            return null;
+          }
+          return new ShardAdapter(moshi.adapter(ShardJson.class));
+        };
+
+    private final JsonAdapter<ShardJson> delegate;
+
+    private ShardAdapter(final JsonAdapter<ShardJson> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public Shard fromJson(final JsonReader reader) throws IOException {
+      final ShardJson shard = delegate.fromJson(reader);
+      if (shard == null) {
+        return null;
+      }
+      final List<ShardRange> ranges;
+      if (shard.ranges == null) {
+        ranges = null;
+      } else {
+        ranges = new ArrayList<>();
+        for (final ShardRangeJson range : shard.ranges) {
+          ranges.add(
+              range == null
+                  ? null
+                  : new ShardRange(
+                      toUnsignedInt(range.start, "range start"),
+                      toUnsignedInt(range.end, "range end")));
+        }
+      }
+      return new Shard(shard.salt, ranges, toUnsignedInt(shard.totalShards, "totalShards"));
+    }
+
+    @Override
+    public void toJson(final JsonWriter writer, final Shard value) {
+      throw new UnsupportedOperationException("Reading only adapter");
+    }
+  }
+
+  private static int toUnsignedInt(final Long value, final String fieldName) {
+    if (value == null) {
+      return 0;
+    }
+    if (value < 0 || value > MAX_UNSIGNED_INT) {
+      throw new IllegalArgumentException("flag contains an invalid " + fieldName + " value");
+    }
+    return value.intValue();
+  }
+
+  private static final class ShardJson {
+    String salt;
+    List<ShardRangeJson> ranges;
+    Long totalShards;
+  }
+
+  private static final class ShardRangeJson {
+    Long start;
+    Long end;
+  }
+
   /** Reads the flags map with per-flag failure isolation, matching the production parser. */
   private static final class FlagMapAdapter extends JsonAdapter<Map<String, Flag>> {
     private static final Type FLAGS_TYPE =
@@ -1129,7 +1203,6 @@ public class DDEvaluatorTest {
         final String flagKey = reader.nextName();
         final Object rawFlag = reader.readJsonValue();
         try {
-          validateRawShardBounds(rawFlag);
           final Flag flag = flagAdapter.fromJsonValue(rawFlag);
           if (flag != null) {
             validateFlag(flagKey, flag);
@@ -1142,58 +1215,6 @@ public class DDEvaluatorTest {
       }
       reader.endObject();
       return flags;
-    }
-
-    private static void validateRawShardBounds(final Object rawFlag) {
-      if (!(rawFlag instanceof Map)) {
-        return;
-      }
-      final Object allocations = ((Map<?, ?>) rawFlag).get("allocations");
-      if (!(allocations instanceof List)) {
-        return;
-      }
-      for (final Object allocation : (List<?>) allocations) {
-        if (!(allocation instanceof Map)) {
-          continue;
-        }
-        final Object splits = ((Map<?, ?>) allocation).get("splits");
-        if (!(splits instanceof List)) {
-          continue;
-        }
-        for (final Object split : (List<?>) splits) {
-          if (!(split instanceof Map)) {
-            continue;
-          }
-          final Object shards = ((Map<?, ?>) split).get("shards");
-          if (!(shards instanceof List)) {
-            continue;
-          }
-          for (final Object shard : (List<?>) shards) {
-            if (!(shard instanceof Map)) {
-              continue;
-            }
-            final Map<?, ?> rawShard = (Map<?, ?>) shard;
-            validateUnsignedInt(rawShard.get("totalShards"));
-            final Object ranges = rawShard.get("ranges");
-            if (!(ranges instanceof List)) {
-              continue;
-            }
-            for (final Object range : (List<?>) ranges) {
-              if (range instanceof Map) {
-                final Map<?, ?> rawRange = (Map<?, ?>) range;
-                validateUnsignedInt(rawRange.get("start"));
-                validateUnsignedInt(rawRange.get("end"));
-              }
-            }
-          }
-        }
-      }
-    }
-
-    private static void validateUnsignedInt(final Object value) {
-      if (value instanceof Number && ((Number) value).longValue() > MAX_UNSIGNED_INT) {
-        throw new IllegalArgumentException("flag contains an oversized shard value");
-      }
     }
 
     private static void validateFlag(final String flagKey, final Flag flag) {
@@ -1217,12 +1238,14 @@ public class DDEvaluatorTest {
                 "flag \"" + flagKey + "\" contains a split with missing shards");
           }
           for (final Shard shard : split.shards) {
-            if (shard == null || shard.totalShards <= 0 || shard.ranges == null) {
+            if (shard == null
+                || Integer.toUnsignedLong(shard.totalShards) == 0
+                || shard.ranges == null) {
               throw new IllegalArgumentException(
                   "flag \"" + flagKey + "\" contains invalid shards");
             }
             for (final ShardRange range : shard.ranges) {
-              if (range == null || range.start < 0 || range.end < 0) {
+              if (range == null) {
                 throw new IllegalArgumentException(
                     "flag \"" + flagKey + "\" contains an invalid shard range");
               }

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -33,6 +33,8 @@ import datadog.trace.api.featureflag.ufc.v1.Flag;
 import datadog.trace.api.featureflag.ufc.v1.ParsedSemver;
 import datadog.trace.api.featureflag.ufc.v1.Rule;
 import datadog.trace.api.featureflag.ufc.v1.ServerConfiguration;
+import datadog.trace.api.featureflag.ufc.v1.Shard;
+import datadog.trace.api.featureflag.ufc.v1.ShardRange;
 import datadog.trace.api.featureflag.ufc.v1.Split;
 import datadog.trace.api.featureflag.ufc.v1.ValueType;
 import datadog.trace.api.featureflag.ufc.v1.Variant;
@@ -1117,13 +1119,78 @@ public class DDEvaluatorTest {
         return;
       }
       for (final Allocation allocation : flag.allocations) {
-        if (allocation == null || allocation.splits == null) {
+        if (allocation == null) {
+          continue;
+        }
+        validateConditionOperands(flagKey, allocation);
+        if (allocation.splits == null) {
           continue;
         }
         for (final Split split : allocation.splits) {
-          if (split != null && split.shards == null) {
+          if (split == null) {
+            continue;
+          }
+          if (split.shards == null) {
             throw new IllegalArgumentException(
                 "flag \"" + flagKey + "\" contains a split with missing shards");
+          }
+          for (final Shard shard : split.shards) {
+            if (shard == null
+                || shard.totalShards <= 0
+                || shard.totalShards > Integer.MAX_VALUE
+                || shard.ranges == null) {
+              throw new IllegalArgumentException(
+                  "flag \"" + flagKey + "\" contains invalid shards");
+            }
+            for (final ShardRange range : shard.ranges) {
+              if (range == null || range.start < 0 || range.end < 0) {
+                throw new IllegalArgumentException(
+                    "flag \"" + flagKey + "\" contains an invalid shard range");
+              }
+            }
+          }
+        }
+      }
+    }
+
+    private static void validateConditionOperands(
+        final String flagKey, final Allocation allocation) {
+      if (allocation.rules == null) {
+        return;
+      }
+      for (final Rule rule : allocation.rules) {
+        if (rule == null || rule.conditions == null) {
+          continue;
+        }
+        for (final ConditionConfiguration condition : rule.conditions) {
+          if (condition == null || condition.operator == null) {
+            continue;
+          }
+          switch (condition.operator) {
+            case LT:
+            case LTE:
+            case GT:
+            case GTE:
+              if (!(condition.value instanceof Number)) {
+                throw new IllegalArgumentException(
+                    "flag \"" + flagKey + "\" has a non-numeric condition");
+              }
+              break;
+            case ONE_OF:
+            case NOT_ONE_OF:
+              if (!(condition.value instanceof List)) {
+                throw new IllegalArgumentException(
+                    "flag \"" + flagKey + "\" has a non-list condition");
+              }
+              break;
+            case IS_NULL:
+              if (!(condition.value instanceof Boolean)) {
+                throw new IllegalArgumentException(
+                    "flag \"" + flagKey + "\" has a non-boolean condition");
+              }
+              break;
+            default:
+              break;
           }
         }
       }

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -80,6 +80,7 @@ public class DDEvaluatorTest {
       MOSHI.adapter(FIXTURE_LIST_TYPE);
   private static final ThreadLocal<Map<String, String>> INVALID_FLAGS_HOLDER =
       ThreadLocal.withInitial(HashMap::new);
+  private static final long MAX_UNSIGNED_INT = 0xffff_ffffL;
 
   @Test
   public void testInitializeSignalsApplicationProviderActivation() throws Exception {
@@ -226,6 +227,34 @@ public class DDEvaluatorTest {
     assertThat(details.getValue(), equalTo(23));
     assertThat(details.getReason(), equalTo("DEFAULT"));
     assertThat(details.getErrorCode(), nullValue());
+  }
+
+  @Test
+  public void testEvaluateUnsignedShardRange() {
+    final Map<String, Variant> variations = new HashMap<>();
+    variations.put("on", new Variant("on", 1));
+    final Shard shard =
+        new Shard(
+            "salt",
+            singletonList(new ShardRange(3_699_531_192L, 3_699_531_193L)),
+            MAX_UNSIGNED_INT);
+    final Split split = new Split(singletonList(shard), "on", emptyMap(), null);
+    final Allocation allocation =
+        new Allocation("alloc-1", null, null, null, singletonList(split), Boolean.FALSE);
+    final Map<String, Flag> flags = new HashMap<>();
+    flags.put(
+        "target",
+        new Flag("target", true, ValueType.INTEGER, variations, singletonList(allocation)));
+    final DDEvaluator evaluator = new DDEvaluator(mock(Runnable.class));
+    evaluator.accept(new ServerConfiguration("", "", false, null, flags));
+
+    final EvaluationContext context =
+        new MutableContext("target").setTargetingKey("high-shard-user");
+    final ProviderEvaluation<?> details = evaluator.evaluate(Integer.class, "target", 23, context);
+
+    assertThat(details.getValue(), equalTo(1));
+    assertThat(details.getReason(), equalTo("SPLIT"));
+    assertThat(details.getVariant(), equalTo("on"));
   }
 
   // ---- observeFullEvaluationData metadata is stamped from the evaluator's ServerConfiguration
@@ -1100,7 +1129,7 @@ public class DDEvaluatorTest {
         final String flagKey = reader.nextName();
         final Object rawFlag = reader.readJsonValue();
         try {
-          validateRawShardTotals(rawFlag);
+          validateRawShardBounds(rawFlag);
           final Flag flag = flagAdapter.fromJsonValue(rawFlag);
           if (flag != null) {
             validateFlag(flagKey, flag);
@@ -1115,7 +1144,7 @@ public class DDEvaluatorTest {
       return flags;
     }
 
-    private static void validateRawShardTotals(final Object rawFlag) {
+    private static void validateRawShardBounds(final Object rawFlag) {
       if (!(rawFlag instanceof Map)) {
         return;
       }
@@ -1143,13 +1172,27 @@ public class DDEvaluatorTest {
             if (!(shard instanceof Map)) {
               continue;
             }
-            final Object totalShards = ((Map<?, ?>) shard).get("totalShards");
-            if (totalShards instanceof Number
-                && ((Number) totalShards).longValue() > Integer.MAX_VALUE) {
-              throw new IllegalArgumentException("flag contains an oversized totalShards value");
+            final Map<?, ?> rawShard = (Map<?, ?>) shard;
+            validateUnsignedInt(rawShard.get("totalShards"));
+            final Object ranges = rawShard.get("ranges");
+            if (!(ranges instanceof List)) {
+              continue;
+            }
+            for (final Object range : (List<?>) ranges) {
+              if (range instanceof Map) {
+                final Map<?, ?> rawRange = (Map<?, ?>) range;
+                validateUnsignedInt(rawRange.get("start"));
+                validateUnsignedInt(rawRange.get("end"));
+              }
             }
           }
         }
+      }
+    }
+
+    private static void validateUnsignedInt(final Object value) {
+      if (value instanceof Number && ((Number) value).longValue() > MAX_UNSIGNED_INT) {
+        throw new IllegalArgumentException("flag contains an oversized shard value");
       }
     }
 

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -1100,6 +1100,7 @@ public class DDEvaluatorTest {
         final String flagKey = reader.nextName();
         final Object rawFlag = reader.readJsonValue();
         try {
+          validateRawShardTotals(rawFlag);
           final Flag flag = flagAdapter.fromJsonValue(rawFlag);
           if (flag != null) {
             validateFlag(flagKey, flag);
@@ -1112,6 +1113,44 @@ public class DDEvaluatorTest {
       }
       reader.endObject();
       return flags;
+    }
+
+    private static void validateRawShardTotals(final Object rawFlag) {
+      if (!(rawFlag instanceof Map)) {
+        return;
+      }
+      final Object allocations = ((Map<?, ?>) rawFlag).get("allocations");
+      if (!(allocations instanceof List)) {
+        return;
+      }
+      for (final Object allocation : (List<?>) allocations) {
+        if (!(allocation instanceof Map)) {
+          continue;
+        }
+        final Object splits = ((Map<?, ?>) allocation).get("splits");
+        if (!(splits instanceof List)) {
+          continue;
+        }
+        for (final Object split : (List<?>) splits) {
+          if (!(split instanceof Map)) {
+            continue;
+          }
+          final Object shards = ((Map<?, ?>) split).get("shards");
+          if (!(shards instanceof List)) {
+            continue;
+          }
+          for (final Object shard : (List<?>) shards) {
+            if (!(shard instanceof Map)) {
+              continue;
+            }
+            final Object totalShards = ((Map<?, ?>) shard).get("totalShards");
+            if (totalShards instanceof Number
+                && ((Number) totalShards).longValue() > Integer.MAX_VALUE) {
+              throw new IllegalArgumentException("flag contains an oversized totalShards value");
+            }
+          }
+        }
+      }
     }
 
     private static void validateFlag(final String flagKey, final Flag flag) {
@@ -1135,10 +1174,7 @@ public class DDEvaluatorTest {
                 "flag \"" + flagKey + "\" contains a split with missing shards");
           }
           for (final Shard shard : split.shards) {
-            if (shard == null
-                || shard.totalShards <= 0
-                || shard.totalShards > Integer.MAX_VALUE
-                || shard.ranges == null) {
+            if (shard == null || shard.totalShards <= 0 || shard.ranges == null) {
               throw new IllegalArgumentException(
                   "flag \"" + flagKey + "\" contains invalid shards");
             }

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemver.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemver.java
@@ -1,5 +1,7 @@
 package datadog.trace.api.featureflag.ufc.v1;
 
+import java.util.Arrays;
+
 /**
  * ParsedSemver is the language-neutral representation of the SemVer subset used by FFE. Owning this
  * parser and comparator keeps behavior consistent across SDKs and lets configuration preprocessing
@@ -15,15 +17,13 @@ public final class ParsedSemver {
   /** Sentinel returned by {@link #parse(String)} when the input is not a valid semantic version. */
   public static final ParsedSemver INVALID = null;
 
-  private final long major; // unsigned
-  private final long minor; // unsigned
-  private final long patch; // unsigned
+  private final long[] core; // unsigned, with omitted minor and patch normalized to zero
+  private final int coreLength;
   private final String prerelease;
 
-  ParsedSemver(final long major, final long minor, final long patch, final String prerelease) {
-    this.major = major;
-    this.minor = minor;
-    this.patch = patch;
+  ParsedSemver(final long[] core, final int coreLength, final String prerelease) {
+    this.core = core;
+    this.coreLength = coreLength;
     this.prerelease = prerelease;
   }
 
@@ -35,45 +35,38 @@ public final class ParsedSemver {
    *     version
    */
   public static ParsedSemver parse(final String version) {
-    // Parse major
-    final long[] majorResult = parseCoreIdentifier(version, 0);
-    if (majorResult == null) {
-      return INVALID;
+    long[] core = new long[3];
+    int coreSize = 0;
+    int next = 0;
+    while (true) {
+      final int end = coreIdentifierEnd(version, next);
+      if (end == -1) {
+        return INVALID;
+      }
+      final long component;
+      try {
+        component = Long.parseUnsignedLong(version.substring(next, end));
+      } catch (final NumberFormatException e) {
+        return INVALID; // overflow
+      }
+      if (coreSize == core.length) {
+        core = Arrays.copyOf(core, core.length * 2);
+      }
+      core[coreSize++] = component;
+      next = end;
+      if (next == version.length() || version.charAt(next) != '.') {
+        break;
+      }
+      next++;
     }
-    final long major = majorResult[0];
-    int next = (int) majorResult[1];
-    if (next >= version.length() || version.charAt(next) != '.') {
-      return INVALID;
-    }
-
-    // Parse minor
-    final long[] minorResult = parseCoreIdentifier(version, next + 1);
-    if (minorResult == null) {
-      return INVALID;
-    }
-    final long minor = minorResult[0];
-    next = (int) minorResult[1];
-    if (next >= version.length() || version.charAt(next) != '.') {
-      return INVALID;
-    }
-
-    // Parse patch
-    final long[] patchResult = parseCoreIdentifier(version, next + 1);
-    if (patchResult == null) {
-      return INVALID;
-    }
-    final long patch = patchResult[0];
-    next = (int) patchResult[1];
-
-    final ParsedSemver parsed = new ParsedSemver(major, minor, patch, "");
+    final int coreLength = Math.max(3, coreSize);
     if (next == version.length()) {
-      return parsed;
+      return new ParsedSemver(core, coreLength, "");
     }
 
-    // Parse prerelease and/or build metadata
+    // Parse prerelease and/or build metadata.
     String remainder = version.substring(next);
     String prerelease = "";
-
     if (remainder.charAt(0) == '-') {
       remainder = remainder.substring(1);
       final int buildStart = remainder.indexOf('+');
@@ -81,10 +74,8 @@ public final class ParsedSemver {
         if (!validSemverIdentifiers(remainder, false)) {
           return INVALID;
         }
-        prerelease = remainder;
-        return new ParsedSemver(major, minor, patch, prerelease);
+        return new ParsedSemver(core, coreLength, remainder);
       }
-
       prerelease = remainder.substring(0, buildStart);
       if (!validSemverIdentifiers(prerelease, false)) {
         return INVALID;
@@ -95,11 +86,10 @@ public final class ParsedSemver {
     } else {
       return INVALID;
     }
-
     if (!validSemverIdentifiers(remainder, true)) {
       return INVALID;
     }
-    return new ParsedSemver(major, minor, patch, prerelease);
+    return new ParsedSemver(core, coreLength, prerelease);
   }
 
   /**
@@ -111,45 +101,37 @@ public final class ParsedSemver {
    *     {@code right}, zero if they have equal precedence
    */
   public static int compare(final ParsedSemver left, final ParsedSemver right) {
-    int cmp = Long.compareUnsigned(left.major, right.major);
-    if (cmp != 0) {
-      return cmp;
-    }
-    cmp = Long.compareUnsigned(left.minor, right.minor);
-    if (cmp != 0) {
-      return cmp;
-    }
-    cmp = Long.compareUnsigned(left.patch, right.patch);
-    if (cmp != 0) {
-      return cmp;
+    final int coreLength = Math.max(left.coreLength, right.coreLength);
+    for (int i = 0; i < coreLength; i++) {
+      final int cmp = Long.compareUnsigned(left.coreComponent(i), right.coreComponent(i));
+      if (cmp != 0) {
+        return cmp;
+      }
     }
     return comparePrerelease(left.prerelease, right.prerelease);
   }
 
   /**
-   * Parses a core version identifier (major, minor, or patch). Enforces the unsigned 64-bit bound
-   * without accepting leading zeros (except for the value zero itself).
-   *
-   * @return a two-element array {@code {value, nextIndex}}, or {@code null} on failure
+   * Finds the end of a core version identifier (major, minor, or patch), rejecting leading zeros
+   * except for the value zero itself.
    */
-  private static long[] parseCoreIdentifier(final String version, final int start) {
+  private static int coreIdentifierEnd(final String version, final int start) {
     if (start >= version.length() || !isASCIIDigit(version.charAt(start))) {
-      return null;
+      return -1;
     }
     if (version.charAt(start) == '0') {
-      return new long[] {0, start + 1};
+      return start + 1;
     }
 
     int end = start;
     while (end < version.length() && isASCIIDigit(version.charAt(end))) {
       end++;
     }
-    try {
-      final long value = Long.parseUnsignedLong(version.substring(start, end));
-      return new long[] {value, end};
-    } catch (final NumberFormatException e) {
-      return null; // overflow
-    }
+    return end;
+  }
+
+  private long coreComponent(final int index) {
+    return index < coreLength ? core[index] : 0;
   }
 
   /**
@@ -269,15 +251,15 @@ public final class ParsedSemver {
   // --- Accessors for testing ---
 
   long getMajor() {
-    return major;
+    return core[0];
   }
 
   long getMinor() {
-    return minor;
+    return core[1];
   }
 
   long getPatch() {
-    return patch;
+    return core[2];
   }
 
   String getPrerelease() {
@@ -293,23 +275,36 @@ public final class ParsedSemver {
       return false;
     }
     final ParsedSemver that = (ParsedSemver) o;
-    return major == that.major
-        && minor == that.minor
-        && patch == that.patch
-        && prerelease.equals(that.prerelease);
+    if (coreLength != that.coreLength || !prerelease.equals(that.prerelease)) {
+      return false;
+    }
+    for (int i = 0; i < coreLength; i++) {
+      if (core[i] != that.core[i]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Override
   public int hashCode() {
-    int result = Long.hashCode(major);
-    result = 31 * result + Long.hashCode(minor);
-    result = 31 * result + Long.hashCode(patch);
-    result = 31 * result + prerelease.hashCode();
-    return result;
+    int result = 1;
+    for (int i = 0; i < coreLength; i++) {
+      result = 31 * result + Long.hashCode(core[i]);
+    }
+    result = 31 * result + coreLength;
+    return 31 * result + prerelease.hashCode();
   }
 
   @Override
   public String toString() {
-    return major + "." + minor + "." + patch + (prerelease.isEmpty() ? "" : "-" + prerelease);
+    final StringBuilder value = new StringBuilder();
+    for (int i = 0; i < coreLength; i++) {
+      if (i > 0) {
+        value.append('.');
+      }
+      value.append(Long.toUnsignedString(coreComponent(i)));
+    }
+    return value.append(prerelease.isEmpty() ? "" : "-" + prerelease).toString();
   }
 }

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemver.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemver.java
@@ -135,6 +135,20 @@ public final class ParsedSemver {
   }
 
   /**
+   * Returns the number of significant core components, excluding trailing zero components that
+   * {@link #compare} treats as equal to omitted components. This keeps {@link #equals} and {@link
+   * #hashCode} consistent with precedence comparison so that versions like {@code 1.2.3} and {@code
+   * 1.2.3.0} are equal and hash identically.
+   */
+  private int effectiveCoreLength() {
+    int length = coreLength;
+    while (length > 0 && core[length - 1] == 0L) {
+      length--;
+    }
+    return length;
+  }
+
+  /**
    * Validates dot-separated identifiers. Permits leading zeros for build metadata only; numeric
    * prerelease identifiers reject them.
    */
@@ -274,25 +288,19 @@ public final class ParsedSemver {
     if (!(o instanceof ParsedSemver)) {
       return false;
     }
-    final ParsedSemver that = (ParsedSemver) o;
-    if (coreLength != that.coreLength || !prerelease.equals(that.prerelease)) {
-      return false;
-    }
-    for (int i = 0; i < coreLength; i++) {
-      if (core[i] != that.core[i]) {
-        return false;
-      }
-    }
-    return true;
+    // Delegate to compare so equality matches precedence (SEMVER_EQ) and sorted collections, even
+    // when versions differ only by trailing zero components such as 1.2.3 and 1.2.3.0.
+    return compare(this, (ParsedSemver) o) == 0;
   }
 
   @Override
   public int hashCode() {
+    // Hash over the trailing-zero-stripped core so that compare-equal versions hash identically.
+    final int effectiveLength = effectiveCoreLength();
     int result = 1;
-    for (int i = 0; i < coreLength; i++) {
+    for (int i = 0; i < effectiveLength; i++) {
       result = 31 * result + Long.hashCode(core[i]);
     }
-    result = 31 * result + coreLength;
     return 31 * result + prerelease.hashCode();
   }
 

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/Shard.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/Shard.java
@@ -2,12 +2,19 @@ package datadog.trace.api.featureflag.ufc.v1;
 
 import java.util.List;
 
+/**
+ * A UFC shard.
+ *
+ * <p>{@code totalShards} stores the unsigned 32-bit wire value in an {@code int} to preserve this
+ * bootstrap model's binary compatibility. Consumers must use {@link Integer#toUnsignedLong(int)}
+ * before comparing it or using it for arithmetic.
+ */
 public class Shard {
   public final String salt;
   public final List<ShardRange> ranges;
-  public final long totalShards;
+  public final int totalShards;
 
-  public Shard(final String salt, final List<ShardRange> ranges, final long totalShards) {
+  public Shard(final String salt, final List<ShardRange> ranges, final int totalShards) {
     this.salt = salt;
     this.ranges = ranges;
     this.totalShards = totalShards;

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/Shard.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/Shard.java
@@ -5,9 +5,9 @@ import java.util.List;
 public class Shard {
   public final String salt;
   public final List<ShardRange> ranges;
-  public final long totalShards;
+  public final int totalShards;
 
-  public Shard(final String salt, final List<ShardRange> ranges, final long totalShards) {
+  public Shard(final String salt, final List<ShardRange> ranges, final int totalShards) {
     this.salt = salt;
     this.ranges = ranges;
     this.totalShards = totalShards;

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/Shard.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/Shard.java
@@ -5,9 +5,9 @@ import java.util.List;
 public class Shard {
   public final String salt;
   public final List<ShardRange> ranges;
-  public final int totalShards;
+  public final long totalShards;
 
-  public Shard(final String salt, final List<ShardRange> ranges, final int totalShards) {
+  public Shard(final String salt, final List<ShardRange> ranges, final long totalShards) {
     this.salt = salt;
     this.ranges = ranges;
     this.totalShards = totalShards;

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ShardRange.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ShardRange.java
@@ -1,10 +1,10 @@
 package datadog.trace.api.featureflag.ufc.v1;
 
 public class ShardRange {
-  public final int start;
-  public final int end;
+  public final long start;
+  public final long end;
 
-  public ShardRange(final int start, final int end) {
+  public ShardRange(final long start, final long end) {
     this.start = start;
     this.end = end;
   }

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ShardRange.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/ufc/v1/ShardRange.java
@@ -1,10 +1,17 @@
 package datadog.trace.api.featureflag.ufc.v1;
 
+/**
+ * A UFC shard range.
+ *
+ * <p>{@code start} and {@code end} store unsigned 32-bit wire values in {@code int} fields to
+ * preserve this bootstrap model's binary compatibility. Consumers must use {@link
+ * Integer#toUnsignedLong(int)} before comparing them.
+ */
 public class ShardRange {
-  public final long start;
-  public final long end;
+  public final int start;
+  public final int end;
 
-  public ShardRange(final long start, final long end) {
+  public ShardRange(final int start, final int end) {
     this.start = start;
     this.end = end;
   }

--- a/products/feature-flagging/feature-flagging-bootstrap/src/test/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemverTest.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/test/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemverTest.java
@@ -2,6 +2,7 @@ package datadog.trace.api.featureflag.ufc.v1;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -172,6 +173,40 @@ class ParsedSemverTest {
     final ParsedSemver right = ParsedSemver.parse("1.0.0-11");
     assertTrue(right != null);
     assertTrue(ParsedSemver.compare(left, right) < 0);
+  }
+
+  @Test
+  void testEqualsAndHashCodeNormalizeTrailingZeroComponents() {
+    // Versions that compare as equal must also be equals() and share a hashCode, even when they
+    // differ only by trailing zero components (1.2.3 vs 1.2.3.0 vs 1.2.3.0.0).
+    final ParsedSemver base = ParsedSemver.parse("1.2.3");
+    final ParsedSemver trailingZero = ParsedSemver.parse("1.2.3.0");
+    final ParsedSemver trailingZeros = ParsedSemver.parse("1.2.3.0.0");
+    assertTrue(base != null);
+    assertTrue(trailingZero != null);
+    assertTrue(trailingZeros != null);
+    assertEquals(0, ParsedSemver.compare(base, trailingZero));
+    assertEquals(0, ParsedSemver.compare(base, trailingZeros));
+    assertEquals(base, trailingZero);
+    assertEquals(base, trailingZeros);
+    assertEquals(trailingZero, trailingZeros);
+    assertEquals(base.hashCode(), trailingZero.hashCode());
+    assertEquals(base.hashCode(), trailingZeros.hashCode());
+    assertEquals(trailingZero.hashCode(), trailingZeros.hashCode());
+
+    // All-zero versions of varying length are also compare-equal and must hash identically.
+    final ParsedSemver zero = ParsedSemver.parse("0");
+    final ParsedSemver zeroZero = ParsedSemver.parse("0.0.0.0");
+    assertTrue(zero != null);
+    assertTrue(zeroZero != null);
+    assertEquals(0, ParsedSemver.compare(zero, zeroZero));
+    assertEquals(zero, zeroZero);
+    assertEquals(zero.hashCode(), zeroZero.hashCode());
+
+    // Distinct versions must remain unequal and may differ in hash.
+    final ParsedSemver release = ParsedSemver.parse("1.2.4");
+    assertTrue(release != null);
+    assertNotEquals(base, release);
   }
 
   @Test

--- a/products/feature-flagging/feature-flagging-bootstrap/src/test/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemverTest.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/test/java/datadog/trace/api/featureflag/ufc/v1/ParsedSemverTest.java
@@ -50,9 +50,6 @@ class ParsedSemverTest {
     return Stream.of(
         "",
         "x",
-        "1",
-        "1.2",
-        "1.2.3.4",
         "v1.2.3",
         "01.2.3",
         "1.02.3",
@@ -94,6 +91,33 @@ class ParsedSemverTest {
     "1.1.0",
     "2.0.0",
   };
+
+  @Test
+  void normalizesMissingCorePartsAndComparesExtendedCoreParts() {
+    assertEquals(0, ParsedSemver.compare(ParsedSemver.parse("18"), ParsedSemver.parse("18.0.0")));
+    assertEquals(0, ParsedSemver.compare(ParsedSemver.parse("18.0"), ParsedSemver.parse("18.0.0")));
+    assertEquals(
+        0, ParsedSemver.compare(ParsedSemver.parse("1.2.3"), ParsedSemver.parse("1.2.3.0")));
+    assertEquals(
+        0, ParsedSemver.compare(ParsedSemver.parse("1.2.3"), ParsedSemver.parse("1.2.3.0.0")));
+    assertTrue(
+        ParsedSemver.compare(ParsedSemver.parse("1.2.3.4"), ParsedSemver.parse("1.2.3.5")) < 0);
+    assertTrue(ParsedSemver.parse("1.2.3.4.5.6") != null);
+    assertTrue(ParsedSemver.parse("1.2.3.4.5.6.7") != null);
+    assertTrue(
+        ParsedSemver.compare(ParsedSemver.parse("1.2.3.4.5"), ParsedSemver.parse("1.2.3.4.6")) < 0);
+    assertTrue(
+        ParsedSemver.compare(ParsedSemver.parse("1.2.3.4.5.6"), ParsedSemver.parse("1.2.3.4.5.7"))
+            < 0);
+    assertTrue(
+        ParsedSemver.compare(
+                ParsedSemver.parse("1.2.3.4.5.6.7"), ParsedSemver.parse("1.2.3.4.5.6.8"))
+            < 0);
+    assertTrue(
+        ParsedSemver.compare(ParsedSemver.parse("18.0.0.0"), ParsedSemver.parse("17.0.0")) > 0);
+    assertTrue(
+        ParsedSemver.compare(ParsedSemver.parse("18.0.0.0.0"), ParsedSemver.parse("17.0.0")) > 0);
+  }
 
   @Test
   void testCompareSemverOrdering() {

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
@@ -39,6 +39,7 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
 
   static final String INVALID_FLAG = "invalid_flag";
   static final String INVALID_SEMVER_COMPARAND = "invalid_semver_comparand";
+  private static final long MAX_UNSIGNED_INT = 0xffff_ffffL;
 
   /**
    * Side-channel for tracking flags that failed semver comparand validation during parsing. Cleared
@@ -91,8 +92,8 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
     reader.peek();
   }
 
-  /** Rejects raw shard counts that exceed the bootstrap model's signed-int range. */
-  private static void validateRawShardTotals(final Object rawFlag) {
+  /** Rejects shard values that exceed the UFC unsigned 32-bit range. */
+  private static void validateRawShardBounds(final Object rawFlag) {
     if (!(rawFlag instanceof Map)) {
       return;
     }
@@ -120,13 +121,27 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
           if (!(shard instanceof Map)) {
             continue;
           }
-          final Object totalShards = ((Map<?, ?>) shard).get("totalShards");
-          if (totalShards instanceof Number
-              && ((Number) totalShards).longValue() > Integer.MAX_VALUE) {
-            throw new InvalidFlagException("flag contains an oversized totalShards value");
+          final Map<?, ?> rawShard = (Map<?, ?>) shard;
+          validateUnsignedInt(rawShard.get("totalShards"), "totalShards");
+          final Object ranges = rawShard.get("ranges");
+          if (!(ranges instanceof List)) {
+            continue;
+          }
+          for (final Object range : (List<?>) ranges) {
+            if (range instanceof Map) {
+              final Map<?, ?> rawRange = (Map<?, ?>) range;
+              validateUnsignedInt(rawRange.get("start"), "range start");
+              validateUnsignedInt(rawRange.get("end"), "range end");
+            }
           }
         }
       }
+    }
+  }
+
+  private static void validateUnsignedInt(final Object value, final String fieldName) {
+    if (value instanceof Number && ((Number) value).longValue() > MAX_UNSIGNED_INT) {
+      throw new InvalidFlagException("flag contains an oversized " + fieldName + " value");
     }
   }
 
@@ -322,7 +337,7 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
         final String flagKey = reader.nextName();
         final Object rawFlag = reader.readJsonValue();
         try {
-          validateRawShardTotals(rawFlag);
+          validateRawShardBounds(rawFlag);
           final Flag flag = flagAdapter.fromJsonValue(rawFlag);
           if (flag != null) {
             validateFlag(flagKey, flag);

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
@@ -22,6 +22,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +55,7 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
   private static final Moshi MOSHI =
       new Moshi.Builder()
           .add(Instant.class, new InstantAdapter())
+          .add(ShardAdapter.FACTORY)
           .add(AllocationAdapter.FACTORY)
           .add(FlagMapAdapter.FACTORY)
           .add(LenientBooleanAdapter.FACTORY)
@@ -92,57 +94,15 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
     reader.peek();
   }
 
-  /** Rejects shard values that exceed the UFC unsigned 32-bit range. */
-  private static void validateRawShardBounds(final Object rawFlag) {
-    if (!(rawFlag instanceof Map)) {
-      return;
+  /** Converts a UFC uint32 wire value to its binary-compatible int representation. */
+  private static int toUnsignedInt(@Nullable final Long value, final String fieldName) {
+    if (value == null) {
+      return 0;
     }
-    final Object allocations = ((Map<?, ?>) rawFlag).get("allocations");
-    if (!(allocations instanceof List)) {
-      return;
+    if (value < 0 || value > MAX_UNSIGNED_INT) {
+      throw new InvalidFlagException("flag contains an invalid " + fieldName + " value");
     }
-    for (final Object allocation : (List<?>) allocations) {
-      if (!(allocation instanceof Map)) {
-        continue;
-      }
-      final Object splits = ((Map<?, ?>) allocation).get("splits");
-      if (!(splits instanceof List)) {
-        continue;
-      }
-      for (final Object split : (List<?>) splits) {
-        if (!(split instanceof Map)) {
-          continue;
-        }
-        final Object shards = ((Map<?, ?>) split).get("shards");
-        if (!(shards instanceof List)) {
-          continue;
-        }
-        for (final Object shard : (List<?>) shards) {
-          if (!(shard instanceof Map)) {
-            continue;
-          }
-          final Map<?, ?> rawShard = (Map<?, ?>) shard;
-          validateUnsignedInt(rawShard.get("totalShards"), "totalShards");
-          final Object ranges = rawShard.get("ranges");
-          if (!(ranges instanceof List)) {
-            continue;
-          }
-          for (final Object range : (List<?>) ranges) {
-            if (range instanceof Map) {
-              final Map<?, ?> rawRange = (Map<?, ?>) range;
-              validateUnsignedInt(rawRange.get("start"), "range start");
-              validateUnsignedInt(rawRange.get("end"), "range end");
-            }
-          }
-        }
-      }
-    }
-  }
-
-  private static void validateUnsignedInt(final Object value, final String fieldName) {
-    if (value instanceof Number && ((Number) value).longValue() > MAX_UNSIGNED_INT) {
-      throw new InvalidFlagException("flag contains an oversized " + fieldName + " value");
-    }
+    return value.intValue();
   }
 
   /** Validates the required nested UFC fields and SemVer comparands for a flag. */
@@ -167,11 +127,13 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
               "flag \"" + flagKey + "\" contains a split with missing shards");
         }
         for (final Shard shard : split.shards) {
-          if (shard == null || shard.totalShards <= 0 || shard.ranges == null) {
+          if (shard == null
+              || Integer.toUnsignedLong(shard.totalShards) == 0
+              || shard.ranges == null) {
             throw new InvalidFlagException("flag \"" + flagKey + "\" contains invalid shards");
           }
           for (final ShardRange range : shard.ranges) {
-            if (range == null || range.start < 0 || range.end < 0) {
+            if (range == null) {
               throw new InvalidFlagException(
                   "flag \"" + flagKey + "\" contains an invalid shard range");
             }
@@ -299,6 +261,74 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
     }
   }
 
+  /**
+   * Reads UFC uint32 shard fields through Long first, then preserves the bootstrap model's int ABI
+   * by storing the accepted value as its two's-complement bit pattern.
+   */
+  static final class ShardAdapter extends JsonAdapter<Shard> {
+
+    static final Factory FACTORY =
+        new Factory() {
+          @Nullable
+          @Override
+          public JsonAdapter<?> create(
+              @Nonnull final Type type,
+              @Nonnull final Set<? extends Annotation> annotations,
+              @Nonnull final Moshi moshi) {
+            if (!annotations.isEmpty() || type != Shard.class) {
+              return null;
+            }
+            return new ShardAdapter(moshi.adapter(ShardJson.class));
+          }
+        };
+
+    private final JsonAdapter<ShardJson> delegate;
+
+    ShardAdapter(final JsonAdapter<ShardJson> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Nullable
+    @Override
+    public Shard fromJson(@Nonnull final JsonReader reader) throws IOException {
+      final ShardJson shard = delegate.fromJson(reader);
+      if (shard == null) {
+        return null;
+      }
+      final List<ShardRange> ranges;
+      if (shard.ranges == null) {
+        ranges = null;
+      } else {
+        ranges = new ArrayList<>();
+        for (final ShardRangeJson range : shard.ranges) {
+          ranges.add(
+              range == null
+                  ? null
+                  : new ShardRange(
+                      toUnsignedInt(range.start, "range start"),
+                      toUnsignedInt(range.end, "range end")));
+        }
+      }
+      return new Shard(shard.salt, ranges, toUnsignedInt(shard.totalShards, "totalShards"));
+    }
+
+    @Override
+    public void toJson(@Nonnull final JsonWriter writer, @Nullable final Shard value) {
+      throw new UnsupportedOperationException("Reading only adapter");
+    }
+  }
+
+  static final class ShardJson {
+    String salt;
+    List<ShardRangeJson> ranges;
+    Long totalShards;
+  }
+
+  static final class ShardRangeJson {
+    Long start;
+    Long end;
+  }
+
   static final class FlagMapAdapter extends JsonAdapter<Map<String, Flag>> {
 
     private static final Type FLAGS_TYPE =
@@ -337,7 +367,6 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
         final String flagKey = reader.nextName();
         final Object rawFlag = reader.readJsonValue();
         try {
-          validateRawShardBounds(rawFlag);
           final Flag flag = flagAdapter.fromJsonValue(rawFlag);
           if (flag != null) {
             validateFlag(flagKey, flag);

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
@@ -91,6 +91,45 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
     reader.peek();
   }
 
+  /** Rejects raw shard counts that exceed the bootstrap model's signed-int range. */
+  private static void validateRawShardTotals(final Object rawFlag) {
+    if (!(rawFlag instanceof Map)) {
+      return;
+    }
+    final Object allocations = ((Map<?, ?>) rawFlag).get("allocations");
+    if (!(allocations instanceof List)) {
+      return;
+    }
+    for (final Object allocation : (List<?>) allocations) {
+      if (!(allocation instanceof Map)) {
+        continue;
+      }
+      final Object splits = ((Map<?, ?>) allocation).get("splits");
+      if (!(splits instanceof List)) {
+        continue;
+      }
+      for (final Object split : (List<?>) splits) {
+        if (!(split instanceof Map)) {
+          continue;
+        }
+        final Object shards = ((Map<?, ?>) split).get("shards");
+        if (!(shards instanceof List)) {
+          continue;
+        }
+        for (final Object shard : (List<?>) shards) {
+          if (!(shard instanceof Map)) {
+            continue;
+          }
+          final Object totalShards = ((Map<?, ?>) shard).get("totalShards");
+          if (totalShards instanceof Number
+              && ((Number) totalShards).longValue() > Integer.MAX_VALUE) {
+            throw new InvalidFlagException("flag contains an oversized totalShards value");
+          }
+        }
+      }
+    }
+  }
+
   /** Validates the required nested UFC fields and SemVer comparands for a flag. */
   private static void validateFlag(final String flagKey, final Flag flag) {
     if (flag.allocations == null) {
@@ -115,7 +154,6 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
         for (final Shard shard : split.shards) {
           if (shard == null
               || shard.totalShards <= 0
-              || shard.totalShards > Integer.MAX_VALUE
               || shard.ranges == null) {
             throw new InvalidFlagException("flag \"" + flagKey + "\" contains invalid shards");
           }
@@ -286,6 +324,7 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
         final String flagKey = reader.nextName();
         final Object rawFlag = reader.readJsonValue();
         try {
+          validateRawShardTotals(rawFlag);
           final Flag flag = flagAdapter.fromJsonValue(rawFlag);
           if (flag != null) {
             validateFlag(flagKey, flag);

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
@@ -13,6 +13,8 @@ import datadog.trace.api.featureflag.ufc.v1.Flag;
 import datadog.trace.api.featureflag.ufc.v1.ParsedSemver;
 import datadog.trace.api.featureflag.ufc.v1.Rule;
 import datadog.trace.api.featureflag.ufc.v1.ServerConfiguration;
+import datadog.trace.api.featureflag.ufc.v1.Shard;
+import datadog.trace.api.featureflag.ufc.v1.ShardRange;
 import datadog.trace.api.featureflag.ufc.v1.Split;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -95,17 +97,79 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
       return;
     }
     for (final Allocation allocation : flag.allocations) {
-      if (allocation == null || allocation.splits == null) {
+      if (allocation == null) {
+        continue;
+      }
+      validateConditionOperands(flagKey, allocation);
+      if (allocation.splits == null) {
         continue;
       }
       for (final Split split : allocation.splits) {
-        if (split != null && split.shards == null) {
+        if (split == null) {
+          continue;
+        }
+        if (split.shards == null) {
           throw new InvalidFlagException(
               "flag \"" + flagKey + "\" contains a split with missing shards");
+        }
+        for (final Shard shard : split.shards) {
+          if (shard == null
+              || shard.totalShards <= 0
+              || shard.totalShards > Integer.MAX_VALUE
+              || shard.ranges == null) {
+            throw new InvalidFlagException("flag \"" + flagKey + "\" contains invalid shards");
+          }
+          for (final ShardRange range : shard.ranges) {
+            if (range == null || range.start < 0 || range.end < 0) {
+              throw new InvalidFlagException(
+                  "flag \"" + flagKey + "\" contains an invalid shard range");
+            }
+          }
         }
       }
     }
     validateAndCacheSemverComparands(flagKey, flag);
+  }
+
+  private static void validateConditionOperands(final String flagKey, final Allocation allocation) {
+    if (allocation.rules == null) {
+      return;
+    }
+    for (final Rule rule : allocation.rules) {
+      if (rule == null || rule.conditions == null) {
+        continue;
+      }
+      for (final ConditionConfiguration condition : rule.conditions) {
+        if (condition == null || condition.operator == null) {
+          continue;
+        }
+        switch (condition.operator) {
+          case LT:
+          case LTE:
+          case GT:
+          case GTE:
+            if (!(condition.value instanceof Number)) {
+              throw new InvalidFlagException(
+                  "flag \"" + flagKey + "\" has a non-numeric condition");
+            }
+            break;
+          case ONE_OF:
+          case NOT_ONE_OF:
+            if (!(condition.value instanceof List)) {
+              throw new InvalidFlagException("flag \"" + flagKey + "\" has a non-list condition");
+            }
+            break;
+          case IS_NULL:
+            if (!(condition.value instanceof Boolean)) {
+              throw new InvalidFlagException(
+                  "flag \"" + flagKey + "\" has a non-boolean condition");
+            }
+            break;
+          default:
+            break;
+        }
+      }
+    }
   }
 
   /**

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/UniversalFlagConfigParser.java
@@ -152,9 +152,7 @@ final class UniversalFlagConfigParser implements ConfigurationDeserializer<Serve
               "flag \"" + flagKey + "\" contains a split with missing shards");
         }
         for (final Shard shard : split.shards) {
-          if (shard == null
-              || shard.totalShards <= 0
-              || shard.ranges == null) {
+          if (shard == null || shard.totalShards <= 0 || shard.ranges == null) {
             throw new InvalidFlagException("flag \"" + flagKey + "\" contains invalid shards");
           }
           for (final ShardRange range : shard.ranges) {

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
@@ -217,7 +217,7 @@ class JsonApiUfcResponseParserTest {
                         ",\"allocations\":[{\"key\":\"zero-total-shards\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"salt\",\"totalShards\":0,\"ranges\":[]}]}]}]"),
                     booleanFlag(
                         "unsigned-total-shards",
-                        ",\"allocations\":[{\"key\":\"unsigned-total-shards\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"salt\",\"totalShards\":2147483648,\"ranges\":[]}]}]}]"),
+                        ",\"allocations\":[{\"key\":\"unsigned-total-shards\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"salt\",\"totalShards\":2147483648,\"ranges\":[{\"start\":2147483648,\"end\":2147483649}]}]}]}]"),
                     booleanFlag(
                         "too-many-shards",
                         ",\"allocations\":[{\"key\":\"too-many-shards\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"salt\",\"totalShards\":4294967296,\"ranges\":[]}]}]}]"),
@@ -249,16 +249,47 @@ class JsonApiUfcResponseParserTest {
     assertTrue(configuration.flags.containsKey("unsigned-total-shards"));
     assertEquals(
         2_147_483_648L,
-        configuration
-            .flags
-            .get("unsigned-total-shards")
-            .allocations
-            .get(0)
-            .splits
-            .get(0)
-            .shards
-            .get(0)
-            .totalShards);
+        Integer.toUnsignedLong(
+            configuration
+                .flags
+                .get("unsigned-total-shards")
+                .allocations
+                .get(0)
+                .splits
+                .get(0)
+                .shards
+                .get(0)
+                .totalShards));
+    assertEquals(
+        2_147_483_648L,
+        Integer.toUnsignedLong(
+            configuration
+                .flags
+                .get("unsigned-total-shards")
+                .allocations
+                .get(0)
+                .splits
+                .get(0)
+                .shards
+                .get(0)
+                .ranges
+                .get(0)
+                .start));
+    assertEquals(
+        2_147_483_649L,
+        Integer.toUnsignedLong(
+            configuration
+                .flags
+                .get("unsigned-total-shards")
+                .allocations
+                .get(0)
+                .splits
+                .get(0)
+                .shards
+                .get(0)
+                .ranges
+                .get(0)
+                .end));
     assertFalse(configuration.flags.containsKey("too-many-shards"));
     assertFalse(configuration.flags.containsKey("missing-ranges"));
     assertFalse(configuration.flags.containsKey("null-shard"));

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
@@ -207,6 +207,52 @@ class JsonApiUfcResponseParserTest {
   }
 
   @Test
+  void dropsFlagsWithInvalidShardBoundsAndConditionOperands() throws Exception {
+    final ServerConfiguration configuration =
+        parse(
+            wrap(
+                configWithFlags(
+                    booleanFlag(
+                        "zero-total-shards",
+                        ",\"allocations\":[{\"key\":\"zero-total-shards\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"salt\",\"totalShards\":0,\"ranges\":[]}]}]}]"),
+                    booleanFlag(
+                        "too-many-shards",
+                        ",\"allocations\":[{\"key\":\"too-many-shards\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"salt\",\"totalShards\":2147483648,\"ranges\":[]}]}]}]"),
+                    booleanFlag(
+                        "missing-ranges",
+                        ",\"allocations\":[{\"key\":\"missing-ranges\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"salt\",\"totalShards\":1}]}]}]"),
+                    booleanFlag(
+                        "null-shard",
+                        ",\"allocations\":[{\"key\":\"null-shard\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[null]}]}]"),
+                    booleanFlag(
+                        "null-range",
+                        ",\"allocations\":[{\"key\":\"null-range\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"salt\",\"totalShards\":1,\"ranges\":[null]}]}]}]"),
+                    booleanFlag(
+                        "negative-range-end",
+                        ",\"allocations\":[{\"key\":\"negative-range-end\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"salt\",\"totalShards\":1,\"ranges\":[{\"start\":0,\"end\":-1}]}]}]}]"),
+                    booleanFlag(
+                        "non-boolean-is-null",
+                        allocation(
+                            "non-boolean-is-null",
+                            "[{\"conditions\":[{\"attribute\":\"enabled\",\"operator\":\"IS_NULL\",\"value\":\"false\"}]}]")),
+                    booleanFlag(
+                        "valid-condition-operands",
+                        allocation(
+                            "valid-condition-operands",
+                            "[{\"conditions\":[{\"attribute\":\"age\",\"operator\":\"LT\",\"value\":1},{\"attribute\":\"role\",\"operator\":\"ONE_OF\",\"value\":[\"admin\"]},{\"attribute\":\"enabled\",\"operator\":\"IS_NULL\",\"value\":true}]}]")))));
+
+    assertNotNull(configuration);
+    assertFalse(configuration.flags.containsKey("zero-total-shards"));
+    assertFalse(configuration.flags.containsKey("too-many-shards"));
+    assertFalse(configuration.flags.containsKey("missing-ranges"));
+    assertFalse(configuration.flags.containsKey("null-shard"));
+    assertFalse(configuration.flags.containsKey("null-range"));
+    assertFalse(configuration.flags.containsKey("negative-range-end"));
+    assertFalse(configuration.flags.containsKey("non-boolean-is-null"));
+    assertTrue(configuration.flags.containsKey("valid-condition-operands"));
+  }
+
+  @Test
   void nullAttributesAreRejectedWithoutInvokingTheFlagParser() throws Exception {
     assertNull(parse("{\"data\":{\"type\":\"universal-flag-configuration\",\"attributes\":null}}"));
   }

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
@@ -176,6 +176,37 @@ class JsonApiUfcResponseParserTest {
   }
 
   @Test
+  void dropsFlagsWithInvalidConditionOperandsAndShardBounds() throws Exception {
+    final ServerConfiguration configuration =
+        parse(
+            wrap(
+                configWithFlags(
+                    booleanFlag(
+                        "non-numeric-gt",
+                        allocation(
+                            "non-numeric-gt",
+                            "[{\"conditions\":[{\"attribute\":\"age\",\"operator\":\"GT\",\"value\":\"bad\"}]}]")),
+                    booleanFlag(
+                        "non-list-one-of",
+                        allocation(
+                            "non-list-one-of",
+                            "[{\"conditions\":[{\"attribute\":\"role\",\"operator\":\"ONE_OF\",\"value\":\"admin\"}]}]")),
+                    booleanFlag(
+                        "negative-shard-range",
+                        ",\"allocations\":[{\"key\":\"negative-shard-range\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"salt\",\"totalShards\":100,\"ranges\":[{\"start\":-1,\"end\":1}]}]}]}]"),
+                    booleanFlag("valid-sibling", ""))));
+
+    assertNotNull(configuration);
+    assertFalse(configuration.flags.containsKey("non-numeric-gt"));
+    assertFalse(configuration.flags.containsKey("non-list-one-of"));
+    assertFalse(configuration.flags.containsKey("negative-shard-range"));
+    assertTrue(configuration.flags.containsKey("valid-sibling"));
+    assertEquals("invalid_flag", configuration.invalidFlags.get("non-numeric-gt"));
+    assertEquals("invalid_flag", configuration.invalidFlags.get("non-list-one-of"));
+    assertEquals("invalid_flag", configuration.invalidFlags.get("negative-shard-range"));
+  }
+
+  @Test
   void nullAttributesAreRejectedWithoutInvokingTheFlagParser() throws Exception {
     assertNull(parse("{\"data\":{\"type\":\"universal-flag-configuration\",\"attributes\":null}}"));
   }

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
@@ -216,8 +216,11 @@ class JsonApiUfcResponseParserTest {
                         "zero-total-shards",
                         ",\"allocations\":[{\"key\":\"zero-total-shards\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"salt\",\"totalShards\":0,\"ranges\":[]}]}]}]"),
                     booleanFlag(
+                        "unsigned-total-shards",
+                        ",\"allocations\":[{\"key\":\"unsigned-total-shards\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"salt\",\"totalShards\":2147483648,\"ranges\":[]}]}]}]"),
+                    booleanFlag(
                         "too-many-shards",
-                        ",\"allocations\":[{\"key\":\"too-many-shards\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"salt\",\"totalShards\":2147483648,\"ranges\":[]}]}]}]"),
+                        ",\"allocations\":[{\"key\":\"too-many-shards\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"salt\",\"totalShards\":4294967296,\"ranges\":[]}]}]}]"),
                     booleanFlag(
                         "missing-ranges",
                         ",\"allocations\":[{\"key\":\"missing-ranges\",\"rules\":[],\"splits\":[{\"variationKey\":\"on\",\"shards\":[{\"salt\":\"salt\",\"totalShards\":1}]}]}]"),
@@ -243,6 +246,19 @@ class JsonApiUfcResponseParserTest {
 
     assertNotNull(configuration);
     assertFalse(configuration.flags.containsKey("zero-total-shards"));
+    assertTrue(configuration.flags.containsKey("unsigned-total-shards"));
+    assertEquals(
+        2_147_483_648L,
+        configuration
+            .flags
+            .get("unsigned-total-shards")
+            .allocations
+            .get(0)
+            .splits
+            .get(0)
+            .shards
+            .get(0)
+            .totalShards);
     assertFalse(configuration.flags.containsKey("too-many-shards"));
     assertFalse(configuration.flags.containsKey("missing-ranges"));
     assertFalse(configuration.flags.containsKey("null-shard"));

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
@@ -101,12 +101,12 @@ class JsonApiUfcResponseParserTest {
                         "valid-semver",
                         allocation(
                             "valid-semver",
-                            "[{\"conditions\":[{\"attribute\":\"version\",\"operator\":\"SEMVER_EQ\",\"value\":\"1.2.3\"}]}]")),
+                            "[{\"conditions\":[{\"attribute\":\"version\",\"operator\":\"SEMVER_EQ\",\"value\":\"1.2\"}]}]")),
                     booleanFlag(
                         "invalid-semver",
                         allocation(
                             "invalid-semver",
-                            "[{\"conditions\":[{\"attribute\":\"version\",\"operator\":\"SEMVER_EQ\",\"value\":\"1.2\"}]}]")),
+                            "[{\"conditions\":[{\"attribute\":\"version\",\"operator\":\"SEMVER_EQ\",\"value\":\"1.02\"}]}]")),
                     booleanFlag(
                         "non-string-semver",
                         allocation(
@@ -141,6 +141,21 @@ class JsonApiUfcResponseParserTest {
             .conditions
             .get(0)
             .semverComparand);
+  }
+
+  @Test
+  void dropsFlagWithMalformedAllocationsWithoutRejectingConfig() throws Exception {
+    final ServerConfiguration configuration =
+        parse(
+            wrap(
+                configWithFlags(
+                    booleanFlag("malformed-allocations", ",\"allocations\":\"not-a-list\""),
+                    booleanFlag("valid-sibling", ""))));
+
+    assertNotNull(configuration);
+    assertFalse(configuration.flags.containsKey("malformed-allocations"));
+    assertTrue(configuration.flags.containsKey("valid-sibling"));
+    assertEquals("invalid_flag", configuration.invalidFlags.get("malformed-allocations"));
   }
 
   @Test

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/JsonApiUfcResponseParserTest.java
@@ -8,8 +8,16 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.squareup.moshi.JsonQualifier;
+import com.squareup.moshi.Moshi;
 import datadog.trace.api.featureflag.ufc.v1.ServerConfiguration;
+import datadog.trace.api.featureflag.ufc.v1.Shard;
 import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -298,6 +306,23 @@ class JsonApiUfcResponseParserTest {
     assertFalse(configuration.flags.containsKey("non-boolean-is-null"));
     assertTrue(configuration.flags.containsKey("valid-condition-operands"));
   }
+
+  @Test
+  void shardAdapterFactoryRejectsQualifiedShard() {
+    assertNull(
+        UniversalFlagConfigParser.ShardAdapter.FACTORY.create(
+            Shard.class,
+            Collections.singleton(QualifiedShard.class.getAnnotation(ShardQualifier.class)),
+            new Moshi.Builder().build()));
+  }
+
+  @JsonQualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.TYPE)
+  private @interface ShardQualifier {}
+
+  @ShardQualifier
+  private static final class QualifiedShard {}
 
   @Test
   void nullAttributesAreRejectedWithoutInvokingTheFlagParser() throws Exception {


### PR DESCRIPTION
## Summary
- accept and compare arbitrary-length dot-separated SemVer core components for FFE/OpenFeature
- pin the OpenFeature system-test fixture submodule to `2c0c8d55f665fe4a847fc0ded3abf59b7e2896fc`
- cover six-component equality and ordering through `DDEvaluator`
- support the UFC `uint32` shard range without changing the bootstrap model's public `int` field and constructor descriptors

## UFC shard representation
The UFC wire format allows shard totals and range bounds up to `4_294_967_295`, while the existing bootstrap model uses public `int` fields. The parser now reads those fields as `Long`, validates the `uint32` bounds, and stores valid values as their two's-complement `int` bit patterns. Evaluation converts them with `Integer.toUnsignedLong(...)` before modulo and range comparisons.

Keeping the public `int` fields and constructors avoids a binary-incompatible change for code compiled against the bootstrap agent model, while still correctly supporting values above `Integer.MAX_VALUE`.

## Validation
- `./gradlew :products:feature-flagging:feature-flagging-bootstrap:test --tests datadog.trace.api.featureflag.ufc.v1.ParsedSemverTest`
- `./gradlew :products:feature-flagging:feature-flagging-api:test --tests datadog.trace.api.openfeature.DDEvaluatorTest.testEvaluateSemverCondition`
- `./gradlew :products:feature-flagging:feature-flagging-api:test :products:feature-flagging:feature-flagging-lib:test`