### PR TITLE
skill(apm-integrations): Message Queues - document per-item span pattern for batch-consume ops

### DIFF
--- a/.agents/skills/apm-integrations/references/advice-class.md
+++ b/.agents/skills/apm-integrations/references/advice-class.md
@@ -31,6 +31,34 @@ Exit method:
 6. `scope.close()`
 7. `span.finish()`
 
+### Batch-consume operations: one span per item, not one span for the whole batch
+
+Some client APIs return a batch of items from a single call — a message broker's poll returning N records, a search client returning a page of hits, a bulk API returning multiple results. If the caller iterates the batch and does further per-item work (deserializing, dispatching to a handler, downstream calls), a single span around the whole batch call is wrong: it cannot attach any of that follow-on work to the specific item that triggered it, and it does not reflect where the actual work happens or ends.
+
+**The pattern**: wrap the returned `Iterable`/`Iterator`/`List` so that advancing to the next item closes the previous item's span and opens a new one for the current item. Do not span the method that returns the batch; span the act of consuming each item from it.
+
+```java
+// WRONG — one span covers the whole batch; no way to attach per-item follow-on work
+@Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+public static void exit(@Advice.Return Iterable<Record> records) {
+  AgentSpan span = startSpan(DECORATE.operationName(), ...);
+  // ... consume the whole Iterable under one span — individual item work has no span of its own
+}
+
+// CORRECT — wrap the Iterable so each item gets its own span, started on next() and
+// closed when the following item starts (or when iteration ends)
+@Advice.OnMethodExit(suppress = Throwable.class)
+public static void exit(@Advice.Return(readOnly = false) Iterable<Record> records) {
+  if (records != null) {
+    records = new TracingIterable(records, DECORATE.operationName(), DECORATE);
+  }
+}
+```
+
+The wrapping iterator's `next()` starts the span for the item it returns, after first closing whichever span was opened for the previous item. Its `hasNext()` closes the last open span when the delegate has no more items — this is what closes out the final item's span if the caller finishes iterating normally, since there's no explicit "close" call for the last item otherwise. If the caller abandons the iteration partway through (stops calling `next()`/`hasNext()` before reaching the end), the last opened span is left unclosed by this mechanism alone — this is an accepted, known gap (spans opened this way are not finished by a background timeout), not something the advice needs to additionally guard.
+
+**How to discover the right hook point**: don't span the accessor that *returns* the batch (e.g. a `records()`/`poll()` method returning `Iterable<T>` or `List<T>`) — span the iteration over it. If the batch is returned as an `Iterable`, wrap the `Iterable` (whose `iterator()` produces a wrapping `Iterator`). If it's returned as a `List`, the same wrapping applies to `List.iterator()`/`listIterator()`. See `dd-java-agent/instrumentation/kafka/kafka-clients-0.11/src/main/java/datadog/trace/instrumentation/kafka_clients/{TracingIterable,TracingIterator,TracingList,TracingListIterator}.java` for the canonical implementation — this is the reference pattern for any future batch-consume instrumentation (message queues, but not limited to them).
+
 ### onExit handling when the target method throws
 
 The `onThrowable = Throwable.class` attribute on `@Advice.OnMethodExit` controls whether the exit advice fires when the **instrumented target method** throws. You **must** set it explicitly to `Throwable.class` for any exit advice that closes a scope or finishes a span — the default skips exceptional termination, which leaks active scopes when the instrumented method throws.

--- a/.agents/skills/apm-integrations/references/advice-class.md
+++ b/.agents/skills/apm-integrations/references/advice-class.md
@@ -134,6 +134,42 @@ Before adding advice to an async wrapper, trace the call path to the sync delega
 
 The completion callback advice (whenComplete-style) is still useful for span-close cleanup on the caller's future, but it does not by itself guarantee the sync client's advice sees the right parent. See `context-tracking.md` for the propagation patterns and the specific `readOnly`/lambda constraints.
 
+### One matcher spanning sync and callback-based overloads must not finish the span at method exit
+
+This is a distinct failure from the double-span case above: here there is only ONE advice, but its method matcher is broad enough to also match an overload that takes a completion callback (e.g. a JMS-style `send(Message)` and `send(Message, CompletionListener)`, or any library's `doThing(Args)` / `doThing(Args, Callback)` pair). If the exit advice unconditionally finishes the span, the callback-based overload's span is finished when the submitting call returns — not when the operation actually completes — truncating its duration and losing any error the callback would have reported.
+
+**Fix:** either (a) split into two advices with matchers narrow enough to distinguish the callback-taking overload from the synchronous one, or (b) in a single advice, branch on whether the callback parameter is present: if absent, finish the span at exit as normal; if present, wrap the callback (mirroring the delegate-wrapper pattern used for async HTTP clients above) so the wrapper's `onCompletion()`/`onSuccess()`/`onError()` finishes the span, and do NOT finish it in the exit advice for that call.
+
+```java
+// WRONG — same exit advice finishes the span whether or not a callback was supplied
+@Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+public static void exit(@Advice.Enter AgentScope scope, @Advice.Thrown Throwable thrown) {
+  if (scope != null) {
+    DECORATE.onError(scope.span(), thrown);
+    scope.close();
+    scope.span().finish();  // wrong for the callback-based overload — completes too early
+  }
+}
+
+// CORRECT — the callback-based overload's advice wraps the callback and does NOT
+// finish the span itself; only the callback-less overload's advice finishes at exit
+@Advice.OnMethodExit(suppress = Throwable.class)
+public static void exit(
+    @Advice.Enter AgentScope scope,
+    @Advice.Argument(value = 1, readOnly = false) CompletionListener listener) {
+  if (scope != null) {
+    if (listener != null) {
+      listener = new DatadogCompletionListener(listener, scope.span());
+    } else {
+      scope.span().finish();
+    }
+    scope.close();
+  }
+}
+```
+
+**How to discover**: before writing the exit advice, check whether the method being matched has a sibling overload that accepts a callback/listener parameter. If the matcher (or the matched method set) covers both, this rule applies.
+
 ## Multiple advice classes and `@AppliesOn`
 
 If your instrumentation needs to apply multiple advices to the same method (e.g. separate context-tracking from tracing logic), use `applyAdvices()` inside `methodAdvice()`. Use the `@AppliesOn` annotation to control which target systems each advice applies to.


### PR DESCRIPTION
# What Does This Do

Adds two sections to `.agents/skills/apm-integrations/references/advice-class.md`:

1. **Per-item span pattern for batch-consume operations** — when a client API returns a batch of items from one call (e.g. a message broker's poll returning N records), the instrumentation should wrap the returned `Iterable`/`Iterator`/`List` so each item gets its own span — opened on `next()`, closed when the following item starts or when iteration ends — rather than spanning the batch-returning call itself.
2. **Callback-overload span-finish bug** — if a single advice's method matcher covers both a synchronous overload and a sibling overload that accepts a completion callback (e.g. `send(Message)` and `send(Message, CompletionListener)`), unconditionally finishing the span in the exit advice truncates the callback-based call's span duration and drops any error the callback would report. The advice must branch on whether the callback is present and finish the span from the wrapped callback instead, for that call.

# Motivation

Both patterns were found via a blind regeneration research cycle on the messaging category (JMS, kafka-clients) and confirmed against the current codebase before encoding:

1. The batch-consume pattern is already implemented correctly in `kafka-clients-0.11` (`TracingIterable`/`TracingIterator`/`TracingList`/`TracingListIterator`), but had never been written down — without it, a future messaging (or other batch-returning) instrumentation has no way to discover the pattern except by happening to copy kafka's code.
2. The callback-overload bug was found live in a JMS regen: `send(Message)` and `send(Message, CompletionListener)` were matched by one advice that always finished the span at exit, truncating the async variant's span and dropping its errors.

# Additional Notes

Off-band engineering guidance, not tied to a specific PR review comment. No code changes — skill/reference documentation only.

Note: two other candidate findings from the same regen cycle (a `messaging.system`/`messaging.operation` tag requirement, and a `super(...)` naming-collision rule) were investigated and NOT added here — the tag claim didn't hold up against master (no dd-trace-java messaging integration sets those tags; they're OTel-shim-only conventions), and the naming rule is already fully covered by `instrumenter-module.md`'s existing version-alias guidance (the gap there is adherence, not missing content).

Jira ticket: [none]