### PR TITLE
🪞 11882 - Allow tracer clock to be resynced after an AWS Lambda SnapStart restore

### DIFF
--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -98,6 +98,8 @@ public final class ConfigDefaults {
 
   static final int DEFAULT_CLOCK_SYNC_PERIOD = 30; // seconds
 
+  static final boolean DEFAULT_TRACE_LAMBDA_SNAPSTART_CLOCK_RESYNC_ENABLED = false;
+
   static final TracePropagationBehaviorExtract DEFAULT_TRACE_PROPAGATION_BEHAVIOR_EXTRACT =
       TracePropagationBehaviorExtract.CONTINUE;
   static final boolean DEFAULT_TRACE_PROPAGATION_EXTRACT_FIRST = false;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -136,9 +136,9 @@ public final class TracerConfig {
 
   /**
    * Opt-in (defaults to disabled). When enabled, resyncs the tracer's cached clock reference on
-   * every AWS Lambda invocation, before any span for that invocation is created, instead of
-   * relying on the periodic {@link #CLOCK_SYNC_PERIOD} check - which is gated on monotonic ticks
-   * elapsed and may never trigger following an AWS Lambda SnapStart restore, since a short-lived
+   * every AWS Lambda invocation, before any span for that invocation is created, instead of relying
+   * on the periodic {@link #CLOCK_SYNC_PERIOD} check - which is gated on monotonic ticks elapsed
+   * and may never trigger following an AWS Lambda SnapStart restore, since a short-lived
    * restore-then-invoke sequence can leave that reference stale for hours or days. Only takes
    * effect inside an instrumented AWS Lambda handler invocation; a no-op everywhere else.
    */

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -134,6 +134,17 @@ public final class TracerConfig {
 
   public static final String CLOCK_SYNC_PERIOD = "trace.clock.sync.period";
 
+  /**
+   * Opt-in (defaults to disabled). When enabled, resyncs the tracer's cached clock reference on
+   * every AWS Lambda invocation, before any span for that invocation is created, instead of
+   * relying on the periodic {@link #CLOCK_SYNC_PERIOD} check - which is gated on monotonic ticks
+   * elapsed and may never trigger following an AWS Lambda SnapStart restore, since a short-lived
+   * restore-then-invoke sequence can leave that reference stale for hours or days. Only takes
+   * effect inside an instrumented AWS Lambda handler invocation; a no-op everywhere else.
+   */
+  public static final String TRACE_LAMBDA_SNAPSTART_CLOCK_RESYNC_ENABLED =
+      "trace.lambda.snapstart.clock.resync.enabled";
+
   public static final String TRACE_SPAN_ATTRIBUTE_SCHEMA = "trace.span.attribute.schema";
 
   public static final String TRACE_LONG_RUNNING_ENABLED = "trace.experimental.long-running.enabled";

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TracerConfig.java
@@ -135,12 +135,9 @@ public final class TracerConfig {
   public static final String CLOCK_SYNC_PERIOD = "trace.clock.sync.period";
 
   /**
-   * Opt-in (defaults to disabled). When enabled, resyncs the tracer's cached clock reference on
-   * every AWS Lambda invocation, before any span for that invocation is created, instead of relying
-   * on the periodic {@link #CLOCK_SYNC_PERIOD} check - which is gated on monotonic ticks elapsed
-   * and may never trigger following an AWS Lambda SnapStart restore, since a short-lived
-   * restore-then-invoke sequence can leave that reference stale for hours or days. Only takes
-   * effect inside an instrumented AWS Lambda handler invocation; a no-op everywhere else.
+   * Opt-in (defaults to disabled). Resyncs the tracer's clock on every AWS Lambda invocation to fix
+   * drift left by an AWS Lambda SnapStart restore, which the periodic {@link #CLOCK_SYNC_PERIOD}
+   * check can miss. No-op outside an instrumented Lambda invocation.
    */
   public static final String TRACE_LAMBDA_SNAPSTART_CLOCK_RESYNC_ENABLED =
       "trace.lambda.snapstart.clock.resync.enabled";

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1034,13 +1034,21 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
   long getTimeWithNanoTicks(long nanoTicks) {
     long computedNanoTime = startTimeNano + Math.max(0, nanoTicks - startNanoTicks);
     if (nanoTicks - lastSyncTicks >= clockSyncPeriod) {
-      long drift = computedNanoTime - timeSource.getCurrentTimeNanos();
-      if (Math.abs(drift + counterDrift) >= 1_000_000L) { // allow up to 1ms of drift
-        counterDrift = -MILLISECONDS.toNanos(NANOSECONDS.toMillis(drift));
-      }
+      correctCounterDrift(computedNanoTime);
       lastSyncTicks = nanoTicks;
     }
     return computedNanoTime + counterDrift;
+  }
+
+  /**
+   * Computes {@link #counterDrift} corrected against {@code computedNanoTime}, gated by a 1ms
+   * threshold to avoid regressing the clock on {@link SystemTimeSource}'s millisecond precision.
+   */
+  private void correctCounterDrift(long computedNanoTime) {
+    long drift = computedNanoTime - timeSource.getCurrentTimeNanos();
+    if (Math.abs(drift + counterDrift) >= 1_000_000L) { // allow up to 1ms of drift
+      counterDrift = -MILLISECONDS.toNanos(NANOSECONDS.toMillis(drift));
+    }
   }
 
   /**
@@ -1059,9 +1067,8 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
    * <p>Rather than reset {@link #startTimeNano}/{@link #startNanoTicks} themselves - which would
    * require making those fields {@code volatile}, since they're read on every {@link
    * #getTimeWithNanoTicks} call from arbitrary tracing threads - this folds the entire observed
-   * drift into {@link #counterDrift} directly, the same field (already {@code volatile}) that the
-   * periodic self-correction in {@link #getTimeWithNanoTicks} uses, just without that correction's
-   * 1ms drift threshold, since here the drift can be hours or days.
+   * drift into {@link #counterDrift} via the same {@link #correctCounterDrift} used by the periodic
+   * self-correction in {@link #getTimeWithNanoTicks}.
    *
    * <p>Rather than reacting to the restore event itself (which would need a JVM-level
    * checkpoint/restore hook), this is called from {@link #notifyLambdaStart} - already invoked once
@@ -1083,7 +1090,7 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
     }
     long nanoTicks = timeSource.getNanoTicks();
     long computedNanoTime = startTimeNano + Math.max(0, nanoTicks - startNanoTicks);
-    counterDrift = timeSource.getCurrentTimeNanos() - computedNanoTime;
+    correctCounterDrift(computedNanoTime);
     lastSyncTicks = nanoTicks;
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -1052,34 +1052,11 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
   }
 
   /**
-   * AWS Lambda SnapStart checkpoints the JVM at snapshot-creation time and later restores it,
-   * potentially much later (a restored snapshot can go {@code Inactive} and be restored again after
-   * 14 days of no invocations). {@link System#nanoTime()} does not account for the frozen duration
-   * across that restore, so {@link #startTimeNano}/{@link #startNanoTicks} - captured once at
-   * construction time, i.e. at snapshot-creation time - go stale, and the periodic self-correction
-   * in {@link #getTimeWithNanoTicks} may never trigger to fix it: that correction is gated on
-   * {@code nanoTicks - lastSyncTicks >= clockSyncPeriod} (monotonic ticks elapsed), which a
-   * short-lived restore-then-invoke sequence can easily never reach even though wall-clock time has
-   * moved on by hours or days. Left uncorrected, every span timestamp computed via {@link
-   * #getTimeWithNanoTicks} stays anchored near the original snapshot-creation instant instead of
-   * the real restore/invocation time.
-   *
-   * <p>Rather than reset {@link #startTimeNano}/{@link #startNanoTicks} themselves - which would
-   * require making those fields {@code volatile}, since they're read on every {@link
-   * #getTimeWithNanoTicks} call from arbitrary tracing threads - this folds the entire observed
-   * drift into {@link #counterDrift} via the same {@link #correctCounterDrift} used by the periodic
-   * self-correction in {@link #getTimeWithNanoTicks}.
-   *
-   * <p>Rather than reacting to the restore event itself (which would need a JVM-level
-   * checkpoint/restore hook), this is called from {@link #notifyLambdaStart} - already invoked once
-   * per Lambda invocation, before any span for that invocation is created. Any real restore is
-   * always followed by an invocation, so resyncing there catches it with no extra dependency. Doing
-   * this on every invocation (not just ones following a restore) is deliberate: outside SnapStart,
-   * {@link System#nanoTime()} correctly tracks elapsed time across a warm container's normal
-   * freeze/thaw between invocations (same continuously-executing process, unlike SnapStart's
-   * restore-into-a-new-context), so this is a correct no-op there - just a couple of field reads
-   * and a subtraction, negligible next to the HTTP round-trip {@link #notifyLambdaStart} already
-   * makes.
+   * AWS Lambda SnapStart restores a checkpointed JVM, potentially hours or days later, without
+   * {@link System#nanoTime()} accounting for the frozen duration. That can leave the computed time
+   * stale for longer than {@link #getTimeWithNanoTicks}'s periodic self-correction can catch, as
+   * that's gated on ticks elapsed rather than wall-clock time. Called once per Lambda invocation,
+   * before any span for it is created, so it's a cheap no-op outside SnapStart.
    *
    * <p>Gated on {@link Config#isLambdaSnapStartClockResyncEnabled()} as an escape hatch.
    */

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -148,11 +148,22 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
     return new CoreTracerBuilder();
   }
 
-  /** Tracer start time in nanoseconds measured up to a millisecond accuracy */
-  private final long startTimeNano;
+  /**
+   * Tracer start time in nanoseconds measured up to a millisecond accuracy.
+   *
+   * <p>Not final: reset by {@link #maybeResyncClockForLambdaInvocation()} on every Lambda invocation,
+   * since the value captured at construction time can predate an AWS Lambda SnapStart restore by
+   * hours or days - see that method's javadoc for why.
+   */
+  private volatile long startTimeNano;
 
-  /** Nanosecond ticks value at tracer start */
-  private final long startNanoTicks;
+  /**
+   * Nanosecond ticks value at tracer start.
+   *
+   * <p>Not final: reset by {@link #maybeResyncClockForLambdaInvocation()} on every Lambda invocation -
+   * see {@link #startTimeNano}.
+   */
+  private volatile long startNanoTicks;
 
   /** How often should traced threads check clock ticks against the wall clock */
   private final long clockSyncPeriod;
@@ -1043,6 +1054,42 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
     return computedNanoTime + counterDrift;
   }
 
+  /**
+   * AWS Lambda SnapStart checkpoints the JVM at snapshot-creation time and later restores it,
+   * potentially much later (a restored snapshot can go {@code Inactive} and be restored again after
+   * 14 days of no invocations). {@link System#nanoTime()} does not account for the frozen duration
+   * across that restore, so {@link #startTimeNano}/{@link #startNanoTicks} - captured once at
+   * construction time, i.e. at snapshot-creation time - go stale, and the periodic self-correction
+   * in {@link #getTimeWithNanoTicks} may never trigger to fix it: that correction is gated on
+   * {@code nanoTicks - lastSyncTicks >= clockSyncPeriod} (monotonic ticks elapsed), which a
+   * short-lived restore-then-invoke sequence can easily never reach even though wall-clock time has
+   * moved on by hours or days. Left uncorrected, every span timestamp computed via {@link
+   * #getTimeWithNanoTicks} stays anchored near the original snapshot-creation instant instead of
+   * the real restore/invocation time.
+   *
+   * <p>Rather than reacting to the restore event itself (which would need a JVM-level
+   * checkpoint/restore hook), this is called from {@link #notifyLambdaStart} - already invoked once
+   * per Lambda invocation, before any span for that invocation is created. Any real restore is
+   * always followed by an invocation, so resyncing there catches it with no extra dependency. Doing
+   * this on every invocation (not just ones following a restore) is deliberate: outside SnapStart,
+   * {@link System#nanoTime()} correctly tracks elapsed time across a warm container's normal
+   * freeze/thaw between invocations (same continuously-executing process, unlike SnapStart's
+   * restore-into-a-new-context), so this is a correct no-op there - just a few field writes,
+   * negligible next to the HTTP round-trip {@link #notifyLambdaStart} already makes.
+   *
+   * <p>Gated on {@link Config#isLambdaSnapStartClockResyncEnabled()} as an escape hatch.
+   */
+  @VisibleForTesting
+  void maybeResyncClockForLambdaInvocation() {
+    if (!initialConfig.isLambdaSnapStartClockResyncEnabled()) {
+      return;
+    }
+    startTimeNano = timeSource.getCurrentTimeNanos();
+    startNanoTicks = timeSource.getNanoTicks();
+    lastSyncTicks = startNanoTicks;
+    counterDrift = 0;
+  }
+
   @Override
   public CoreSpanBuilder buildSpan(
       final String instrumentationName, final CharSequence operationName) {
@@ -1250,6 +1297,8 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
 
   @Override
   public AgentSpanContext notifyLambdaStart(Object event, String lambdaRequestId) {
+    maybeResyncClockForLambdaInvocation();
+
     // Get context from AppSec
     AgentSpanContext appSecContext = LambdaAppSecHandler.processRequestStart(event);
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -148,22 +148,11 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
     return new CoreTracerBuilder();
   }
 
-  /**
-   * Tracer start time in nanoseconds measured up to a millisecond accuracy.
-   *
-   * <p>Not final: reset by {@link #maybeResyncClockForLambdaInvocation()} on every Lambda invocation,
-   * since the value captured at construction time can predate an AWS Lambda SnapStart restore by
-   * hours or days - see that method's javadoc for why.
-   */
-  private volatile long startTimeNano;
+  /** Tracer start time in nanoseconds measured up to a millisecond accuracy */
+  private final long startTimeNano;
 
-  /**
-   * Nanosecond ticks value at tracer start.
-   *
-   * <p>Not final: reset by {@link #maybeResyncClockForLambdaInvocation()} on every Lambda invocation -
-   * see {@link #startTimeNano}.
-   */
-  private volatile long startNanoTicks;
+  /** Nanosecond ticks value at tracer start */
+  private final long startNanoTicks;
 
   /** How often should traced threads check clock ticks against the wall clock */
   private final long clockSyncPeriod;
@@ -1067,6 +1056,13 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
    * #getTimeWithNanoTicks} stays anchored near the original snapshot-creation instant instead of
    * the real restore/invocation time.
    *
+   * <p>Rather than reset {@link #startTimeNano}/{@link #startNanoTicks} themselves - which would
+   * require making those fields {@code volatile}, since they're read on every {@link
+   * #getTimeWithNanoTicks} call from arbitrary tracing threads - this folds the entire observed
+   * drift into {@link #counterDrift} directly, the same field (already {@code volatile}) that the
+   * periodic self-correction in {@link #getTimeWithNanoTicks} uses, just without that correction's
+   * 1ms drift threshold, since here the drift can be hours or days.
+   *
    * <p>Rather than reacting to the restore event itself (which would need a JVM-level
    * checkpoint/restore hook), this is called from {@link #notifyLambdaStart} - already invoked once
    * per Lambda invocation, before any span for that invocation is created. Any real restore is
@@ -1074,8 +1070,9 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
    * this on every invocation (not just ones following a restore) is deliberate: outside SnapStart,
    * {@link System#nanoTime()} correctly tracks elapsed time across a warm container's normal
    * freeze/thaw between invocations (same continuously-executing process, unlike SnapStart's
-   * restore-into-a-new-context), so this is a correct no-op there - just a few field writes,
-   * negligible next to the HTTP round-trip {@link #notifyLambdaStart} already makes.
+   * restore-into-a-new-context), so this is a correct no-op there - just a couple of field reads
+   * and a subtraction, negligible next to the HTTP round-trip {@link #notifyLambdaStart} already
+   * makes.
    *
    * <p>Gated on {@link Config#isLambdaSnapStartClockResyncEnabled()} as an escape hatch.
    */
@@ -1084,10 +1081,10 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
     if (!initialConfig.isLambdaSnapStartClockResyncEnabled()) {
       return;
     }
-    startTimeNano = timeSource.getCurrentTimeNanos();
-    startNanoTicks = timeSource.getNanoTicks();
-    lastSyncTicks = startNanoTicks;
-    counterDrift = 0;
+    long nanoTicks = timeSource.getNanoTicks();
+    long computedNanoTime = startTimeNano + Math.max(0, nanoTicks - startNanoTicks);
+    counterDrift = timeSource.getCurrentTimeNanos() - computedNanoTime;
+    lastSyncTicks = nanoTicks;
   }
 
   @Override

--- a/dd-trace-core/src/test/java/datadog/trace/core/CoreTracerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/CoreTracerTest.java
@@ -28,6 +28,7 @@ import datadog.trace.api.config.GeneralConfig;
 import datadog.trace.api.config.TracerConfig;
 import datadog.trace.api.remoteconfig.ServiceNameCollector;
 import datadog.trace.api.sampling.PrioritySampling;
+import datadog.trace.api.time.ControllableTimeSource;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.ServiceNameSources;
 import datadog.trace.common.sampling.AllSampler;
@@ -74,6 +75,93 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
       assertFalse(tracer.serviceName.isEmpty());
       assertInstanceOf(RateByServiceTraceSampler.class, tracer.initialSampler);
       assertInstanceOf(DDAgentWriter.class, tracer.writer);
+    } finally {
+      tracer.close();
+    }
+  }
+
+  @Test
+  void
+      getTimeWithNanoTicks_whenNanoTicksStaleAfterSimulatedRestore_thenTimestampStaysAnchoredToConstructionTime() {
+    // Characterizes the AWS Lambda SnapStart bug this fix addresses: System.nanoTime() does not
+    // account for the frozen duration across a checkpoint/restore, so a nanoTicks reading taken
+    // right after restore can be indistinguishable from one taken at construction (snapshot
+    // creation) time, even though wall-clock time has moved on by hours. Without a resync, span
+    // timestamps computed from that stale nanoTicks stay anchored to construction time.
+    ControllableTimeSource timeSource = new ControllableTimeSource();
+    timeSource.set(TimeUnit.SECONDS.toNanos(1000));
+    CoreTracer tracer = tracerBuilder().writer(new ListWriter()).timeSource(timeSource).build();
+    try {
+      long constructionTimeNanoTicks = timeSource.getNanoTicks();
+
+      // Wall-clock time moves on by 2 hours (the restore happens much later), but the nanoTicks
+      // value a span would be timestamped with right after restore hasn't advanced.
+      timeSource.set(TimeUnit.SECONDS.toNanos(1000) + TimeUnit.HOURS.toNanos(2));
+
+      assertEquals(
+          TimeUnit.SECONDS.toNanos(1000), tracer.getTimeWithNanoTicks(constructionTimeNanoTicks));
+    } finally {
+      tracer.close();
+    }
+  }
+
+  @Test
+  @WithConfig(key = TracerConfig.TRACE_LAMBDA_SNAPSTART_CLOCK_RESYNC_ENABLED, value = "true")
+  void
+      maybeResyncClockForLambdaInvocation_whenEnabledAndCalledAfterSimulatedRestore_thenTimestampReflectsPostRestoreTime() {
+    ControllableTimeSource timeSource = new ControllableTimeSource();
+    timeSource.set(TimeUnit.SECONDS.toNanos(1000));
+    CoreTracer tracer = tracerBuilder().writer(new ListWriter()).timeSource(timeSource).build();
+    try {
+      // The restore happens: wall-clock/tick source jumps forward by 2 hours.
+      long postRestoreNanos = TimeUnit.SECONDS.toNanos(1000) + TimeUnit.HOURS.toNanos(2);
+      timeSource.set(postRestoreNanos);
+
+      tracer.maybeResyncClockForLambdaInvocation();
+
+      // A span timestamped right after resync now reflects the real post-restore time, not the
+      // stale construction-time (pre-restore) anchor.
+      assertEquals(postRestoreNanos, tracer.getTimeWithNanoTicks(timeSource.getNanoTicks()));
+    } finally {
+      tracer.close();
+    }
+  }
+
+  @Test
+  @WithConfig(key = TracerConfig.TRACE_LAMBDA_SNAPSTART_CLOCK_RESYNC_ENABLED, value = "true")
+  void notifyLambdaStart_whenExplicitlyEnabled_thenResyncsClockToCurrentTime() {
+    // notifyLambdaStart runs once per Lambda invocation, before any span for that invocation is
+    // created - the actual trigger point for the resync in production, not just the extracted
+    // maybeResyncClockForLambdaInvocation() logic exercised directly above.
+    ControllableTimeSource timeSource = new ControllableTimeSource();
+    timeSource.set(TimeUnit.SECONDS.toNanos(1000));
+    CoreTracer tracer = tracerBuilder().writer(new ListWriter()).timeSource(timeSource).build();
+    try {
+      long postRestoreNanos = TimeUnit.SECONDS.toNanos(1000) + TimeUnit.HOURS.toNanos(2);
+      timeSource.set(postRestoreNanos);
+
+      tracer.notifyLambdaStart(new Object(), "lambda-request-123");
+
+      assertEquals(postRestoreNanos, tracer.getTimeWithNanoTicks(timeSource.getNanoTicks()));
+    } finally {
+      tracer.close();
+    }
+  }
+
+  @Test
+  void notifyLambdaStart_whenResyncDefaultsToDisabled_thenTimestampStaysAnchoredToConstructionTime() {
+    ControllableTimeSource timeSource = new ControllableTimeSource();
+    timeSource.set(TimeUnit.SECONDS.toNanos(1000));
+    CoreTracer tracer = tracerBuilder().writer(new ListWriter()).timeSource(timeSource).build();
+    try {
+      long constructionTimeNanoTicks = timeSource.getNanoTicks();
+      timeSource.set(TimeUnit.SECONDS.toNanos(1000) + TimeUnit.HOURS.toNanos(2));
+
+      // No @WithConfig override here - this is an opt-in feature, off by default.
+      tracer.notifyLambdaStart(new Object(), "lambda-request-123");
+
+      assertEquals(
+          TimeUnit.SECONDS.toNanos(1000), tracer.getTimeWithNanoTicks(constructionTimeNanoTicks));
     } finally {
       tracer.close();
     }

--- a/dd-trace-core/src/test/java/datadog/trace/core/CoreTracerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/CoreTracerTest.java
@@ -149,7 +149,8 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
   }
 
   @Test
-  void notifyLambdaStart_whenResyncDefaultsToDisabled_thenTimestampStaysAnchoredToConstructionTime() {
+  void
+      notifyLambdaStart_whenResyncDefaultsToDisabled_thenTimestampStaysAnchoredToConstructionTime() {
     ControllableTimeSource timeSource = new ControllableTimeSource();
     timeSource.set(TimeUnit.SECONDS.toNanos(1000));
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).timeSource(timeSource).build();

--- a/dd-trace-core/src/test/java/datadog/trace/core/CoreTracerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/CoreTracerTest.java
@@ -80,6 +80,8 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
     }
   }
 
+  private static final long SNAPSTART_CONSTRUCTION_TIME_NANOS = TimeUnit.SECONDS.toNanos(1000);
+
   @Test
   void
       getTimeWithNanoTicks_whenNanoTicksStaleAfterSimulatedRestore_thenTimestampStaysAnchoredToConstructionTime() {
@@ -88,7 +90,7 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
     // with right after restore is (almost) unchanged from construction (snapshot creation) time,
     // even though wall-clock time has moved on by hours. Without a resync, span timestamps
     // computed from that near-frozen nanoTicks stay anchored to construction time.
-    SnapStartTimeSource timeSource = new SnapStartTimeSource(TimeUnit.SECONDS.toNanos(1000));
+    SnapStartTimeSource timeSource = new SnapStartTimeSource(SNAPSTART_CONSTRUCTION_TIME_NANOS);
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).timeSource(timeSource).build();
     try {
       long constructionTimeNanoTicks = timeSource.getNanoTicks();
@@ -98,7 +100,8 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
       timeSource.simulateSnapStartRestore(TimeUnit.HOURS.toNanos(2));
 
       assertEquals(
-          TimeUnit.SECONDS.toNanos(1000), tracer.getTimeWithNanoTicks(constructionTimeNanoTicks));
+          SNAPSTART_CONSTRUCTION_TIME_NANOS,
+          tracer.getTimeWithNanoTicks(constructionTimeNanoTicks));
     } finally {
       tracer.close();
     }
@@ -108,12 +111,12 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
   @WithConfig(key = TracerConfig.TRACE_LAMBDA_SNAPSTART_CLOCK_RESYNC_ENABLED, value = "true")
   void
       maybeResyncClockForLambdaInvocation_whenEnabledAndCalledAfterSimulatedRestore_thenTimestampReflectsPostRestoreTime() {
-    SnapStartTimeSource timeSource = new SnapStartTimeSource(TimeUnit.SECONDS.toNanos(1000));
+    SnapStartTimeSource timeSource = new SnapStartTimeSource(SNAPSTART_CONSTRUCTION_TIME_NANOS);
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).timeSource(timeSource).build();
     try {
       // The restore happens: wall-clock jumps forward by 2 hours, nanoTicks barely moves.
-      long postRestoreNanos = TimeUnit.SECONDS.toNanos(1000) + TimeUnit.HOURS.toNanos(2);
       timeSource.simulateSnapStartRestore(TimeUnit.HOURS.toNanos(2));
+      long postRestoreNanos = timeSource.getCurrentTimeNanos();
 
       tracer.maybeResyncClockForLambdaInvocation();
 
@@ -133,11 +136,11 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
     // notifyLambdaStart runs once per Lambda invocation, before any span for that invocation is
     // created - the actual trigger point for the resync in production, not just the extracted
     // maybeResyncClockForLambdaInvocation() logic exercised directly above.
-    SnapStartTimeSource timeSource = new SnapStartTimeSource(TimeUnit.SECONDS.toNanos(1000));
+    SnapStartTimeSource timeSource = new SnapStartTimeSource(SNAPSTART_CONSTRUCTION_TIME_NANOS);
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).timeSource(timeSource).build();
     try {
-      long postRestoreNanos = TimeUnit.SECONDS.toNanos(1000) + TimeUnit.HOURS.toNanos(2);
       timeSource.simulateSnapStartRestore(TimeUnit.HOURS.toNanos(2));
+      long postRestoreNanos = timeSource.getCurrentTimeNanos();
 
       tracer.notifyLambdaStart(new Object(), "lambda-request-123");
 
@@ -152,7 +155,7 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
   @Test
   void
       notifyLambdaStart_whenResyncDefaultsToDisabled_thenTimestampStaysAnchoredToConstructionTime() {
-    SnapStartTimeSource timeSource = new SnapStartTimeSource(TimeUnit.SECONDS.toNanos(1000));
+    SnapStartTimeSource timeSource = new SnapStartTimeSource(SNAPSTART_CONSTRUCTION_TIME_NANOS);
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).timeSource(timeSource).build();
     try {
       long constructionTimeNanoTicks = timeSource.getNanoTicks();
@@ -162,7 +165,8 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
       tracer.notifyLambdaStart(new Object(), "lambda-request-123");
 
       assertEquals(
-          TimeUnit.SECONDS.toNanos(1000), tracer.getTimeWithNanoTicks(constructionTimeNanoTicks));
+          SNAPSTART_CONSTRUCTION_TIME_NANOS,
+          tracer.getTimeWithNanoTicks(constructionTimeNanoTicks));
     } finally {
       tracer.close();
     }

--- a/dd-trace-core/src/test/java/datadog/trace/core/CoreTracerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/CoreTracerTest.java
@@ -84,19 +84,18 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
   void
       getTimeWithNanoTicks_whenNanoTicksStaleAfterSimulatedRestore_thenTimestampStaysAnchoredToConstructionTime() {
     // Characterizes the AWS Lambda SnapStart bug this fix addresses: System.nanoTime() does not
-    // account for the frozen duration across a checkpoint/restore, so a nanoTicks reading taken
-    // right after restore can be indistinguishable from one taken at construction (snapshot
-    // creation) time, even though wall-clock time has moved on by hours. Without a resync, span
-    // timestamps computed from that stale nanoTicks stay anchored to construction time.
-    ControllableTimeSource timeSource = new ControllableTimeSource();
-    timeSource.set(TimeUnit.SECONDS.toNanos(1000));
+    // accumulate the frozen checkpoint/restore duration, so the nanoTicks a span is timestamped
+    // with right after restore is (almost) unchanged from construction (snapshot creation) time,
+    // even though wall-clock time has moved on by hours. Without a resync, span timestamps
+    // computed from that near-frozen nanoTicks stay anchored to construction time.
+    SnapStartTimeSource timeSource = new SnapStartTimeSource(TimeUnit.SECONDS.toNanos(1000));
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).timeSource(timeSource).build();
     try {
       long constructionTimeNanoTicks = timeSource.getNanoTicks();
 
-      // Wall-clock time moves on by 2 hours (the restore happens much later), but the nanoTicks
-      // value a span would be timestamped with right after restore hasn't advanced.
-      timeSource.set(TimeUnit.SECONDS.toNanos(1000) + TimeUnit.HOURS.toNanos(2));
+      // The restore happens much later: wall-clock jumps forward by 2 hours, but nanoTicks - tied
+      // to monotonic JVM uptime, which does not advance while the snapshot is frozen - does not.
+      timeSource.simulateSnapStartRestore(TimeUnit.HOURS.toNanos(2));
 
       assertEquals(
           TimeUnit.SECONDS.toNanos(1000), tracer.getTimeWithNanoTicks(constructionTimeNanoTicks));
@@ -109,18 +108,19 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
   @WithConfig(key = TracerConfig.TRACE_LAMBDA_SNAPSTART_CLOCK_RESYNC_ENABLED, value = "true")
   void
       maybeResyncClockForLambdaInvocation_whenEnabledAndCalledAfterSimulatedRestore_thenTimestampReflectsPostRestoreTime() {
-    ControllableTimeSource timeSource = new ControllableTimeSource();
-    timeSource.set(TimeUnit.SECONDS.toNanos(1000));
+    SnapStartTimeSource timeSource = new SnapStartTimeSource(TimeUnit.SECONDS.toNanos(1000));
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).timeSource(timeSource).build();
     try {
-      // The restore happens: wall-clock/tick source jumps forward by 2 hours.
+      // The restore happens: wall-clock jumps forward by 2 hours, nanoTicks barely moves.
       long postRestoreNanos = TimeUnit.SECONDS.toNanos(1000) + TimeUnit.HOURS.toNanos(2);
-      timeSource.set(postRestoreNanos);
+      timeSource.simulateSnapStartRestore(TimeUnit.HOURS.toNanos(2));
 
       tracer.maybeResyncClockForLambdaInvocation();
 
-      // A span timestamped right after resync now reflects the real post-restore time, not the
-      // stale construction-time (pre-restore) anchor.
+      // A span timestamped with the near-frozen, post-restore nanoTicks reading now reflects the
+      // real post-restore time, not the stale construction-time anchor - proving the resync
+      // actually corrected counterDrift rather than the assertion just re-deriving the same
+      // reading.
       assertEquals(postRestoreNanos, tracer.getTimeWithNanoTicks(timeSource.getNanoTicks()));
     } finally {
       tracer.close();
@@ -133,15 +133,16 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
     // notifyLambdaStart runs once per Lambda invocation, before any span for that invocation is
     // created - the actual trigger point for the resync in production, not just the extracted
     // maybeResyncClockForLambdaInvocation() logic exercised directly above.
-    ControllableTimeSource timeSource = new ControllableTimeSource();
-    timeSource.set(TimeUnit.SECONDS.toNanos(1000));
+    SnapStartTimeSource timeSource = new SnapStartTimeSource(TimeUnit.SECONDS.toNanos(1000));
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).timeSource(timeSource).build();
     try {
       long postRestoreNanos = TimeUnit.SECONDS.toNanos(1000) + TimeUnit.HOURS.toNanos(2);
-      timeSource.set(postRestoreNanos);
+      timeSource.simulateSnapStartRestore(TimeUnit.HOURS.toNanos(2));
 
       tracer.notifyLambdaStart(new Object(), "lambda-request-123");
 
+      // Same near-frozen-nanoTicks check as above: proves notifyLambdaStart's resync corrected
+      // the drift, rather than the assertion re-deriving the answer independently.
       assertEquals(postRestoreNanos, tracer.getTimeWithNanoTicks(timeSource.getNanoTicks()));
     } finally {
       tracer.close();
@@ -151,12 +152,11 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
   @Test
   void
       notifyLambdaStart_whenResyncDefaultsToDisabled_thenTimestampStaysAnchoredToConstructionTime() {
-    ControllableTimeSource timeSource = new ControllableTimeSource();
-    timeSource.set(TimeUnit.SECONDS.toNanos(1000));
+    SnapStartTimeSource timeSource = new SnapStartTimeSource(TimeUnit.SECONDS.toNanos(1000));
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).timeSource(timeSource).build();
     try {
       long constructionTimeNanoTicks = timeSource.getNanoTicks();
-      timeSource.set(TimeUnit.SECONDS.toNanos(1000) + TimeUnit.HOURS.toNanos(2));
+      timeSource.simulateSnapStartRestore(TimeUnit.HOURS.toNanos(2));
 
       // No @WithConfig override here - this is an opt-in feature, off by default.
       tracer.notifyLambdaStart(new Object(), "lambda-request-123");
@@ -165,6 +165,46 @@ public class CoreTracerTest extends DDCoreJavaSpecification {
           TimeUnit.SECONDS.toNanos(1000), tracer.getTimeWithNanoTicks(constructionTimeNanoTicks));
     } finally {
       tracer.close();
+    }
+  }
+
+  /**
+   * A {@link datadog.trace.api.time.TimeSource} that decouples wall-clock time from nanoTicks, to
+   * simulate an AWS Lambda SnapStart checkpoint/restore: while frozen, monotonic nanoTicks do not
+   * advance but wall-clock time does. {@link ControllableTimeSource} can't simulate this because it
+   * derives both from the same underlying counter.
+   */
+  private static final class SnapStartTimeSource implements datadog.trace.api.time.TimeSource {
+    private final long nanoTicks;
+    private long currentTimeNanos;
+
+    SnapStartTimeSource(long initialNanos) {
+      this.nanoTicks = initialNanos;
+      this.currentTimeNanos = initialNanos;
+    }
+
+    void simulateSnapStartRestore(long wallClockJumpNanos) {
+      currentTimeNanos += wallClockJumpNanos;
+    }
+
+    @Override
+    public long getNanoTicks() {
+      return nanoTicks;
+    }
+
+    @Override
+    public long getCurrentTimeMillis() {
+      return TimeUnit.NANOSECONDS.toMillis(currentTimeNanos);
+    }
+
+    @Override
+    public long getCurrentTimeMicros() {
+      return TimeUnit.NANOSECONDS.toMicros(currentTimeNanos);
+    }
+
+    @Override
+    public long getCurrentTimeNanos() {
+      return currentTimeNanos;
     }
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -182,6 +182,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_CLOUD_PAYLOAD_TAGGI
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_EXPERIMENTAL_FEATURES_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_HTTP_RESOURCE_REMOVE_TRAILING_SLASH;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_KEEP_LATENCY_THRESHOLD_MS;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_LAMBDA_SNAPSTART_CLOCK_RESYNC_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_LONG_RUNNING_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_LONG_RUNNING_FLUSH_INTERVAL;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_LONG_RUNNING_INITIAL_FLUSH_INTERVAL;
@@ -701,6 +702,7 @@ import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_SERVER_ERROR_STAT
 import static datadog.trace.api.config.TracerConfig.TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING;
 import static datadog.trace.api.config.TracerConfig.TRACE_INFERRED_PROXY_SERVICES_ENABLED;
 import static datadog.trace.api.config.TracerConfig.TRACE_KEEP_LATENCY_THRESHOLD_MS;
+import static datadog.trace.api.config.TracerConfig.TRACE_LAMBDA_SNAPSTART_CLOCK_RESYNC_ENABLED;
 import static datadog.trace.api.config.TracerConfig.TRACE_LONG_RUNNING_ENABLED;
 import static datadog.trace.api.config.TracerConfig.TRACE_LONG_RUNNING_FLUSH_INTERVAL;
 import static datadog.trace.api.config.TracerConfig.TRACE_LONG_RUNNING_INITIAL_FLUSH_INTERVAL;
@@ -1350,6 +1352,8 @@ public class Config {
 
   private final boolean secureRandom;
 
+  private final boolean lambdaSnapStartClockResyncEnabled;
+
   private final boolean trace128bitTraceIdGenerationEnabled;
   private final boolean logs128bitTraceIdEnabled;
 
@@ -1557,6 +1561,10 @@ public class Config {
     } else {
       secureRandom = configProvider.getBoolean(SECURE_RANDOM, DEFAULT_SECURE_RANDOM);
     }
+    lambdaSnapStartClockResyncEnabled =
+        configProvider.getBoolean(
+            TRACE_LAMBDA_SNAPSTART_CLOCK_RESYNC_ENABLED,
+            DEFAULT_TRACE_LAMBDA_SNAPSTART_CLOCK_RESYNC_ENABLED);
     cassandraKeyspaceStatementExtractionEnabled =
         configProvider.getBoolean(
             CASSANDRA_KEYSPACE_STATEMENT_EXTRACTION_ENABLED,
@@ -5166,6 +5174,10 @@ public class Config {
 
   public boolean isAwsServerless() {
     return awsServerless;
+  }
+
+  public boolean isLambdaSnapStartClockResyncEnabled() {
+    return lambdaSnapStartClockResyncEnabled;
   }
 
   public boolean isDataStreamsEnabled() {

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -5233,6 +5233,14 @@
         "aliases": []
       }
     ],
+    "DD_TRACE_LAMBDA_SNAPSTART_CLOCK_RESYNC_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "false",
+        "aliases": []
+      }
+    ],
     "DD_TRACE_CLOUD_PAYLOAD_TAGGING_MAX_DEPTH": [
       {
         "version": "A",


### PR DESCRIPTION
To enable this opt-in feature add this JVM option:
```
-Ddd.trace.lambda.snapstart.clock.resync.enabled=true
```
or set this environment variable:
```
DD_TRACE_LAMBDA_SNAPSTART_CLOCK_RESYNC_ENABLED=true
```
---

This PR mirrors the changes from the original community contribution to enable CI testing with maintainer privileges.

**Original PR:** https://github.com/DataDog/dd-trace-java/pull/11882
**Original Author:** @sheldon-nadarajah-sft
**Original Branch:** sheldon-nadarajah-sft/dd-trace-java:fix/snapstart-clock-resync

Closes #11882

---

*This is an automated mirror created to run CI checks. See tooling/mirror-community-pull-request.sh for details.*