### PR TITLE
🪞 12053 - Fix concurrent span event recording in OTel shim

### DIFF
--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
@@ -37,8 +37,14 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   private StatusCode statusCode;
   private boolean recording;
 
-  /** Span events ({@code null} until an event is added). */
-  private List<OtelSpanEvent> events;
+  /**
+   * Span events ({@code null} until an event is added). Mutations are guarded by synchronizing on
+   * {@code this}: events can be recorded from application threads while the span is finished (and
+   * its events serialized) from a different thread, so unsynchronized access would corrupt the
+   * backing list. Declared {@code volatile} so {@link #onSpanFinished()} can take a lock-free fast
+   * path for the common case of a span with no events.
+   */
+  private volatile List<OtelSpanEvent> events;
 
   public OtelSpan(AgentSpan delegate) {
     this.delegate = delegate;
@@ -85,10 +91,7 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   @Override
   public Span addEvent(String name, Attributes attributes) {
     if (this.recording) {
-      if (this.events == null) {
-        this.events = new ArrayList<>();
-      }
-      this.events.add(new OtelSpanEvent(name, attributes));
+      addEvent(new OtelSpanEvent(name, attributes));
     }
     return this;
   }
@@ -96,12 +99,16 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   @Override
   public Span addEvent(String name, Attributes attributes, long timestamp, TimeUnit unit) {
     if (this.recording) {
-      if (this.events == null) {
-        this.events = new ArrayList<>();
-      }
-      this.events.add(new OtelSpanEvent(name, attributes, timestamp, unit));
+      addEvent(new OtelSpanEvent(name, attributes, timestamp, unit));
     }
     return this;
+  }
+
+  private synchronized void addEvent(OtelSpanEvent event) {
+    if (this.events == null) {
+      this.events = new ArrayList<>();
+    }
+    this.events.add(event);
   }
 
   @Override
@@ -123,12 +130,9 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   @Override
   public Span recordException(Throwable exception, Attributes additionalAttributes) {
     if (this.recording) {
-      if (this.events == null) {
-        this.events = new ArrayList<>();
-      }
       additionalAttributes = initializeExceptionAttributes(exception, additionalAttributes);
       applySpanEventExceptionAttributesAsTags(this.delegate, additionalAttributes);
-      this.events.add(new OtelSpanEvent(EXCEPTION_SPAN_EVENT_NAME, additionalAttributes));
+      addEvent(new OtelSpanEvent(EXCEPTION_SPAN_EVENT_NAME, additionalAttributes));
     }
     return this;
   }
@@ -179,7 +183,17 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   @Override
   public void onSpanFinished() {
     applyNamingConvention(this.delegate);
-    setEventsAsTag(this.delegate, this.events);
+    // Fast path: most spans have no events, so avoid taking the lock entirely (single volatile
+    // read).
+    List<OtelSpanEvent> eventsSnapshot = this.events;
+    if (eventsSnapshot != null) {
+      // Copy under lock so serialization iterates a private snapshot that cannot be mutated
+      // concurrently by an application thread still recording events.
+      synchronized (this) {
+        eventsSnapshot = new ArrayList<>(this.events);
+      }
+    }
+    setEventsAsTag(this.delegate, eventsSnapshot);
   }
 
   private static class NoopSpan implements Span {

--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
@@ -105,10 +105,11 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   }
 
   private synchronized void doAddEvent(OtelSpanEvent event) {
-    if (this.events == null) {
-      this.events = new ArrayList<>();
+    List<OtelSpanEvent> eventsSnapshot = this.events;
+    if (eventsSnapshot == null) {
+      this.events = eventsSnapshot = new ArrayList<>();
     }
-    this.events.add(event);
+    eventsSnapshot.add(event);
   }
 
   @Override
@@ -183,11 +184,13 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   @Override
   public void onSpanFinished() {
     applyNamingConvention(this.delegate);
-    // Fast path: skip the lock when there are no events (the common case).
+    // Fast path: skip the lock when there are no events (the common case)
     if (this.events != null) {
       List<OtelSpanEvent> eventsSnapshot;
       synchronized (this) {
-        eventsSnapshot = new ArrayList<>(this.events);
+        // detach events for serialization
+        eventsSnapshot = this.events;
+        this.events = null;
       }
       setEventsAsTag(this.delegate, eventsSnapshot);
     }

--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
@@ -91,7 +91,7 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   @Override
   public Span addEvent(String name, Attributes attributes) {
     if (this.recording) {
-      addEvent(new OtelSpanEvent(name, attributes));
+      doAddEvent(new OtelSpanEvent(name, attributes));
     }
     return this;
   }
@@ -99,12 +99,12 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   @Override
   public Span addEvent(String name, Attributes attributes, long timestamp, TimeUnit unit) {
     if (this.recording) {
-      addEvent(new OtelSpanEvent(name, attributes, timestamp, unit));
+      doAddEvent(new OtelSpanEvent(name, attributes, timestamp, unit));
     }
     return this;
   }
 
-  private synchronized void addEvent(OtelSpanEvent event) {
+  private synchronized void doAddEvent(OtelSpanEvent event) {
     if (this.events == null) {
       this.events = new ArrayList<>();
     }
@@ -132,7 +132,7 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
     if (this.recording) {
       additionalAttributes = initializeExceptionAttributes(exception, additionalAttributes);
       applySpanEventExceptionAttributesAsTags(this.delegate, additionalAttributes);
-      addEvent(new OtelSpanEvent(EXCEPTION_SPAN_EVENT_NAME, additionalAttributes));
+      doAddEvent(new OtelSpanEvent(EXCEPTION_SPAN_EVENT_NAME, additionalAttributes));
     }
     return this;
   }

--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
@@ -38,11 +38,11 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   private boolean recording;
 
   /**
-   * Span events ({@code null} until an event is added). Mutations are guarded by synchronizing on
-   * {@code this}: events can be recorded from application threads while the span is finished (and
-   * its events serialized) from a different thread, so unsynchronized access would corrupt the
-   * backing list. Declared {@code volatile} so {@link #onSpanFinished()} can take a lock-free fast
-   * path for the common case of a span with no events.
+   * Span events ({@code null} until an event is added).
+   *
+   * <p>Volatile so {@link #onSpanFinished()} can skip the lock in common no-events case; writes and
+   * the rare non-null read synchronize on {@code this} to guard against concurrent recording from
+   * another thread.
    */
   private volatile List<OtelSpanEvent> events;
 
@@ -183,17 +183,14 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   @Override
   public void onSpanFinished() {
     applyNamingConvention(this.delegate);
-    // Fast path: most spans have no events, so avoid taking the lock entirely (single volatile
-    // read).
-    List<OtelSpanEvent> eventsSnapshot = this.events;
-    if (eventsSnapshot != null) {
-      // Copy under lock so serialization iterates a private snapshot that cannot be mutated
-      // concurrently by an application thread still recording events.
+    // Fast path: skip the lock when there are no events (the common case).
+    if (this.events != null) {
+      List<OtelSpanEvent> eventsSnapshot;
       synchronized (this) {
         eventsSnapshot = new ArrayList<>(this.events);
       }
+      setEventsAsTag(this.delegate, eventsSnapshot);
     }
-    setEventsAsTag(this.delegate, eventsSnapshot);
   }
 
   private static class NoopSpan implements Span {

--- a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
+++ b/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelSpan.java
@@ -34,8 +34,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
   private final AgentSpan delegate;
-  private StatusCode statusCode;
-  private boolean recording;
+  private StatusCode statusCode = UNSET;
+  private volatile boolean recording = true;
 
   /**
    * Span events ({@code null} until an event is added).
@@ -51,8 +51,6 @@ public class OtelSpan implements Span, WithAgentSpan, SpanWrapper {
     if (delegate instanceof AttachableWrapper) {
       ((AttachableWrapper) delegate).attachWrapper(this);
     }
-    this.statusCode = UNSET;
-    this.recording = true;
     delegate.spanContext().setIntegrationName("otel");
   }
 

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/java/opentelemetry14/OpenTelemetry14Test.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/java/opentelemetry14/OpenTelemetry14Test.java
@@ -67,9 +67,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import opentelemetry14.context.propagation.TextMap;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -287,6 +289,52 @@ class OpenTelemetry14Test extends AbstractOpenTelemetry14Test {
                     defaultTags(),
                     tag(SPAN_KIND, is(SPAN_KIND_INTERNAL)),
                     tag(SPAN_EVENTS, isJson(expectedEventTag)))));
+  }
+
+  @Test
+  void testConcurrentAddEvents() throws Exception {
+    // Regression test for the concurrent recording of span events. Events used to be stored in a
+    // plain ArrayList mutated without synchronization; recording events from multiple threads (as
+    // GraphQL DataLoaders do on virtual threads) corrupted the backing list, leaving null holes
+    // that
+    // triggered a NullPointerException in OtelSpanEvent.toTag when the span was finished. See trace
+    // b8b8e4edde47f90a92e832b63251a577.
+    int threadCount = 8;
+    int eventsPerThread = 2000;
+    Span span = this.otelTracer.spanBuilder("some-name").startSpan();
+
+    CountDownLatch start = new CountDownLatch(1);
+    List<Thread> threads = new ArrayList<>();
+    for (int t = 0; t < threadCount; t++) {
+      Thread thread =
+          new Thread(
+              () -> {
+                try {
+                  start.await();
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  return;
+                }
+                for (int i = 0; i < eventsPerThread; i++) {
+                  span.addEvent("event");
+                }
+              });
+      thread.start();
+      threads.add(thread);
+    }
+
+    start.countDown();
+    for (Thread thread : threads) {
+      thread.join();
+    }
+    span.end();
+
+    writer.waitForTraces(1);
+    List<DDSpan> firstTrace = writer.firstTrace();
+    assertEquals(1, firstTrace.size());
+    Object eventsTag = firstTrace.get(0).getTags().get(SPAN_EVENTS);
+    JSONArray events = new JSONArray((String) eventsTag);
+    assertEquals(threadCount * eventsPerThread, events.length());
   }
 
   @Test

--- a/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/java/opentelemetry14/OpenTelemetry14Test.java
+++ b/dd-java-agent/instrumentation/opentelemetry/opentelemetry-1.4/src/test/java/opentelemetry14/OpenTelemetry14Test.java
@@ -293,12 +293,8 @@ class OpenTelemetry14Test extends AbstractOpenTelemetry14Test {
 
   @Test
   void testConcurrentAddEvents() throws Exception {
-    // Regression test for the concurrent recording of span events. Events used to be stored in a
-    // plain ArrayList mutated without synchronization; recording events from multiple threads (as
-    // GraphQL DataLoaders do on virtual threads) corrupted the backing list, leaving null holes
-    // that
-    // triggered a NullPointerException in OtelSpanEvent.toTag when the span was finished. See trace
-    // b8b8e4edde47f90a92e832b63251a577.
+    // Regression test: concurrent addEvent calls (e.g. from GraphQL DataLoaders on virtual
+    // threads) used to corrupt unsynchronized backing list, causing NPE on span finish.
     int threadCount = 8;
     int eventsPerThread = 2000;
     Span span = this.otelTracer.spanBuilder("some-name").startSpan();


### PR DESCRIPTION
This PR mirrors the changes from the original community contribution to enable CI testing with maintainer privileges.

**Original PR:** https://github.com/DataDog/dd-trace-java/pull/12053
**Original Author:** @Meemaw
**Original Branch:** Meemaw/dd-trace-java:fix-otel-span-events-concurrency

Closes #12053

---

*This is an automated mirror created to run CI checks. See tooling/mirror-community-pull-request.sh for details.*