### PR TITLE
Enable Pekko HTTP forked tests

### DIFF
--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/build.gradle
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/build.gradle
@@ -45,6 +45,10 @@ sourceSets {
   latestPekko10Test.scala.srcDir sourceSets.baseTest.scala
 }
 
+['baseTest', 'latestPekko10Test', 'latestDepTest'].each {
+  addForkedTestTask(it)
+}
+
 dependencies {
   compileOnly libs.scala212
   compileOnly group: 'org.apache.pekko', name: 'pekko-http-core_2.12', version: '1.0.0'

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/build.gradle
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/build.gradle
@@ -8,10 +8,16 @@ plugins {
 // we put the test classes in the baseTest test set so that the scala
 // version is not inherited
 addTestSuite('baseTest')
+addForkedTestTask('baseTest')
+
 addTestSuite('latestDepTest')
+addForkedTestTask('latestDepTest')
+
 addTestSuiteForDir('latestPekko10Test', 'latestDepTest')
+addForkedTestTask('latestPekko10Test')
+
 addTestSuite('iastTest')
-addTestSuiteForDir 'latestDepIastTest', 'iastTest'
+addTestSuiteForDir('latestDepIastTest', 'iastTest')
 
 muzzle {
   pass {
@@ -43,10 +49,6 @@ sourceSets {
   latestDepTest.scala.srcDir sourceSets.baseTest.scala
   latestPekko10Test.groovy.srcDir sourceSets.baseTest.groovy
   latestPekko10Test.scala.srcDir sourceSets.baseTest.scala
-}
-
-['baseTest', 'latestPekko10Test', 'latestDepTest'].each {
-  addForkedTestTask(it)
 }
 
 dependencies {

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/baseTest/groovy/PekkoHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/baseTest/groovy/PekkoHttpClientInstrumentationTest.groovy
@@ -10,6 +10,7 @@ import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.pekkohttp.PekkoHttpClientDecorator
+import datadog.trace.instrumentation.pekkohttp.PekkoHttpSingleRequestInstrumentation.SingleRequestContextPropagationAdvice
 import scala.compat.java8.FutureConverters
 import scala.concurrent.Future
 import spock.lang.Shared
@@ -61,6 +62,14 @@ abstract class PekkoHttpClientInstrumentationTest extends HttpClientTest {
     return false
   }
 
+  def "does not inject context into a null request"() {
+    when:
+    SingleRequestContextPropagationAdvice.methodEnter(null)
+
+    then:
+    noExceptionThrown()
+  }
+
   def "singleRequest exception trace"() {
     when:
     // Passing null causes NPE in singleRequest
@@ -73,14 +82,14 @@ abstract class PekkoHttpClientInstrumentationTest extends HttpClientTest {
         span {
           parent()
           operationName operation()
-          resourceName "pekko-http.client.request"
+          resourceName operation() // resource name is not set so defaults to operationName
           spanType DDSpanTypes.HTTP_CLIENT
           errored true
           tags {
             "$Tags.COMPONENT" "pekko-http-client"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             errorTags(exception)
-            defaultTags()
+            defaultTags(false, false)
           }
         }
       }

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/baseTest/groovy/PekkoHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/baseTest/groovy/PekkoHttpClientInstrumentationTest.groovy
@@ -10,7 +10,6 @@ import datadog.trace.agent.test.naming.TestingGenericHttpNamingConventions
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.bootstrap.instrumentation.api.Tags
 import datadog.trace.instrumentation.pekkohttp.PekkoHttpClientDecorator
-import datadog.trace.instrumentation.pekkohttp.PekkoHttpSingleRequestInstrumentation.SingleRequestContextPropagationAdvice
 import scala.compat.java8.FutureConverters
 import scala.concurrent.Future
 import spock.lang.Shared
@@ -60,14 +59,6 @@ abstract class PekkoHttpClientInstrumentationTest extends HttpClientTest {
   boolean testRemoteConnection() {
     // Not sure how to properly set timeouts...
     return false
-  }
-
-  def "does not inject context into a null request"() {
-    when:
-    SingleRequestContextPropagationAdvice.methodEnter(null)
-
-    then:
-    noExceptionThrown()
   }
 
   def "singleRequest exception trace"() {

--- a/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/PekkoHttpSingleRequestInstrumentation.java
+++ b/dd-java-agent/instrumentation/pekko/pekko-http-1.0/src/main/java/datadog/trace/instrumentation/pekkohttp/PekkoHttpSingleRequestInstrumentation.java
@@ -115,6 +115,9 @@ public final class PekkoHttpSingleRequestInstrumentation extends InstrumenterMod
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static void methodEnter(
         @Advice.Argument(value = 0, readOnly = false) HttpRequest request) {
+      if (request == null) {
+        return;
+      }
       final PekkoHttpHeaders headers = new PekkoHttpHeaders(request);
       DECORATE.injectContext(currentContext(), request, headers);
       request = headers.getRequest();


### PR DESCRIPTION
# What Does This Do

Enables the six existing Pekko HTTP `*ForkedTest` classes across the base, latest Pekko 1.0.x, and latest dependency test suites.

It also fixes the failures exposed by that coverage:

- skips context injection when `singleRequest` receives a null request;
- verifies the null-carrier path directly; and
- updates the exception-span assertions for schema-specific operation names and absent peer metadata.

# Motivation

Pekko's tests live in custom source sets, so the default `forkedTest` task used the empty `test` source set. The six forked classes were compiled but never executed.

Enabling them exposed a suppressed Data Streams injection failure when the existing exception test calls `singleRequest(null)`:

```text
java.lang.NullPointerException: Cannot invoke "HttpRequest.addHeader(...)" because "this.request" is null
    at PekkoHttpClientHelpers$PekkoHttpHeaders.set(...)
    at DataStreamsPropagator.injectPathwayContext(...)
```

The context-propagation advice now returns before injection when there is no carrier. Normal requests are unchanged.

# Additional Notes

This PR is stacked on #12308, which is stacked on #12147.

Validation:

```shell
./gradlew :dd-java-agent:instrumentation:pekko:pekko-http-1.0:baseTestForkedTest :dd-java-agent:instrumentation:pekko:pekko-http-1.0:latestPekko10TestForkedTest :dd-java-agent:instrumentation:pekko:pekko-http-1.0:latestDepTestForkedTest --rerun-tasks
./gradlew :dd-java-agent:instrumentation:pekko:pekko-http-1.0:spotlessCheck
```

The forked-test matrix ran 894 cases across 18 isolated class executions: 0 failures, 0 errors, and 402 conditionally skipped cases.

`muzzle` could not complete locally because Maven Central range metadata resolution returned no versions for the existing `pekko-http_2.12:[1.0.0,)` range after retries. This PR does not change the muzzle configuration.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
