### PR TITLE
Exclude unused dependencies from WildFly Muzzle checks

### DIFF
--- a/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
+++ b/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
@@ -8,6 +8,7 @@ muzzle {
     group = 'org.wildfly'
     module = 'wildfly-ee'
     versions = '[9.0.0.Final,)'
+    skipVersions += '41.0.1.Final' // TODO - remove once fixed: wildfly-core-parent 33.0.1.Final unavailable via Depot
     excludeDependency 'org.jboss.xnio:*' // not related and causes issues with missing jar in maven repo
   }
 }

--- a/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
+++ b/dd-java-agent/instrumentation/wildfly-9.0/build.gradle
@@ -8,7 +8,9 @@ muzzle {
     group = 'org.wildfly'
     module = 'wildfly-ee'
     versions = '[9.0.0.Final,)'
-    skipVersions += '41.0.1.Final' // TODO - remove once fixed: wildfly-core-parent 33.0.1.Final unavailable via Depot
+    // WildFly runtime dependencies not used by this instrumentation. Some versions are unavailable from Maven Central.
+    excludeDependency 'io.undertow:*'
+    excludeDependency 'org.jboss.remoting:*'
     excludeDependency 'org.jboss.xnio:*' // not related and causes issues with missing jar in maven repo
   }
 }
@@ -192,5 +194,4 @@ tasks.named("latestDepForkedTest", Test) {
     }
     )
 }
-
 


### PR DESCRIPTION
# What Does This Do

Excludes unused `io.undertow` and `org.jboss.remoting` dependencies from WildFly Muzzle checks. This removes the temporary exclusion for `wildfly-ee:41.0.1.Final`, so Muzzle continues to validate that version.

# Motivation

WildFly 41.0.1 pulls in `jboss-remoting:5.0.32.Final` and `undertow-core:2.4.3.Final`. Both artifacts are published in JBoss Releases but not in Maven Central or Red Hat GA, and Depot currently returns 404 for them. Dependency resolution therefore fails before Muzzle compatibility assertions can run.

The WildFly instrumentation does not reference APIs from either dependency group, so they do not need to be present on the Muzzle analysis classpath.

# Additional Notes

This follows the dependency-exclusion approach used in #12243. The exclusions apply only to Muzzle's generated dependency configurations; the WildFly runtime test dependencies remain unchanged.

- [JBoss Remoting 5.0.32.Final in JBoss Releases](https://repository.jboss.org/nexus/repository/releases/org/jboss/remoting/jboss-remoting/5.0.32.Final/jboss-remoting-5.0.32.Final.pom)
- [Undertow Core 2.4.3.Final in JBoss Releases](https://repository.jboss.org/nexus/repository/releases/io/undertow/undertow-core/2.4.3.Final/undertow-core-2.4.3.Final.pom)
- [JBoss Remoting 5.0.32.Final through Depot](https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/org/jboss/remoting/jboss-remoting/5.0.32.Final/jboss-remoting-5.0.32.Final.pom)
- [Undertow Core 2.4.3.Final through Depot](https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/io/undertow/undertow-core/2.4.3.Final/undertow-core-2.4.3.Final.pom)

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: N/A
