### PR TITLE
Reuse source sets for forked test tasks

### DIFF
--- a/dd-java-agent/instrumentation/akka/akka-actor-2.5/build.gradle
+++ b/dd-java-agent/instrumentation/akka/akka-actor-2.5/build.gradle
@@ -17,15 +17,12 @@ muzzle {
 }
 
 addTestSuite('akka23Test')
-addTestSuiteExtendingForDir('akka23ForkedTest', 'akka23Test', 'akka23Test')
+addForkedTestTask('akka23Test')
 addTestSuiteForDir('latestDepTest', 'test')
 addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'akka23Test')
 
 tasks.named("compileAkka23TestGroovy", GroovyCompile) {
   classpath += files(sourceSets.akka23Test.scala.classesDirectory)
-}
-tasks.named("compileAkka23ForkedTestGroovy", GroovyCompile) {
-  classpath += files(sourceSets.akka23ForkedTest.scala.classesDirectory)
 }
 tasks.named("compileLatestDepForkedTestGroovy", GroovyCompile) {
   classpath += files(sourceSets.latestDepForkedTest.scala.classesDirectory)

--- a/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.0/build.gradle
+++ b/dd-java-agent/instrumentation/akka/akka-http/akka-http-10.0/build.gradle
@@ -8,7 +8,7 @@ plugins {
 // we put the test classes in the baseTest test set so that the scala
 // version is not inherited
 addTestSuite('baseTest')
-addTestSuiteExtendingForDir('baseForkedTest', 'baseTest', 'baseTest')
+addForkedTestTask('baseTest')
 addTestSuiteForDir('version101Test', 'baseTest')
 addTestSuiteExtendingForDir('version101ForkedTest', 'version101Test', 'baseTest')
 addTestSuiteForDir('version102Scala213Test', 'latestDepTest')
@@ -175,10 +175,6 @@ dependencies {
 }
 
 tasks.named("compileBaseTestGroovy", GroovyCompile) {
-  classpath += files(tasks.named('compileBaseTestScala').map { it.destinationDirectory })
-}
-
-tasks.named("compileBaseForkedTestGroovy", GroovyCompile) {
   classpath += files(tasks.named('compileBaseTestScala').map { it.destinationDirectory })
 }
 

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sdk-1.11/build.gradle
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sdk-1.11/build.gradle
@@ -26,13 +26,13 @@ muzzle {
 // We test older version in separate test set to test newer version and latest deps in the 'default'
 // test dir. Otherwise we get strange warnings in Idea.
 addTestSuite('test_before_1_11_106')
-addTestSuiteExtendingForDir('test_before_1_11_106ForkedTest', 'test_before_1_11_106', 'test_before_1_11_106')
+addForkedTestTask('test_before_1_11_106')
 
 addTestSuiteForDir('latestDepTest', 'test')
 addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
 
 addTestSuite('dsmTest')
-addTestSuiteExtendingForDir('dsmForkedTest', 'dsmTest', 'dsmTest')
+addForkedTestTask('dsmTest')
 addTestSuiteForDir('latestDsmTest', 'dsmTest')
 addTestSuiteExtendingForDir('latestDsmForkedTest', 'latestDsmTest', 'dsmTest')
 

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sdk-2.2/build.gradle
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sdk-2.2/build.gradle
@@ -17,12 +17,12 @@ addTestSuiteForDir('latestDepTest', 'test')
 // addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'test')
 
 addTestSuite('dsmTest')
-addTestSuiteExtendingForDir('dsmForkedTest', 'dsmTest', 'dsmTest')
+addForkedTestTask('dsmTest')
 addTestSuiteForDir('latestDsmTest', 'dsmTest')
 addTestSuiteExtendingForDir('latestDsmForkedTest', 'latestDsmTest', 'dsmTest')
 
 addTestSuite('payloadTaggingTest')
-addTestSuiteExtendingForDir('payloadTaggingForkedTest', 'payloadTaggingTest', 'payloadTaggingTest')
+addForkedTestTask('payloadTaggingTest')
 addTestSuiteForDir('latestPayloadTaggingTest', 'payloadTaggingTest')
 addTestSuiteExtendingForDir('latestPayloadTaggingForkedTest', 'latestPayloadTaggingTest', 'payloadTaggingTest')
 

--- a/dd-java-agent/instrumentation/build.gradle
+++ b/dd-java-agent/instrumentation/build.gradle
@@ -85,7 +85,7 @@ subprojects { Project subProj ->
       }
 
       subProj.tasks.withType(Test).configureEach { subTask ->
-        if (subTask.name in ['latestDepTest', 'latestDepForkedTest']) {
+        if (subTask.name in ['latestDepTest', 'latestDepForkedTest', 'latestDepTestForkedTest']) {
           subTask.jvmArgs '-Dtest.dd.latestDepTest=true'
         }
       }

--- a/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-scheduling-3.1/build.gradle
@@ -19,23 +19,23 @@ muzzle {
 }
 
 addTestSuite('latestDepTest')
-addTestSuiteExtendingForDir('latestDepForkedTest','latestDepTest', 'latestDepTest')
+addForkedTestTask('latestDepTest')
 addTestSuiteForDir('spring6Test', 'test')
 addTestSuiteForDir('latestSpring5Test', 'test')
 
-["compileSpring6TestJava", "compileLatestDepTestJava", "compileLatestDepForkedTestJava"].each { name ->
+["compileSpring6TestJava", "compileLatestDepTestJava"].each { name ->
   tasks.named(name, JavaCompile) {
     configureCompiler(it, 17, JavaVersion.VERSION_1_8)
   }
 }
 
-["compileSpring6TestGroovy", "compileLatestDepTestGroovy", "compileLatestDepForkedTestGroovy"].each { name ->
+["compileSpring6TestGroovy", "compileLatestDepTestGroovy"].each { name ->
   tasks.named(name, GroovyCompile) {
     configureCompiler(it, 17)
   }
 }
 
-["spring6Test", "latestDepTest", "latestDepForkedTest"].each { name ->
+["spring6Test", "latestDepTest", "latestDepTestForkedTest"].each { name ->
   tasks.named(name, Test) {
     javaLauncher = getJavaLauncherFor(17)
     jvmArgs("--add-opens", "java.base/java.util=ALL-UNNAMED")
@@ -73,7 +73,7 @@ dependencies {
   latestDepTestImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '3.+'
 }
 
-tasks.named("latestDepForkedTest", Test) {
+tasks.named("latestDepTestForkedTest", Test) {
   testJvmConstraints {
     minJavaVersion = JavaVersion.VERSION_17
   }

--- a/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-webmvc/spring-webmvc-3.1/build.gradle
@@ -36,7 +36,7 @@ muzzle {
 }
 
 addTestSuite("latestDepTest")
-addTestSuiteExtendingForDir("latestDepForkedTest", "latestDepTest", "latestDepTest")
+addForkedTestTask("latestDepTest")
 
 dependencies {
   compileOnly group: 'org.springframework', name: 'spring-webmvc', version: '3.1.0.RELEASE'

--- a/dd-java-agent/instrumentation/tomcat/tomcat-5.5/build.gradle
+++ b/dd-java-agent/instrumentation/tomcat/tomcat-5.5/build.gradle
@@ -50,7 +50,7 @@ muzzle {
 }
 
 addTestSuite('latestDepTest')
-addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'latestDepTest')
+addForkedTestTask('latestDepTest')
 
 addTestSuite("tomcat9Test")
 
@@ -72,10 +72,8 @@ configurations.configureEach {
   }
 }
 
-["compileLatestDepTestGroovy", "compileLatestDepForkedTestGroovy"].each { name ->
-  tasks.named(name, GroovyCompile) {
-    configureCompiler(it, 17)
-  }
+tasks.named("compileLatestDepTestGroovy", GroovyCompile) {
+  configureCompiler(it, 17)
 }
 
 dependencies {
@@ -173,7 +171,7 @@ tasks.named("latestDepTest", Test) {
   }
 }
 
-tasks.named("latestDepForkedTest", Test) {
+tasks.named("latestDepTestForkedTest", Test) {
   testJvmConstraints {
     minJavaVersion = JavaVersion.VERSION_17
   }

--- a/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/build.gradle
+++ b/dd-java-agent/instrumentation/vertx/vertx-web/vertx-web-4.0/build.gradle
@@ -21,7 +21,7 @@ muzzle {
 }
 
 addTestSuiteForDir('latestDepTest', 'latestDepTest')
-addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'latestDepTest')
+addForkedTestTask('latestDepTest')
 
 configurations {
   testArtifacts
@@ -56,15 +56,11 @@ dependencies {
   latestDepTestImplementation group: 'io.vertx', name: 'vertx-web-client', version: '4.+'
 }
 
-["compileLatestDepTestJava", "compileLatestDepForkedTestJava"].each { name ->
-  tasks.named(name, JavaCompile) {
-    configureCompiler(it, 11)
-  }
+tasks.named("compileLatestDepTestJava", JavaCompile) {
+  configureCompiler(it, 11)
 }
-["compileLatestDepForkedTestGroovy", "compileLatestDepTestGroovy"].each {
-  tasks.named(it, GroovyCompile) {
-    configureCompiler(it, 11)
-  }
+tasks.named("compileLatestDepTestGroovy", GroovyCompile) {
+  configureCompiler(it, 11)
 }
 
 tasks.named("latestDepTest", Test) {
@@ -74,10 +70,9 @@ tasks.named("latestDepTest", Test) {
   }
 }
 
-tasks.named("latestDepForkedTest", Test) {
+tasks.named("latestDepTestForkedTest", Test) {
   testJvmConstraints {
     minJavaVersion = JavaVersion.VERSION_11
     maxJavaVersion = JavaVersion.VERSION_25
   }
 }
-

--- a/docs/how_to_work_with_gradle.md
+++ b/docs/how_to_work_with_gradle.md
@@ -613,11 +613,12 @@ Each test suite (like `test`, `integrationTest`) gets its own set of configurati
 
 In this project, the `gradle/test-suites.gradle` script provides helpers to create test suites with proper configuration inheritance:
 
-| Helper                                                 | Description                                                                    |
-|--------------------------------------------------------|--------------------------------------------------------------------------------|
-| `addTestSuite('name')`                                 | Creates `name` test suite extending `test`, sources in `src/name/`             |
-| `addTestSuiteForDir('name', 'dir')`                    | Creates `name` test suite extending `test`, sources in `src/dir/`              |
-| `addTestSuiteExtendingForDir('name', 'parent', 'dir')` | Creates `name` test suite extending `parent` test suite, sources in `src/dir/` |
+| Helper                                                 | Description                                                                           |
+|--------------------------------------------------------|---------------------------------------------------------------------------------------|
+| `addTestSuite('name')`                                 | Creates `name` test suite extending `test`, sources in `src/name/`                    |
+| `addTestSuiteForDir('name', 'dir')`                    | Creates `name` test suite extending `test`, sources in `src/dir/`                    |
+| `addTestSuiteExtendingForDir('name', 'parent', 'dir')` | Creates `name` test suite extending `parent` test suite, sources in `src/dir/`        |
+| `addForkedTestTask('name')`                            | Creates `nameForkedTest`, reusing the `name` source set output and runtime classpath |
 
 For example:
 
@@ -625,8 +626,8 @@ For example:
 // Creates 'latestDepTest' suite extending 'test', sources in src/latestDepTest/
 addTestSuite('latestDepTest')
 
-// Creates 'latestDepForkedTest' suite extending 'latestDepTest', sources in src/latestDepTest/
-addTestSuiteExtendingForDir('latestDepForkedTest', 'latestDepTest', 'latestDepTest')
+// Creates 'latestDepTestForkedTest' using the compiled latestDepTest classes and dependencies
+addForkedTestTask('latestDepTest')
 ```
 
 ```mermaid
@@ -643,14 +644,13 @@ graph LR
         latestDepTestImplementation
     end
 
-    subgraph latestDepForkedTest
-        latestDepForkedTestImplementation
-    end
-
-    implementation --> testImplementation --> latestDepTestImplementation --> latestDepForkedTestImplementation
+    implementation --> testImplementation --> latestDepTestImplementation
 ```
 
 *Similar inheritance applies to `compileOnly`, `runtimeOnly`, and `annotationProcessor` configurations.*
+
+Use a separate suite only when forked tests need different sources or dependencies. When they run
+the same source set and classpath, prefer `addForkedTestTask` to avoid compiling those sources twice.
 
 ### Creating Custom Configurations
 


### PR DESCRIPTION
# What Does This Do

Replaces ten duplicate forked-test source sets across eight instrumentation modules with `addForkedTestTask(...)`.

The affected tasks now reuse their parent source set's compiled output and runtime classpath instead of recompiling identical sources. This also removes redundant forked compile-task configuration, preserves the latest-dependency test flag for the new task name, and updates the Gradle guide.

The migrated modules cover Akka actor and HTTP, AWS SDK 1.x and 2.x, Spring scheduling and Web MVC, Tomcat, and Vert.x Web.

# Motivation

[#12147](https://github.com/DataDog/dd-trace-java/pull/12147) introduces `addForkedTestTask` for running a custom source set's `*ForkedTest` classes in isolated JVMs.

These modules currently create a second source set with the same sources and dependencies solely to obtain a forked runner. Reusing the original source set removes duplicate configurations and compilation while preserving test isolation and CI task selection.

This PR is stacked on #12147.

# Additional Notes

Task names now follow the helper's `<sourceSetName>ForkedTest` convention; for example, `latestDepForkedTest` becomes `latestDepTestForkedTest` because it runs the `latestDepTest` source set.

Validation:

- All ten migrated forked tasks ran with fresh outputs: 1,000 test cases, 0 failures, 275 conditional skips.
- The four latest-dependency tasks ran after applying their required test flag: 643 test cases, 0 failures, 153 conditional skips.
- `./gradlew spotlessGroovyGradleCheck` passed.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]
