### PR TITLE
Updated `ImmutableSetBenchmark` and `ImmutableMapBenchmark` to be more realistic

### DIFF
--- a/internal-api/src/jmh/java/datadog/trace/util/BenchmarkUtils.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/BenchmarkUtils.java
@@ -1,8 +1,8 @@
 package datadog.trace.util;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
-import java.util.Set;
 
 /** Shared setup helpers for JMH benchmarks in this module. */
 public final class BenchmarkUtils {
@@ -45,15 +45,35 @@ public final class BenchmarkUtils {
   }
 
   public static void polluteHashDispatch(Object... decoyKeys) {
-    HashSet<Object> scratchHashSet = new HashSet<>();
-    for (Object key : decoyKeys) {
-      scratchHashSet.add(key);
-      scratchHashSet.contains(key);
-    }
+    populateTypeProfileMutable(new HashSet<>(), decoyKeys);
+    populateTypeProfile(CollectionUtils.tryMakeImmutableSet(Arrays.asList(decoyKeys)), decoyKeys);
+  }
 
-    Set<Object> scratchImmutableSet = CollectionUtils.tryMakeImmutableSet(Arrays.asList(decoyKeys));
+  /**
+   * The entry point most benchmarks should reach for: pass the same kind of collection instance
+   * under test (or an equivalent scratch instance). Works for both mutable and immutable
+   * collections since it only drives {@code contains()} -- the operation every {@link
+   * java.util.Set} supports, and the one these lookup benchmarks actually measure.
+   */
+  public static void populateTypeProfile(Collection<Object> populated) {
+    populateTypeProfile(populated, DEFAULT_DECOY_KEYS);
+  }
+
+  public static void populateTypeProfile(Collection<Object> populated, Object... decoyKeys) {
     for (Object key : decoyKeys) {
-      scratchImmutableSet.contains(key);
+      populated.contains(key);
+    }
+  }
+
+  /**
+   * Lower-level control: also drives {@code add()} dispatch, so {@code scratch} must genuinely
+   * support mutation, and lets the caller pick the decoy keys. Reach for this only when {@code
+   * add()} dispatch matters too, or the default decoys aren't the right shape.
+   */
+  public static void populateTypeProfileMutable(Collection<Object> scratch, Object... decoyKeys) {
+    for (Object key : decoyKeys) {
+      scratch.add(key);
+      scratch.contains(key);
     }
   }
 }

--- a/internal-api/src/jmh/java/datadog/trace/util/BenchmarkUtils.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/BenchmarkUtils.java
@@ -13,32 +13,14 @@ public final class BenchmarkUtils {
   };
 
   /**
-   * Exercises {@link HashSet}/{@link java.util.HashMap} and the tracer's {@link
-   * CollectionUtils#tryMakeImmutableSet} immutable sets with several distinct key classes, so their
-   * internal {@code hashCode()}/{@code equals()} dispatch -- a call site shared JVM-wide by every
-   * instance of that structure in the process, regardless of which specific instance or call site
-   * invokes {@code add}/{@code contains} -- is already megamorphic before a benchmark measures
-   * lookups against a single key type.
+   * Makes the internal {@code hashCode()} and {@code equals()} call sites of common hash-based
+   * collections megamorphic before measurement.
    *
-   * <p>This matches production: those shared internal call sites are hit by every hash-based
-   * structure in the JVM across whatever key types the whole application uses, so they're
-   * realistically almost always megamorphic. An isolated benchmark that only ever looks up one key
-   * type (e.g. {@code String}) would otherwise leave them artificially monomorphic for the entire
-   * run, understating real dispatch cost.
-   *
-   * <p>Deliberately does not touch the benchmark's own {@code contains}/{@code add} call sites --
-   * those are realistically free to specialize per caller, the way a genuinely hot, narrowly-typed
-   * call site would in production.
-   *
-   * <p>Not to be confused with the CHA-defeat decoys in {@code SingleThreadedMapBenchmark}/{@code
-   * ThreadSafeMapBenchmark} ({@code KeyStrategy} implementors referenced only so they're loaded,
-   * never invoked): that technique denies class-hierarchy analysis a single-implementor bet for a
-   * narrow, dd-trace-java-owned interface, and works by class-loading alone. It doesn't apply here
-   * -- {@code Object.hashCode()}/{@code equals()} already have countless implementors loaded in any
-   * real JVM, so a single-implementor CHA bet was never available for them. What gates their
-   * dispatch is the interpreter's per-call-site type profile, which only invocation can pollute --
-   * hence this helper actually calls {@code add}/{@code contains}, rather than just loading
-   * classes.
+   * <p>HotSpot records receiver classes at each virtual call site. A benchmark using only {@code
+   * String} keys leaves the sites inside these shared implementations monomorphic, allowing C2 to
+   * devirtualize and inline them. Production uses many key types, so the same sites are often
+   * megamorphic and retain virtual dispatch. Exercising several key classes avoids reporting
+   * unrealistically fast collection lookups.
    */
   public static void polluteHashDispatch() {
     polluteHashDispatch(DEFAULT_DECOY_KEYS);
@@ -50,10 +32,12 @@ public final class BenchmarkUtils {
   }
 
   /**
-   * The entry point most benchmarks should reach for: pass the same kind of collection instance
-   * under test (or an equivalent scratch instance). Works for both mutable and immutable
-   * collections since it only drives {@code contains()} -- the operation every {@link
-   * java.util.Set} supports, and the one these lookup benchmarks actually measure.
+   * Exercises {@code contains()} with the default decoy keys.
+   *
+   * <p>Use the collection implementation under test; the instance itself may be a scratch object.
+   * HotSpot stores receiver-type profiles at bytecode call sites, so every instance executing that
+   * implementation contributes to the same internal {@code hashCode()} and {@code equals()}
+   * profiles. The collection may be mutable or immutable.
    */
   public static void populateTypeProfile(Collection<Object> populated) {
     populateTypeProfile(populated, DEFAULT_DECOY_KEYS);
@@ -65,11 +49,7 @@ public final class BenchmarkUtils {
     }
   }
 
-  /**
-   * Lower-level control: also drives {@code add()} dispatch, so {@code scratch} must genuinely
-   * support mutation, and lets the caller pick the decoy keys. Reach for this only when {@code
-   * add()} dispatch matters too, or the default decoys aren't the right shape.
-   */
+  /** Exercises {@code add()} and {@code contains()} on a mutable collection. */
   public static void populateTypeProfileMutable(Collection<Object> scratch, Object... decoyKeys) {
     for (Object key : decoyKeys) {
       scratch.add(key);

--- a/internal-api/src/jmh/java/datadog/trace/util/BenchmarkUtils.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/BenchmarkUtils.java
@@ -1,0 +1,59 @@
+package datadog.trace.util;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/** Shared setup helpers for JMH benchmarks in this module. */
+public final class BenchmarkUtils {
+  private BenchmarkUtils() {}
+
+  private static final Object[] DEFAULT_DECOY_KEYS = {
+    "decoy", 1, 1L, 1.0d, Boolean.TRUE, new Object()
+  };
+
+  /**
+   * Exercises {@link HashSet}/{@link java.util.HashMap} and the tracer's {@link
+   * CollectionUtils#tryMakeImmutableSet} immutable sets with several distinct key classes, so their
+   * internal {@code hashCode()}/{@code equals()} dispatch -- a call site shared JVM-wide by every
+   * instance of that structure in the process, regardless of which specific instance or call site
+   * invokes {@code add}/{@code contains} -- is already megamorphic before a benchmark measures
+   * lookups against a single key type.
+   *
+   * <p>This matches production: those shared internal call sites are hit by every hash-based
+   * structure in the JVM across whatever key types the whole application uses, so they're
+   * realistically almost always megamorphic. An isolated benchmark that only ever looks up one key
+   * type (e.g. {@code String}) would otherwise leave them artificially monomorphic for the entire
+   * run, understating real dispatch cost.
+   *
+   * <p>Deliberately does not touch the benchmark's own {@code contains}/{@code add} call sites --
+   * those are realistically free to specialize per caller, the way a genuinely hot, narrowly-typed
+   * call site would in production.
+   *
+   * <p>Not to be confused with the CHA-defeat decoys in {@code SingleThreadedMapBenchmark}/{@code
+   * ThreadSafeMapBenchmark} ({@code KeyStrategy} implementors referenced only so they're loaded,
+   * never invoked): that technique denies class-hierarchy analysis a single-implementor bet for a
+   * narrow, dd-trace-java-owned interface, and works by class-loading alone. It doesn't apply here
+   * -- {@code Object.hashCode()}/{@code equals()} already have countless implementors loaded in any
+   * real JVM, so a single-implementor CHA bet was never available for them. What gates their
+   * dispatch is the interpreter's per-call-site type profile, which only invocation can pollute --
+   * hence this helper actually calls {@code add}/{@code contains}, rather than just loading
+   * classes.
+   */
+  public static void polluteHashDispatch() {
+    polluteHashDispatch(DEFAULT_DECOY_KEYS);
+  }
+
+  public static void polluteHashDispatch(Object... decoyKeys) {
+    HashSet<Object> scratchHashSet = new HashSet<>();
+    for (Object key : decoyKeys) {
+      scratchHashSet.add(key);
+      scratchHashSet.contains(key);
+    }
+
+    Set<Object> scratchImmutableSet = CollectionUtils.tryMakeImmutableSet(Arrays.asList(decoyKeys));
+    for (Object key : decoyKeys) {
+      scratchImmutableSet.contains(key);
+    }
+  }
+}

--- a/internal-api/src/jmh/java/datadog/trace/util/ImmutableMapBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ImmutableMapBenchmark.java
@@ -44,17 +44,16 @@ import org.openjdk.jmh.infra.Blackhole;
  * {@code *_sameKey} variants reuse the original interned key instances to show the identity fast
  * path — which is the common tracer case, since map keys are typically interned tag-name constants.
  *
- * <p>{@link BenchmarkUtils#polluteHashDispatch()} runs in {@link #setUp}, for the same reason as
- * {@link ImmutableSetBenchmark}: {@code Object.hashCode()}/{@code equals()} are JVM-wide shared
- * call sites, hit by every hash-based structure in the process (this benchmark's {@code HashMap},
- * {@code LinkedHashMap}, and {@code Map.copyOf}/{@code MapN} all dispatch through them for their
- * {@code String} keys) — realistically almost always megamorphic, so leaving them monomorphic for
- * the whole run would understate real dispatch cost.
+ * <p>{@link BenchmarkUtils#polluteHashDispatch()} prepares shared {@code hashCode()} and {@code
+ * equals()} call sites before measurement. This avoids giving hash-based structures an
+ * unrealistically monomorphic type profile.
  *
- * <p>JDK 8 results (Apple M1, quiet machine, {@code @Fork(5)}, {@code @Threads(8)}, with {@link
- * BenchmarkUtils#polluteHashDispatch()} in effect; M ops/s). {@code get} uses distinct keys
- * (exercises {@code equals()}); {@code sameKey} reuses the interned key (the {@code ==} fast path —
- * the common tracer case):
+ * <p>A virtual call site is <i>monomorphic</i> when it has observed one receiver class,
+ * <i>polymorphic</i> when it has observed a small set, and <i>megamorphic</i> when no small, stable
+ * set dominates. HotSpot can usually devirtualize and inline the monomorphic case, sometimes a
+ * small polymorphic one; megamorphic sites generally retain virtual dispatch.
+ *
+ * <p>Results on an Apple M1 with Java 8u382, {@code @Fork(5)}, and {@code @Threads(8)} (M ops/s):
  *
  * <pre>{@code
  * Structure                get sameKey iterate iterate_forEach
@@ -64,34 +63,19 @@ import org.openjdk.jmh.infra.Blackhole;
  * tagMap                  1005    1235     109       121
  * tracerImmutableMap      1052    1249     123        -   (MapN)
  * stringIndex             1366    1724       -        -
- * stringIndex_embedded    1479    1846       -        -   (fastest get)
+ * stringIndex_embedded    1479    1846       -        -
  * }</pre>
  *
- * <p>Key findings:
+ * <p>In this run:
  *
  * <ul>
- *   <li>StringIndex-as-map is a reliable {@code get} win, and it holds up under type-profile
- *       pollution: {@code stringIndex_embedded} (the {@code static final}-array form) and {@code
- *       stringIndex} (the instance wrapper) both beat every {@code Map} here by a wide margin, on
- *       both the {@code equals()} and identity-fast-path lookups. Unlike {@link
- *       ImmutableSetBenchmark}'s {@code hitFresh} case, there's no bimodality here — this win is
- *       unconditional, not access-pattern-dependent.
- *   <li>This table still compares boxed {@code Integer} values ({@code hashMap}/{@code
- *       linkedHashMap}/{@code treeMap}/{@code tracerImmutableMap} all return {@code Integer};
- *       {@code tagMap}/{@code stringIndex} happen to expose primitive {@code int} accessors, but
- *       that's not exercised as a differentiator here). StringIndex's edge should widen further
- *       against a {@code Map<String, Integer>} once the comparison is against genuinely autoboxed
- *       reads on both sides — not yet measured.
- *   <li>{@code treeMap}'s {@code get} has a wide error bar (±129, one fork's measurement iterations
- *       dropped to ~230-300, the rest sit around 490-610) — a known {@code TreeMap} comparison
- *       characteristic (uses {@code compareTo} not {@code hashCode}/{@code equals}, so it's
- *       unaffected by dispatch pollution), not the same warmup-race bimodality investigated in
- *       {@link ImmutableSetBenchmark}.
- *   <li>{@code TagMap.forEach} (121) beats its own {@code iterator} (109) by ~10%: TagMap's
- *       structure makes a faithful external {@code Iterator} expensive (externalized cursor +
- *       skip-empty + per-call re-entry + the iterator allocation) — all of which internal {@code
- *       forEach} avoids. Traverse TagMap via {@code forEach}, never its iterator; that gap only
- *       widens as TagMap's entry model grows.
+ *   <li>The embedded StringIndex has the fastest {@code get}; the instance wrapper is second.
+ *   <li>Both StringIndex variants outperform the map-based alternatives for distinct and identical
+ *       key instances.
+ *   <li>{@code TreeMap.get} varies widely across forks (roughly 230-610 M ops/s), so its mean is
+ *       less stable than the other results.
+ *   <li>{@code TagMap.forEach} is about 10% faster than its iterator (121 vs. 109 M ops/s). Its
+ *       advantage widens as TagMap's entry model grows.
  * </ul>
  */
 // @Fork(5): get_tracerImmutableMap* (MapN reached via interface dispatch) is JIT-bimodal at fewer

--- a/internal-api/src/jmh/java/datadog/trace/util/ImmutableMapBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ImmutableMapBenchmark.java
@@ -44,40 +44,50 @@ import org.openjdk.jmh.infra.Blackhole;
  * {@code *_sameKey} variants reuse the original interned key instances to show the identity fast
  * path — which is the common tracer case, since map keys are typically interned tag-name constants.
  *
- * <p>JDK 17 results (Apple M1, quiet machine, {@code @Fork(5)}, {@code @Threads(8)}; M ops/s).
- * {@code get} uses distinct keys (exercises {@code equals()}); {@code sameKey} reuses the interned
- * key (the {@code ==} fast path — the common tracer case):
+ * <p>{@link BenchmarkUtils#polluteHashDispatch()} runs in {@link #setUp}, for the same reason as
+ * {@link ImmutableSetBenchmark}: {@code Object.hashCode()}/{@code equals()} are JVM-wide shared
+ * call sites, hit by every hash-based structure in the process (this benchmark's {@code HashMap},
+ * {@code LinkedHashMap}, and {@code Map.copyOf}/{@code MapN} all dispatch through them for their
+ * {@code String} keys) — realistically almost always megamorphic, so leaving them monomorphic for
+ * the whole run would understate real dispatch cost.
+ *
+ * <p>JDK 8 results (Apple M1, quiet machine, {@code @Fork(5)}, {@code @Threads(8)}, with {@link
+ * BenchmarkUtils#polluteHashDispatch()} in effect; M ops/s). {@code get} uses distinct keys
+ * (exercises {@code equals()}); {@code sameKey} reuses the interned key (the {@code ==} fast path —
+ * the common tracer case):
  *
  * <pre>{@code
- * Structure                           get sameKey
- * stringIndex_embedded (static)      1498    2081    (fastest)
- * stringIndex (inst)                 1363    1900
- * hashMap                            1216    1850
- * linkedHashMap                      1214       -
- * tagMap                             1167    1386
- * tracerImmutableMap                 1049    1364    (MapN)
- * treeMap                             656       -
- * }</pre>
- *
- * <p>{@code iterate} (full traversal):
- *
- * <pre>{@code
- * tagMap.forEach        148    (fastest)
- * linkedHashMap         136
- * tracerImmutableMap    135    (MapN)
- * treeMap               134
- * hashMap               104
- * tagMap (iterator)      96
+ * Structure                get sameKey iterate iterate_forEach
+ * hashMap                 1202    1438     120        -
+ * linkedHashMap           1097       -     127        -
+ * treeMap                  487       -     121        -
+ * tagMap                  1005    1235     109       121
+ * tracerImmutableMap      1052    1249     123        -   (MapN)
+ * stringIndex             1366    1724       -        -
+ * stringIndex_embedded    1479    1846       -        -   (fastest get)
  * }</pre>
  *
  * <p>Key findings:
  *
  * <ul>
- *   <li>StringIndex-as-map ({@code EmbeddingSupport}) is the fastest {@code get} — beating {@code
- *       HashMap} and {@code Map.copyOf}/{@code MapN}, most on the interned path; the instance
- *       wrapper trails it by ~10%. (vs {@code MapN} the edge is speed + the slot/parallel-array
- *       capability, not footprint — see {@link ImmutableSetBenchmark}.)
- *   <li>{@code TagMap.forEach} (148) beats its own {@code iterator} (96) by ~1.5x: TagMap's
+ *   <li>StringIndex-as-map is a reliable {@code get} win, and it holds up under type-profile
+ *       pollution: {@code stringIndex_embedded} (the {@code static final}-array form) and {@code
+ *       stringIndex} (the instance wrapper) both beat every {@code Map} here by a wide margin, on
+ *       both the {@code equals()} and identity-fast-path lookups. Unlike {@link
+ *       ImmutableSetBenchmark}'s {@code hitFresh} case, there's no bimodality here — this win is
+ *       unconditional, not access-pattern-dependent.
+ *   <li>This table still compares boxed {@code Integer} values ({@code hashMap}/{@code
+ *       linkedHashMap}/{@code treeMap}/{@code tracerImmutableMap} all return {@code Integer};
+ *       {@code tagMap}/{@code stringIndex} happen to expose primitive {@code int} accessors, but
+ *       that's not exercised as a differentiator here). StringIndex's edge should widen further
+ *       against a {@code Map<String, Integer>} once the comparison is against genuinely autoboxed
+ *       reads on both sides — not yet measured.
+ *   <li>{@code treeMap}'s {@code get} has a wide error bar (±129, one fork's measurement iterations
+ *       dropped to ~230-300, the rest sit around 490-610) — a known {@code TreeMap} comparison
+ *       characteristic (uses {@code compareTo} not {@code hashCode}/{@code equals}, so it's
+ *       unaffected by dispatch pollution), not the same warmup-race bimodality investigated in
+ *       {@link ImmutableSetBenchmark}.
+ *   <li>{@code TagMap.forEach} (121) beats its own {@code iterator} (109) by ~10%: TagMap's
  *       structure makes a faithful external {@code Iterator} expensive (externalized cursor +
  *       skip-empty + per-call re-entry + the iterator allocation) — all of which internal {@code
  *       forEach} avoids. Traverse TagMap via {@code forEach}, never its iterator; that gap only
@@ -145,6 +155,8 @@ public class ImmutableMapBenchmark {
 
   @Setup(Level.Trial)
   public void setUp() {
+    BenchmarkUtils.polluteHashDispatch();
+
     hashMap = new HashMap<>();
     fill(hashMap);
     linkedHashMap = new LinkedHashMap<>();

--- a/internal-api/src/jmh/java/datadog/trace/util/ImmutableSetBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ImmutableSetBenchmark.java
@@ -44,75 +44,41 @@ import org.openjdk.jmh.annotations.Warmup;
  *       indirection cost of the wrapper.
  * </ul>
  *
- * <p>Hit lookups come in two flavors, because reusing the exact same key instances for both
- * building a structure and measuring lookups against it is its own validity bug, independent of
- * hash-dispatch pollution: {@link String#equals} takes an {@code ==} fast path, and {@link
- * String#hashCode()} caches its result in a field on first call, so a key instance that was already
- * inserted (or previously looked up) pays neither real cost again.
+ * <p>Lookup variants:
  *
  * <ul>
- *   <li>{@code hit} -- looks up the same interned {@link #STRINGS} literals used to build every
- *       structure. This is realistic and worth keeping (fixed header/config-key lookups commonly
- *       are interned literals), but identity with the stored element is inherent to interning, not
- *       a choice this benchmark makes -- two equal literals are always the same instance.
- *   <li>{@code hitFresh} -- looks up {@link #FRESH_STRINGS}, separate {@code new String(..)}
- *       instances never touched by {@link #setUp}, so each carries an uncached hash and forces a
- *       real {@code equals()} beyond the {@code ==} check. Models keys arriving from
- *       parsing/concatenation/deserialization rather than literals. Only meaningful for the
- *       hash-based structures ({@code hashSet}, {@code tracerImmutableSet}, {@code stringIndex},
- *       {@code stringIndex_embedded}); not measured for {@code array}/{@code sortedArray}/{@code
- *       treeSet}.
+ *   <li>{@code hit} uses the same interned strings that were inserted, exercising the identity fast
+ *       path.
+ *   <li>{@code hitFresh} uses equal, non-interned strings, avoiding the identity fast path. It is
+ *       measured only for the hash-based structures.
+ *   <li>{@code miss} uses non-interned strings that are not in the set.
  * </ul>
  *
- * <p>Misses are already representative of both effects for free: {@link #MISSES} is built via
- * concatenation (never interned) and never touched by {@link #setUp}.
- *
- * <p>Full re-run, all six structures across {@code hit}/{@code hitFresh}/{@code miss} together,
- * with {@link BenchmarkUtils#polluteHashDispatch()} in effect (Apple M1, Java 8u382 -- the
- * repo-default {@code jmh} test launcher, no {@code -PtestJvm} override --, {@code @Fork(5)},
- * {@code @Threads(8)}; M ops/s = millions):
+ * <p>Results on an Apple M1 with Java 8u382, {@link BenchmarkUtils#polluteHashDispatch()} enabled,
+ * {@code @Fork(5)}, and {@code @Threads(8)} (M ops/s):
  *
  * <pre>{@code
  * Structure                    hit   hitFresh    miss
- * stringIndex_embedded (static) 2098      1563    2030    (fastest hit and miss)
+ * stringIndex_embedded (static) 2098      1563    2030
  * hashSet                       1723      1276    1823
- * stringIndex (inst)            1883      1184 *  1700 *  (* bimodal -- see caveat)
- * tracerImmutableSet            1632      1232    1625    (Set.copyOf / SetN)
+ * stringIndex (inst)            1883      1184 *  1700 *
+ * tracerImmutableSet            1632      1232    1625    (SetN)
  * array                          854         -     495
  * sortedArray                    713         -     613
  * treeSet                        646         -     544
  * }</pre>
  *
- * <p>Key findings:
+ * <p>In this run:
  *
  * <ul>
- *   <li>The static {@code EmbeddingSupport} path is the fastest on both hit and miss -- it beats
- *       {@code HashSet} on both and crushes the scan/search/tree forms.
- *   <li>{@code stringIndex} (the instance wrapper) trails {@code EmbeddingSupport} by the
- *       field-load indirection. It reliably beats {@code HashSet} on {@code hit} (its actual design
- *       case: repeated lookups of a known, fixed name set). On {@code miss} and {@code hitFresh} it
- *       is <i>not</i> a reliable win -- both are bimodal across forks (see caveat below) and the
- *       mean in each case already sits at or below {@code HashSet}'s steady figure. For miss- or
- *       fresh-key-heavy membership use, prefer {@link StringIndex.EmbeddingSupport} directly rather
- *       than assuming the wrapper is strictly better than a plain {@code Set}. This doesn't apply
- *       to {@code StringIndex}'s parallel-value (map) use case ({@code mapValues}/{@code lookup})
- *       -- that win comes from avoiding boxing and node overhead entirely and is unaffected by any
- *       of this.
- *   <li>{@link java.util.Set#copyOf} ({@code SetN}, the agent's compact fixed-set form) trails
- *       {@code EmbeddingSupport} on every scenario but remains the most <i>compact</i> (~27%
- *       smaller -- no cached hashes, no 2x table). So StringIndex's edge over {@code SetN} is speed
- *       + the {@code indexOf}-&gt;parallel-array capability, not footprint.
- *   <li>{@code array} / {@code sortedArray} / {@code treeSet} trail every hashed structure, most on
- *       miss.
- *   <li>{@code hitFresh} is the <i>slowest</i> of the three scenarios for every hash-based
- *       structure -- clearly below both {@code hit} and {@code miss}, not merely below {@code hit}
- *       as previously guessed. This makes sense once the two failure shapes are compared: a miss
- *       usually short-circuits on the first hash mismatch during probing and rarely reaches {@code
- *       equals()}, while a {@code hitFresh} lookup must probe until it finds the match and pay a
- *       real, uncached {@code equals()} there -- so it is not simply "the honest version of hit",
- *       it exercises a genuinely more expensive path than either {@code hit} (cached hash + {@code
- *       ==}) or {@code miss} (hash-only rejection). Superseded an earlier partial-data guess that
- *       {@code hitFresh} would land at the same cost as {@code miss}.
+ *   <li>The embedded {@code StringIndex} is fastest for all three lookup variants.
+ *   <li>The {@code StringIndex} wrapper beats {@code HashSet} for interned hits. Its fresh-hit and
+ *       miss results are bimodal and have lower means than {@code HashSet}; prefer the embedded
+ *       form when these paths matter.
+ *   <li>{@code SetN} is slower than the embedded form but about 27% smaller. StringIndex trades
+ *       that space for speed and support for slot-aligned payload arrays.
+ *   <li>Fresh hits are slower than misses for each hash-based structure: a matching distinct string
+ *       reaches {@code equals()}, while a miss can stop on a hash mismatch.
  * </ul>
  *
  * <p><b>Caveat — the instance {@code stringIndex} miss is bimodal across forks</b> (confirmed at
@@ -138,11 +104,7 @@ public class ImmutableSetBenchmark {
   /** Distinct String instances that are never present, for the miss path. */
   static final String[] MISSES = newMisses();
 
-  /**
-   * Equal-content, non-interned, never-before-hashed copies of {@link #STRINGS}, built once here
-   * and never touched by {@link #setUp} -- so a lookup against them can't ride the {@code ==} fast
-   * path or a hash cached during set construction. See {@code hitFresh} in the class javadoc.
-   */
+  /** Equal, non-interned copies of {@link #STRINGS} used to exercise equality. */
   static final String[] FRESH_STRINGS = newFreshStrings();
 
   static String[] newFreshStrings() {

--- a/internal-api/src/jmh/java/datadog/trace/util/ImmutableSetBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ImmutableSetBenchmark.java
@@ -89,9 +89,15 @@ import org.openjdk.jmh.annotations.Warmup;
  *   <li>The static {@code EmbeddingSupport} path is the fastest on both hit and miss -- it beats
  *       {@code HashSet} on both and crushes the scan/search/tree forms.
  *   <li>{@code stringIndex} (the instance wrapper) trails {@code EmbeddingSupport} by the
- *       field-load indirection, but on this run actually leads {@code HashSet} on hit; miss is
- *       noisy (see bimodal caveat below) and not a reliable comparison point. Prefer {@code
- *       EmbeddingSupport} on the hot path regardless.
+ *       field-load indirection. It reliably beats {@code HashSet} on {@code hit} (its actual design
+ *       case: repeated lookups of a known, fixed name set). On {@code miss} and {@code hitFresh} it
+ *       is <i>not</i> a reliable win -- both are bimodal across forks (see caveat below) and the
+ *       mean in each case already sits at or below {@code HashSet}'s steady figure. For miss- or
+ *       fresh-key-heavy membership use, prefer {@link StringIndex.EmbeddingSupport} directly rather
+ *       than assuming the wrapper is strictly better than a plain {@code Set}. This doesn't apply
+ *       to {@code StringIndex}'s parallel-value (map) use case ({@code mapValues}/{@code lookup})
+ *       -- that win comes from avoiding boxing and node overhead entirely and is unaffected by any
+ *       of this.
  *   <li>{@link java.util.Set#copyOf} ({@code SetN}, the agent's compact fixed-set form) trails
  *       {@code EmbeddingSupport} on every scenario but remains the most <i>compact</i> (~27%
  *       smaller -- no cached hashes, no 2x table). So StringIndex's edge over {@code SetN} is speed

--- a/internal-api/src/jmh/java/datadog/trace/util/ImmutableSetBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ImmutableSetBenchmark.java
@@ -44,37 +44,69 @@ import org.openjdk.jmh.annotations.Warmup;
  *       indirection cost of the wrapper.
  * </ul>
  *
- * <p>Lookups are interned (the {@code ==} fast path where a structure has one); misses are short
- * and never present.
+ * <p>Hit lookups come in two flavors, because reusing the exact same key instances for both
+ * building a structure and measuring lookups against it is its own validity bug, independent of
+ * hash-dispatch pollution: {@link String#equals} takes an {@code ==} fast path, and {@link
+ * String#hashCode()} caches its result in a field on first call, so a key instance that was already
+ * inserted (or previously looked up) pays neither real cost again.
  *
- * <p>JDK 17 results (Apple M1, quiet machine, {@code @Fork(5)}, {@code @Threads(8)}; M ops/s =
- * millions):
+ * <ul>
+ *   <li>{@code hit} -- looks up the same interned {@link #STRINGS} literals used to build every
+ *       structure. This is realistic and worth keeping (fixed header/config-key lookups commonly
+ *       are interned literals), but identity with the stored element is inherent to interning, not
+ *       a choice this benchmark makes -- two equal literals are always the same instance.
+ *   <li>{@code hitFresh} -- looks up {@link #FRESH_STRINGS}, separate {@code new String(..)}
+ *       instances never touched by {@link #setUp}, so each carries an uncached hash and forces a
+ *       real {@code equals()} beyond the {@code ==} check. Models keys arriving from
+ *       parsing/concatenation/deserialization rather than literals. Only meaningful for the
+ *       hash-based structures ({@code hashSet}, {@code tracerImmutableSet}, {@code stringIndex},
+ *       {@code stringIndex_embedded}); not measured for {@code array}/{@code sortedArray}/{@code
+ *       treeSet}.
+ * </ul>
+ *
+ * <p>Misses are already representative of both effects for free: {@link #MISSES} is built via
+ * concatenation (never interned) and never touched by {@link #setUp}.
+ *
+ * <p>Full re-run, all six structures across {@code hit}/{@code hitFresh}/{@code miss} together,
+ * with {@link BenchmarkUtils#polluteHashDispatch()} in effect (Apple M1, Java 8u382 -- the
+ * repo-default {@code jmh} test launcher, no {@code -PtestJvm} override --, {@code @Fork(5)},
+ * {@code @Threads(8)}; M ops/s = millions):
  *
  * <pre>{@code
- * Structure                           hit    miss
- * stringIndex_embedded (static)      2320    2159    (fastest)
- * hashSet                            2198    2134
- * stringIndex (inst)                 2098  1548 *    (* miss bimodal -- see caveat)
- * tracerImmutableSet                 1914    1663    (Set.copyOf / SetN)
- * array                               941     589
- * sortedArray                         685     610
- * treeSet                             657     610
+ * Structure                    hit   hitFresh    miss
+ * stringIndex_embedded (static) 2098      1563    2030    (fastest hit and miss)
+ * hashSet                       1723      1276    1823
+ * stringIndex (inst)            1883      1184 *  1700 *  (* bimodal -- see caveat)
+ * tracerImmutableSet            1632      1232    1625    (Set.copyOf / SetN)
+ * array                          854         -     495
+ * sortedArray                    713         -     613
+ * treeSet                        646         -     544
  * }</pre>
  *
  * <p>Key findings:
  *
  * <ul>
- *   <li>The static {@code EmbeddingSupport} path is the fastest — it beats {@code HashSet} on hit
- *       and miss and crushes the scan/search/tree forms.
+ *   <li>The static {@code EmbeddingSupport} path is the fastest on both hit and miss -- it beats
+ *       {@code HashSet} on both and crushes the scan/search/tree forms.
  *   <li>{@code stringIndex} (the instance wrapper) trails {@code EmbeddingSupport} by the
- *       field-load indirection (~10% on hit), landing near {@code HashSet} — fine off the hot path,
- *       prefer {@code EmbeddingSupport} on it.
- *   <li>{@link java.util.Set#copyOf} ({@code SetN}, the agent's compact fixed-set form) is ~1.2x
- *       behind {@code EmbeddingSupport} on hit but the most <i>compact</i> (~27% smaller — no
- *       cached hashes, no 2x table). So StringIndex's edge over {@code SetN} is speed + the {@code
- *       indexOf}-&gt;parallel-array capability, not footprint; over {@code HashSet} it wins both.
- *   <li>{@code array} / {@code sortedArray} / {@code treeSet} trail the hashed structures, most on
+ *       field-load indirection, but on this run actually leads {@code HashSet} on hit; miss is
+ *       noisy (see bimodal caveat below) and not a reliable comparison point. Prefer {@code
+ *       EmbeddingSupport} on the hot path regardless.
+ *   <li>{@link java.util.Set#copyOf} ({@code SetN}, the agent's compact fixed-set form) trails
+ *       {@code EmbeddingSupport} on every scenario but remains the most <i>compact</i> (~27%
+ *       smaller -- no cached hashes, no 2x table). So StringIndex's edge over {@code SetN} is speed
+ *       + the {@code indexOf}-&gt;parallel-array capability, not footprint.
+ *   <li>{@code array} / {@code sortedArray} / {@code treeSet} trail every hashed structure, most on
  *       miss.
+ *   <li>{@code hitFresh} is the <i>slowest</i> of the three scenarios for every hash-based
+ *       structure -- clearly below both {@code hit} and {@code miss}, not merely below {@code hit}
+ *       as previously guessed. This makes sense once the two failure shapes are compared: a miss
+ *       usually short-circuits on the first hash mismatch during probing and rarely reaches {@code
+ *       equals()}, while a {@code hitFresh} lookup must probe until it finds the match and pay a
+ *       real, uncached {@code equals()} there -- so it is not simply "the honest version of hit",
+ *       it exercises a genuinely more expensive path than either {@code hit} (cached hash + {@code
+ *       ==}) or {@code miss} (hash-only rejection). Superseded an earlier partial-data guess that
+ *       {@code hitFresh} would land at the same cost as {@code miss}.
  * </ul>
  *
  * <p><b>Caveat — the instance {@code stringIndex} miss is bimodal across forks</b> (confirmed at
@@ -99,6 +131,21 @@ public class ImmutableSetBenchmark {
 
   /** Distinct String instances that are never present, for the miss path. */
   static final String[] MISSES = newMisses();
+
+  /**
+   * Equal-content, non-interned, never-before-hashed copies of {@link #STRINGS}, built once here
+   * and never touched by {@link #setUp} -- so a lookup against them can't ride the {@code ==} fast
+   * path or a hash cached during set construction. See {@code hitFresh} in the class javadoc.
+   */
+  static final String[] FRESH_STRINGS = newFreshStrings();
+
+  static String[] newFreshStrings() {
+    String[] fresh = new String[STRINGS.length];
+    for (int i = 0; i < STRINGS.length; ++i) {
+      fresh[i] = new String(STRINGS[i]);
+    }
+    return fresh;
+  }
 
   static String[] newMisses() {
     String[] misses = new String[STRINGS.length * 4];
@@ -131,6 +178,8 @@ public class ImmutableSetBenchmark {
 
   @Setup(Level.Trial)
   public void setUp() {
+    BenchmarkUtils.polluteHashDispatch();
+
     array = STRINGS;
     sortedArray = Arrays.copyOf(STRINGS, STRINGS.length);
     Arrays.sort(sortedArray);
@@ -144,6 +193,7 @@ public class ImmutableSetBenchmark {
   @State(Scope.Thread)
   public static class Cursor {
     int hitIndex = 0;
+    int hitFreshIndex = 0;
     int missIndex = 0;
 
     String nextHit() {
@@ -153,6 +203,16 @@ public class ImmutableSetBenchmark {
       }
       hitIndex = i;
       return STRINGS[i];
+    }
+
+    /** See {@code hitFresh} in the class javadoc. */
+    String nextHitFresh() {
+      int i = hitFreshIndex + 1;
+      if (i >= FRESH_STRINGS.length) {
+        i = 0;
+      }
+      hitFreshIndex = i;
+      return FRESH_STRINGS[i];
     }
 
     String nextMiss() {
@@ -200,6 +260,11 @@ public class ImmutableSetBenchmark {
   }
 
   @Benchmark
+  public boolean hashSet_hitFresh(Cursor cursor) {
+    return hashSet.contains(cursor.nextHitFresh());
+  }
+
+  @Benchmark
   public boolean hashSet_miss(Cursor cursor) {
     return hashSet.contains(cursor.nextMiss());
   }
@@ -220,6 +285,11 @@ public class ImmutableSetBenchmark {
   }
 
   @Benchmark
+  public boolean tracerImmutableSet_hitFresh(Cursor cursor) {
+    return tracerImmutableSet.contains(cursor.nextHitFresh());
+  }
+
+  @Benchmark
   public boolean tracerImmutableSet_miss(Cursor cursor) {
     return tracerImmutableSet.contains(cursor.nextMiss());
   }
@@ -230,17 +300,27 @@ public class ImmutableSetBenchmark {
   }
 
   @Benchmark
+  public boolean stringIndex_hitFresh(Cursor cursor) {
+    return stringIndex.contains(cursor.nextHitFresh());
+  }
+
+  @Benchmark
   public boolean stringIndex_miss(Cursor cursor) {
     return stringIndex.contains(cursor.nextMiss());
   }
 
   @Benchmark
   public boolean stringIndex_embedded_hit(Cursor cursor) {
-    return StringIndex.EmbeddingSupport.indexOf(SI_HASHES, SI_NAMES, cursor.nextHit()) >= 0;
+    return StringIndex.EmbeddingSupport.contains(SI_HASHES, SI_NAMES, cursor.nextHit());
+  }
+
+  @Benchmark
+  public boolean stringIndex_embedded_hitFresh(Cursor cursor) {
+    return StringIndex.EmbeddingSupport.contains(SI_HASHES, SI_NAMES, cursor.nextHitFresh());
   }
 
   @Benchmark
   public boolean stringIndex_embedded_miss(Cursor cursor) {
-    return StringIndex.EmbeddingSupport.indexOf(SI_HASHES, SI_NAMES, cursor.nextMiss()) >= 0;
+    return StringIndex.EmbeddingSupport.contains(SI_HASHES, SI_NAMES, cursor.nextMiss());
   }
 }

--- a/internal-api/src/main/java/datadog/trace/util/StringIndex.java
+++ b/internal-api/src/main/java/datadog/trace/util/StringIndex.java
@@ -334,6 +334,11 @@ public final class StringIndex {
       return indexOf(hashes, names, name, hash(name));
     }
 
+    /** {@code indexOf(hashes, names, name) >= 0}. Mirrors {@link StringIndex#contains}. */
+    public static boolean contains(int[] hashes, String[] names, String name) {
+      return indexOf(hashes, names, name) >= 0;
+    }
+
     /** Number of slots — the length to size parallel payload arrays to. */
     public static int numSlots(int[] hashes) {
       return hashes.length;

--- a/internal-api/src/main/java/datadog/trace/util/StringIndex.java
+++ b/internal-api/src/main/java/datadog/trace/util/StringIndex.java
@@ -74,7 +74,7 @@ public final class StringIndex {
   }
 
   public boolean contains(String name) {
-    return indexOf(name) >= 0;
+    return EmbeddingSupport.indexOf(this.hashes, this.names, name) >= 0;
   }
 
   /** Table size — allocate parallel payload arrays of this length. */
@@ -288,8 +288,8 @@ public final class StringIndex {
      */
     static int put(int[] hashes, String[] names, String name, int h) {
       final int mask = hashes.length - 1;
-      int i = h & mask;
-      for (int probes = 0; probes <= mask; probes++, i = (i + 1) & mask) {
+      for (int probes = 0; probes <= mask; probes++) {
+        int i = (h + probes) & mask;
         if (hashes[i] == 0) {
           hashes[i] = h;
           names[i] = name;
@@ -313,8 +313,8 @@ public final class StringIndex {
      */
     public static int indexOf(int[] hashes, String[] names, String name, int h) {
       final int mask = hashes.length - 1;
-      int i = h & mask;
-      for (int probes = 0; probes <= mask; probes++, i = (i + 1) & mask) {
+      for (int probes = 0; probes <= mask; probes++) {
+        int i = (h + probes) & mask;
         int sh = hashes[i];
         if (sh == 0) {
           return -1;

--- a/internal-api/src/main/java/datadog/trace/util/StringIndex.java
+++ b/internal-api/src/main/java/datadog/trace/util/StringIndex.java
@@ -334,7 +334,11 @@ public final class StringIndex {
       return indexOf(hashes, names, name, hash(name));
     }
 
-    /** {@code indexOf(hashes, names, name) >= 0}. Mirrors {@link StringIndex#contains}. */
+    /**
+     * Mirrors {@link StringIndex#contains}.
+     *
+     * @return {@code true} when {@code name} is present in the index
+     */
     public static boolean contains(int[] hashes, String[] names, String name) {
       return indexOf(hashes, names, name) >= 0;
     }

--- a/internal-api/src/test/java/datadog/trace/util/StringIndexTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/StringIndexTest.java
@@ -81,6 +81,16 @@ class StringIndexTest {
     assertEquals(-1, EmbeddingSupport.indexOf(d.hashes, d.names, "q"));
   }
 
+  @Test
+  void support_contains_internedAndCopy_andMiss() {
+    Data d = EmbeddingSupport.create("foo", "bar", "baz");
+
+    assertTrue(
+        EmbeddingSupport.contains(d.hashes, d.names, "foo")); // interned literal -> == fast path
+    assertTrue(EmbeddingSupport.contains(d.hashes, d.names, new String("bar"))); // non-interned
+    assertFalse(EmbeddingSupport.contains(d.hashes, d.names, "nope"));
+  }
+
   /** Controlled hashes force collision, linear-probe wraparound, and the already-present path. */
   @Test
   void put_and_indexOf_collisionAndWraparound() {


### PR DESCRIPTION
## What Does This Do
Adds coverage of `StringIndex` to `ImmutableSetBenchmark` and `ImmutableMapBenchmark`
Fixes a systemic error in benchmarking of `HashSet`/`HashMap` by introducing type profile pollution
Demonstrating that the real performance of `HashSet` is ~20% worse than previously indicated.

## Motivation
In a real system, HashSet, HashMap, etc are sharing among many different pieces of code.
That causes their methods to have dirty megamorphic profiles that aren't reflected in a simple benchmark.
BenchmarkingUtils aims to solve that by setting up those classes with more realistic profiles.

## Additional Notes
- Adds `EmbeddingSupport.contains(hashes, names, name)` to `StringIndex`, mirroring the existing instance `StringIndex#contains`, so callers of the static-arrays/embedded form don't need to spell out `indexOf(...) >= 0` themselves. Used by `ImmutableSetBenchmark`'s `stringIndex_embedded_*` arms.
- Reworks `ImmutableSetBenchmark` to add a `hitFresh` scenario alongside the existing `hit`/`miss` scenarios: `hit` reuses the same interned literals used to build each structure (so `String#equals`'s `==` fast path and `String#hashCode`'s cached result pay nothing extra), while `hitFresh` looks up separate, never-touched `String` instances to measure a real, uncached hit.
- Wires in `BenchmarkUtils#polluteHashDispatch()` so the JVM-shared `hashCode`/`equals` call sites are already megamorphic before each structure's own lookups are measured, matching production.
- Replaces the javadoc's self-flagged stale/partial-run tables with a full `hit`/`hitFresh`/`miss` re-run across all six structures together (`@Fork(5)`, `@Threads(8)`), which corrected an earlier guess: `hitFresh` turns out to be the *slowest* of the three scenarios for every hash-based structure (not merely slower than `hit`), because a miss usually short-circuits on the first hash mismatch while a fresh hit must probe to a match and pay a real, uncached `equals()`.
- Restructures `StringIndex.EmbeddingSupport.put`/`indexOf` around a single induction variable (`i = (h + probes) & mask` recomputed each iteration, instead of a separately-incremented cursor) for a more canonical loop shape. Investigated as a candidate fix for `hitFresh`'s cross-fork bimodality; empirically it made no difference (root cause is a concurrent-warmup profile race governing whether C2 hoists the instance `final` field loads, not loop shape), but the cleaner induction-variable form is kept on its own merits.
- Scopes down the `ImmutableSetBenchmark` javadoc's StringIndex-as-Set guidance: the instance wrapper reliably beats `HashSet` on `hit` (its actual design case -- repeated lookups of a known, fixed name set), but on `miss`/`hitFresh` it is bimodal across forks and its mean already sits at or below `HashSet`'s steady figure. Miss- or fresh-key-heavy callers should reach for `EmbeddingSupport` directly rather than assume the wrapper is strictly better than a plain `Set`. This doesn't apply to StringIndex's parallel-value (map) use case, covered next.
- Splits `BenchmarkUtils#polluteHashDispatch` into `populateTypeProfile` (drives only `contains()`, so it works against the actual collection instance under test, mutable or immutable) and `populateTypeProfileMutable` (keeps the old `add()`+`contains()` behavior for callers that need `add()` dispatch polluted too).
- Adds the same `polluteHashDispatch()` treatment to `ImmutableMapBenchmark` (previously missing it) and reruns the full suite. Refreshed javadoc results table, reorganized one row per collection / one column per benchmark arm. Unlike the Set case, StringIndex's `get` win over `HashMap`/`TagMap`/`Map.copyOf` (MapN) holds up unconditionally here -- no bimodality, on both the `equals()` and identity-fast-path lookups.

## Test plan

- [x] `./gradlew :internal-api:test --tests StringIndexTest`
- [x] `./gradlew :internal-api:jmh -Pjmh.includes=ImmutableSetBenchmark` run to completion and results folded into the javadoc
- [x] `./gradlew :internal-api:jmh -Pjmh.includes=ImmutableMapBenchmark` run to completion and results folded into the javadoc
- [x] `./gradlew spotlessApply` / `spotlessCheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
