### PR TITLE
Add API key fingerprint to agentless Feature Flags requests

### DIFF
--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/AgentlessConfigurationSource.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/AgentlessConfigurationSource.java
@@ -41,6 +41,7 @@ final class AgentlessConfigurationSource implements ConfigurationSourceService {
 
   private static final String DATADOG_UFC_RULES_BASED_SERVER_PATH =
       "/api/v2/feature-flagging/config/rules-based/server";
+  private static final String DD_API_KEY_FINGERPRINT_HEADER = "DD-API-KEY-FINGERPRINT";
   private static final int MAX_ATTEMPTS = 3;
   private static final int MINUTES_BETWEEN_WARNINGS = 5;
   private static final long FIRST_RETRY_MIN_MILLIS = 2_000;
@@ -363,9 +364,14 @@ final class AgentlessConfigurationSource implements ConfigurationSourceService {
       if (etag != null) {
         headers.put("If-None-Match", etag);
       }
+      final boolean datadogManagedEndpoint = isDatadogManagedEndpoint(endpoint, config);
+      final String apiKey = config.getApiKey();
+      if (datadogManagedEndpoint && apiKey != null && !apiKey.isEmpty()) {
+        headers.put(DD_API_KEY_FINGERPRINT_HEADER, ApiKeyFingerprint.create(apiKey));
+      }
       // Leave Accept-Encoding unset so OkHttp negotiates gzip and transparently decompresses it.
       final Request request =
-          prepareRequest(endpoint, headers, config, isDatadogManagedEndpoint(endpoint, config))
+          prepareRequest(endpoint, headers, config, datadogManagedEndpoint)
               .get()
               .build();
       if (!fetching.compareAndSet(false, true)) {

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/AgentlessConfigurationSource.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/AgentlessConfigurationSource.java
@@ -371,9 +371,7 @@ final class AgentlessConfigurationSource implements ConfigurationSourceService {
       }
       // Leave Accept-Encoding unset so OkHttp negotiates gzip and transparently decompresses it.
       final Request request =
-          prepareRequest(endpoint, headers, config, datadogManagedEndpoint)
-              .get()
-              .build();
+          prepareRequest(endpoint, headers, config, datadogManagedEndpoint).get().build();
       if (!fetching.compareAndSet(false, true)) {
         throw new IllegalStateException("Feature Flagging HTTP request already in flight");
       }

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/ApiKeyFingerprint.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/ApiKeyFingerprint.java
@@ -1,0 +1,38 @@
+package com.datadog.featureflag;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/** Creates the non-secret identifier required for authenticated Feature Flagging requests. */
+final class ApiKeyFingerprint {
+  private static final char[] BASE62 =
+      "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
+  private static final BigInteger RADIX = BigInteger.valueOf(BASE62.length);
+  private static final int SHA_256_BASE62_LENGTH = 43;
+
+  private ApiKeyFingerprint() {}
+
+  static String create(final String apiKey) {
+    final byte[] digest;
+    try {
+      digest = MessageDigest.getInstance("SHA-256").digest(apiKey.getBytes(StandardCharsets.UTF_8));
+    } catch (final NoSuchAlgorithmException impossible) {
+      throw new IllegalStateException("SHA-256 is unavailable", impossible);
+    }
+
+    BigInteger value = new BigInteger(1, digest);
+    final StringBuilder encoded = new StringBuilder(SHA_256_BASE62_LENGTH);
+    do {
+      final BigInteger[] division = value.divideAndRemainder(RADIX);
+      encoded.append(BASE62[division[1].intValue()]);
+      value = division[0];
+    } while (value.signum() != 0);
+    encoded.reverse();
+    while (encoded.length() < SHA_256_BASE62_LENGTH) {
+      encoded.insert(0, '0');
+    }
+    return "rijn_" + encoded;
+  }
+}

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/AgentlessConfigurationSourceTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/AgentlessConfigurationSourceTest.java
@@ -162,6 +162,7 @@ class AgentlessConfigurationSourceTest {
         assertEquals("etag-b", response.etag);
         assertEquals(emptyConfig(), new String(response.body, UTF_8));
         assertNull(server.getLastRequest().getHeader("DD-API-KEY"));
+        assertNull(server.getLastRequest().getHeader("DD-API-KEY-FINGERPRINT"));
         assertEquals("etag-a", server.getLastRequest().getHeader("If-None-Match"));
         assertEquals("java", server.getLastRequest().getHeader("Datadog-Meta-Lang"));
         assertEquals("gzip", server.getLastRequest().getHeader("Accept-Encoding"));
@@ -182,6 +183,9 @@ class AgentlessConfigurationSourceTest {
     client.fetch(endpoint, config(), null);
 
     assertEquals("test-api-key", requests.get(0).header("DD-API-KEY"));
+    assertEquals(
+        "rijn_i8Jug5ocjALL7JZiV1a8HzXqkwDRKcE7hK9IouPQwio",
+        requests.get(0).header("DD-API-KEY-FINGERPRINT"));
   }
 
   @Test
@@ -198,6 +202,7 @@ class AgentlessConfigurationSourceTest {
     client.fetch(endpoint, config, null);
 
     assertNull(requests.get(0).header("DD-API-KEY"));
+    assertNull(requests.get(0).header("DD-API-KEY-FINGERPRINT"));
   }
 
   @Test
@@ -210,6 +215,7 @@ class AgentlessConfigurationSourceTest {
     client.fetch(endpoint, config(), null);
 
     assertNull(requests.get(0).header("DD-API-KEY"));
+    assertNull(requests.get(0).header("DD-API-KEY-FINGERPRINT"));
   }
 
   @Test

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/ApiKeyFingerprintTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/ApiKeyFingerprintTest.java
@@ -1,0 +1,22 @@
+package com.datadog.featureflag;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class ApiKeyFingerprintTest {
+  @ParameterizedTest
+  @CsvSource(
+      delimiter = '|',
+      value = {
+        "''|rijn_RZwTDmWjELXeEmMEb0eIIegKayGGUPNsuJweEPhlXi5",
+        "padding-171|rijn_053ybBRXypQt9AC6UIlqH1YCFYSV1rQl8HCDIcBZs3D",
+        "!@#$%^𐍈한€हИ£|rijn_eFLHeyLxwaiNs2hY16pjkjNjVSHWRgf2rlveKc8YA1K",
+        "secret|rijn_amLaG4Pd6h6t9VtJna81k744P1DYxGHzIJ6ECO3OOMj"
+      })
+  void matchesCanonicalCliffordV1Vectors(final String apiKey, final String expected) {
+    assertEquals(expected, ApiKeyFingerprint.create(apiKey));
+    assertEquals(48, ApiKeyFingerprint.create(apiKey).length());
+  }
+}


### PR DESCRIPTION
## Motivation

Agentless Feature Flags configuration requests need a stable, non-secret API-key identifier so the backend can correlate authentication without logging the key itself.

## Changes

- Add the canonical SHA-256-to-base62 `rijn_` fingerprint helper.
- Attach `DD-API-KEY-FINGERPRINT` only to authenticated requests to the managed UFC endpoint.
- Cover the shared cross-language golden vectors and custom-endpoint exclusion.

## Decisions

- Custom endpoints receive neither the API key nor its fingerprint.
- The raw API key remains the authentication credential; the fingerprint is supplemental metadata.

## Validation

- `ApiKeyFingerprintTest` covers the canonical vectors.
- `AgentlessConfigurationSourceTest` covers managed, custom, unexpected, and HTTP endpoints.
