### PR TITLE
Limit compiler worker heap sizes

### DIFF
--- a/gradle/java_no_deps.gradle
+++ b/gradle/java_no_deps.gradle
@@ -270,15 +270,20 @@ tasks.withType(Test).configureEach {
 }
 
 
-[JavaCompile, ScalaCompile, GroovyCompile].each {
-  type ->
-  tasks.withType(type).configureEach {
-    if (options.fork) {
-      options.forkOptions.with {
-        memoryMaximumSize = "256M"
-      }
-    }
+tasks.withType(JavaCompile).configureEach {
+  if (options.fork) {
+    options.forkOptions.memoryMaximumSize = "256M"
   }
+}
+
+tasks.withType(GroovyCompile).configureEach {
+  if (groovyOptions.fork) {
+    groovyOptions.forkOptions.memoryMaximumSize = "256M"
+  }
+}
+
+tasks.withType(ScalaCompile).configureEach {
+  scalaCompileOptions.forkOptions.memoryMaximumSize = "256M"
 }
 
 if (project.plugins.hasPlugin('kotlin')) {


### PR DESCRIPTION
# What Does This Do

Applies the existing 256 MiB compiler heap limit through the correct Java, Groovy, and Scala fork-option APIs.

# Motivation

The shared compiler configuration used `options` for every task type. That does not configure Groovy compiler workers or Scala/Zinc workers, so they retained Gradle's larger default heap.

The most memory-intensive GitLab build-test job reached its 20 GiB cgroup limit. Applying the intended heap limit to each compiler worker creates additional headroom without changing build parallelism.

# Additional Notes

Validated with:

- `./gradlew help`
- `./gradlew clean :instrumentationLatestDepTest -PgitBaseRef=origin/master -PskipTests --no-build-cache --stacktrace --parallel --max-workers=6`

GitLab comparison using the same six-worker build-test job:

| Peak cgroup memory | Base | This change | Improvement |
|---|---:|---:|---:|
| Build-test job | 20.00 GiB | 18.68 GiB | 1.32 GiB (6.6%) |

Both builds succeeded with 2,066 actionable tasks: 1,983 executed and 83 restored from cache.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [N/A]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
