### PR TITLE
Keep JDK Unix socket timeouts from stopping trace delivery

### DIFF
--- a/dd-trace-core/build.gradle
+++ b/dd-trace-core/build.gradle
@@ -116,6 +116,8 @@ dependencies {
   testImplementation group: 'commons-codec', name: 'commons-codec', version: '1.3'
   testImplementation group: 'com.amazonaws', name: 'aws-lambda-java-events', version:'3.11.0'
   testImplementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.14.0'
+  testImplementation libs.jnr.unixsocket
+  testImplementation group: 'com.squareup.okhttp3', name: 'mockwebserver', version: libs.versions.okhttp.legacy.get()
   testImplementation libs.testcontainers
   testImplementation project(':utils:test-junit-utils')
   testImplementation project(':utils:test-junit-converter-utils')

--- a/dd-trace-core/src/test/java/datadog/common/socket/UnixDomainServerSocketFactory.java
+++ b/dd-trace-core/src/test/java/datadog/common/socket/UnixDomainServerSocketFactory.java
@@ -1,0 +1,109 @@
+package datadog.common.socket;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.channels.ClosedChannelException;
+import javax.net.ServerSocketFactory;
+import jnr.unixsocket.UnixServerSocketChannel;
+import jnr.unixsocket.UnixSocketAddress;
+import jnr.unixsocket.UnixSocketChannel;
+
+/**
+ * Adapts a JNR Unix-domain server channel to APIs such as MockWebServer that require a {@link
+ * ServerSocket}. Adapted from OkHttp's <a
+ * href="https://github.com/square/okhttp/blob/master/samples/unixdomainsockets/src/main/java/okhttp3/unixdomainsockets/UnixDomainServerSocketFactory.java">Unix-domain
+ * socket sample</a>.
+ */
+public final class UnixDomainServerSocketFactory extends ServerSocketFactory {
+  private final File path;
+
+  public UnixDomainServerSocketFactory(File path) {
+    this.path = path;
+  }
+
+  @Override
+  public ServerSocket createServerSocket() throws IOException {
+    return new UnixDomainServerSocket();
+  }
+
+  @Override
+  public ServerSocket createServerSocket(int port) throws IOException {
+    return createServerSocket();
+  }
+
+  @Override
+  public ServerSocket createServerSocket(int port, int backlog) throws IOException {
+    return createServerSocket();
+  }
+
+  @Override
+  public ServerSocket createServerSocket(int port, int backlog, InetAddress inetAddress)
+      throws IOException {
+    return createServerSocket();
+  }
+
+  private final class UnixDomainServerSocket extends ServerSocket {
+    private UnixServerSocketChannel serverSocketChannel;
+    private InetSocketAddress endpoint;
+
+    private UnixDomainServerSocket() throws IOException {}
+
+    @Override
+    public void bind(SocketAddress endpoint, int backlog) throws IOException {
+      this.endpoint = (InetSocketAddress) endpoint;
+      UnixServerSocketChannel channel = UnixServerSocketChannel.open();
+      boolean bound = false;
+      try {
+        channel.configureBlocking(true);
+        channel.socket().bind(new UnixSocketAddress(path));
+        serverSocketChannel = channel;
+        bound = true;
+      } finally {
+        if (!bound) {
+          channel.close();
+        }
+      }
+    }
+
+    @Override
+    public void setReuseAddress(boolean on) {
+      // MockWebServer configures this TCP option before binding. It has no UDS equivalent.
+    }
+
+    @Override
+    public int getLocalPort() {
+      return 1; // MockWebServer requires a port even though a UDS has none.
+    }
+
+    @Override
+    public SocketAddress getLocalSocketAddress() {
+      return endpoint;
+    }
+
+    @Override
+    public Socket accept() throws IOException {
+      try {
+        UnixSocketChannel channel = serverSocketChannel.accept();
+        return new TunnelingUnixSocket(path, channel, endpoint);
+      } catch (ClosedChannelException e) {
+        SocketException socketException = new SocketException("Socket is closed");
+        socketException.initCause(e);
+        throw socketException;
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+      super.close();
+      if (serverSocketChannel != null) {
+        serverSocketChannel.close();
+      }
+    }
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/common/writer/DDAgentWriterCombinedTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/writer/DDAgentWriterCombinedTest.java
@@ -2,9 +2,18 @@ package datadog.trace.common.writer;
 
 import static datadog.trace.api.ProtocolVersion.V0_5;
 import static datadog.trace.api.config.GeneralConfig.EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.JDK_SOCKET_ENABLED;
 import static datadog.trace.common.writer.ddagent.Prioritization.ENSURE_TRACE;
+import static okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AT_END;
+import static okhttp3.mockwebserver.SocketPolicy.NO_RESPONSE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.junit.jupiter.api.condition.JRE.JAVA_16;
+import static org.junit.jupiter.api.condition.OS.LINUX;
+import static org.junit.jupiter.api.condition.OS.MAC;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -18,6 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import datadog.common.socket.UnixDomainServerSocketFactory;
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.communication.http.OkHttpUtils;
 import datadog.communication.serialization.FlushingBuffer;
@@ -39,6 +49,8 @@ import datadog.trace.core.monitor.TracerHealthMetrics;
 import datadog.trace.test.junit.utils.config.WithConfig;
 import datadog.trace.test.util.Flaky;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -46,11 +58,17 @@ import java.util.concurrent.Phaser;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.mockito.Mockito;
 import org.tabletest.junit.TableTest;
 
@@ -336,12 +354,11 @@ class DDAgentWriterCombinedTest extends DDCoreJavaSpecification {
     List<DDSpan> minimalTrace = createMinimalTrace();
 
     // DQH -- need to set-up a dummy agent for the final send callback to work
-    JavaTestHttpServer agent =
+    try (JavaTestHttpServer agent =
         JavaTestHttpServer.httpServer(
             server ->
                 server.handlers(
-                    h -> h.put(agentVersion, api -> api.getResponse().status(200).send())));
-    try {
+                    h -> h.put(agentVersion, api -> api.getResponse().status(200).send())))) {
       HttpUrl agentUrl = HttpUrl.get(agent.getAddress());
       okhttp3.OkHttpClient client = OkHttpUtils.buildHttpClient(agentUrl, 1000);
       DDAgentFeaturesDiscovery discovery =
@@ -380,8 +397,6 @@ class DDAgentWriterCombinedTest extends DDCoreJavaSpecification {
       writer.close();
 
       verify(healthMetrics, times(1)).onShutdown(true);
-    } finally {
-      agent.close();
     }
   }
 
@@ -397,7 +412,9 @@ class DDAgentWriterCombinedTest extends DDCoreJavaSpecification {
 
     // DQH -- need to set-up a dummy agent for the final send callback to work
     final boolean[] first = {true};
-    JavaTestHttpServer agent =
+    // DQH - DDApi sniffs for end point existence, so respond with 200 the
+    // first time
+    try (JavaTestHttpServer agent =
         JavaTestHttpServer.httpServer(
             server ->
                 server.handlers(
@@ -413,8 +430,7 @@ class DDAgentWriterCombinedTest extends DDCoreJavaSpecification {
                               } else {
                                 api.getResponse().status(500).send();
                               }
-                            })));
-    try {
+                            })))) {
       HttpUrl agentUrl = HttpUrl.get(agent.getAddress());
       okhttp3.OkHttpClient client = OkHttpUtils.buildHttpClient(agentUrl, 1000);
       DDAgentFeaturesDiscovery discovery =
@@ -453,8 +469,82 @@ class DDAgentWriterCombinedTest extends DDCoreJavaSpecification {
       writer.close();
 
       verify(healthMetrics, times(1)).onShutdown(true);
+    }
+  }
+
+  @Test
+  @WithConfig(key = JDK_SOCKET_ENABLED, value = "true")
+  @EnabledForJreRange(min = JAVA_16)
+  @EnabledOnOs({LINUX, MAC})
+  void unixSocketTimeoutKeepsWorkerAliveAndReconnects() throws Exception {
+    assertTrue(Config.get().isJdkSocketEnabled());
+
+    Path socketPath = Files.createTempFile("dd-trace-agent-", ".sock");
+    Files.delete(socketPath);
+
+    HealthMetrics healthMetrics = mock(HealthMetrics.class);
+    AtomicReference<Thread> failedSendThread = new AtomicReference<>();
+    AtomicReference<Thread> successfulSendThread = new AtomicReference<>();
+    doAnswer(
+            invocation -> {
+              failedSendThread.set(Thread.currentThread());
+              return null;
+            })
+        .when(healthMetrics)
+        .onFailedSend(anyInt(), anyInt(), any());
+    doAnswer(
+            invocation -> {
+              successfulSendThread.set(Thread.currentThread());
+              return null;
+            })
+        .when(healthMetrics)
+        .onSend(anyInt(), anyInt(), any());
+
+    DDAgentFeaturesDiscovery discovery = mock(DDAgentFeaturesDiscovery.class);
+    when(discovery.getTraceEndpoint()).thenReturn("v0.4/traces");
+
+    try (MockWebServer server = new MockWebServer();
+        DDAgentWriter writer =
+            DDAgentWriter.builder()
+                .featureDiscovery(discovery)
+                .unixDomainSocket(socketPath.toString())
+                .timeoutMillis(100)
+                .monitoring(monitoring)
+                .healthMetrics(healthMetrics)
+                .flushIntervalMilliseconds(-1)
+                .flushTimeout(5, TimeUnit.SECONDS)
+                .build()) {
+      server.setServerSocketFactory(new UnixDomainServerSocketFactory(socketPath.toFile()));
+      // Read the first request fully, then withhold the response to trigger a header-read timeout.
+      server.enqueue(new MockResponse().setSocketPolicy(NO_RESPONSE));
+      server.enqueue(new MockResponse().setResponseCode(200).setSocketPolicy(DISCONNECT_AT_END));
+      server.start();
+
+      writer.start();
+
+      writer.write(createMinimalTrace());
+      assertTrue(writer.flush());
+
+      RecordedRequest failedRequest = server.takeRequest(5, TimeUnit.SECONDS);
+      assertNotNull(failedRequest);
+      assertEquals(0, failedRequest.getSequenceNumber());
+      assertEquals(1, server.getRequestCount());
+      verify(healthMetrics, times(1)).onFailedSend(anyInt(), anyInt(), any());
+
+      writer.write(createMinimalTrace());
+      assertTrue(writer.flush());
+
+      RecordedRequest successfulRequest = server.takeRequest(5, TimeUnit.SECONDS);
+      assertNotNull(successfulRequest);
+      // Sequence numbers are per connection; zero again proves that this used a fresh socket.
+      assertEquals(0, successfulRequest.getSequenceNumber());
+      assertEquals(2, server.getRequestCount());
+      verify(healthMetrics, times(1)).onSend(anyInt(), anyInt(), any());
+      assertSame(failedSendThread.get(), successfulSendThread.get());
+    } catch (IOException | UnsupportedOperationException e) {
+      assumeTrue(false, "Unix-domain sockets are not supported: " + e.getMessage());
     } finally {
-      agent.close();
+      Files.deleteIfExists(socketPath);
     }
   }
 

--- a/utils/socket-utils/build.gradle.kts
+++ b/utils/socket-utils/build.gradle.kts
@@ -12,6 +12,7 @@ extensions.getByName("tracerJava").withGroovyBuilder {
 }
 
 dependencies {
+  add("main_java17CompileOnly", project(":components:annotations"))
   implementation(project(":components:environment"))
   implementation(project(":utils:logging-utils"))
   implementation(libs.slf4j)

--- a/utils/socket-utils/src/main/java/datadog/common/socket/UnixDomainSocketFactory.java
+++ b/utils/socket-utils/src/main/java/datadog/common/socket/UnixDomainSocketFactory.java
@@ -45,7 +45,7 @@ public final class UnixDomainSocketFactory extends SocketFactory {
       if (this.useJdkUdsSocket) {
         try {
           return new TunnelingJdkSocket(this.path.toPath());
-        } catch (Throwable ignore) {
+        } catch (IOException | UnsupportedOperationException ignore) {
           // fall back to jnr-unixsocket library
         }
       }

--- a/utils/socket-utils/src/main/java17/datadog/common/socket/TunnelingJdkSocket.java
+++ b/utils/socket-utils/src/main/java17/datadog/common/socket/TunnelingJdkSocket.java
@@ -9,6 +9,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
+import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.CancelledKeyException;
@@ -28,10 +29,10 @@ import java.util.Set;
  * 16.
  */
 final class TunnelingJdkSocket extends Socket {
-  private final SocketAddress unixSocketAddress;
-  private InetSocketAddress inetSocketAddress;
+  private final UnixDomainSocketAddress unixSocketAddress;
+  private final SocketChannel unixSocketChannel;
 
-  private volatile SocketChannel unixSocketChannel;
+  private volatile InetSocketAddress inetSocketAddress;
   @VisibleForTesting volatile Selector selector;
 
   private volatile int timeout;
@@ -44,18 +45,14 @@ final class TunnelingJdkSocket extends Socket {
   private int sendBufferSize = -1;
   private int receiveBufferSize = -1;
 
-  TunnelingJdkSocket(final Path path) {
+  TunnelingJdkSocket(final Path path) throws IOException, UnsupportedOperationException {
     this.unixSocketAddress = UnixDomainSocketAddress.of(path);
-  }
-
-  TunnelingJdkSocket(final Path path, final InetSocketAddress address) {
-    this(path);
-    inetSocketAddress = address;
+    this.unixSocketChannel = SocketChannel.open(StandardProtocolFamily.UNIX);
   }
 
   @Override
   public boolean isConnected() {
-    return null != unixSocketChannel;
+    return inetSocketAddress != null;
   }
 
   @Override
@@ -74,7 +71,7 @@ final class TunnelingJdkSocket extends Socket {
   }
 
   @Override
-  public synchronized void setSoTimeout(int timeout) throws SocketException {
+  public void setSoTimeout(int timeout) throws SocketException {
     if (isClosed()) {
       throw new SocketException("Socket is closed");
     }
@@ -85,7 +82,7 @@ final class TunnelingJdkSocket extends Socket {
   }
 
   @Override
-  public synchronized int getSoTimeout() throws SocketException {
+  public int getSoTimeout() throws SocketException {
     if (isClosed()) {
       throw new SocketException("Socket is closed");
     }
@@ -93,26 +90,15 @@ final class TunnelingJdkSocket extends Socket {
   }
 
   @Override
-  public synchronized void connect(final SocketAddress endpoint) throws IOException {
-    if (endpoint == null) {
-      throw new IllegalArgumentException("Endpoint cannot be null");
-    }
-    if (isClosed()) {
-      throw new SocketException("Socket is closed");
-    }
-    if (isConnected()) {
-      throw new SocketException("Socket is already connected");
-    }
-    inetSocketAddress = (InetSocketAddress) endpoint;
-    unixSocketChannel = SocketChannel.open(unixSocketAddress);
+  public void connect(final SocketAddress endpoint) throws IOException {
+    connect(endpoint, 0);
   }
 
   // `timeout` is intentionally ignored here, like in the jnr-unixsocket implementation.
   // See:
   // https://github.com/jnr/jnr-unixsocket/blob/master/src/main/java/jnr/unixsocket/UnixSocket.java#L89-L97
   @Override
-  public synchronized void connect(final SocketAddress endpoint, final int timeout)
-      throws IOException {
+  public void connect(final SocketAddress endpoint, final int timeout) throws IOException {
     if (endpoint == null) {
       throw new IllegalArgumentException("Endpoint cannot be null");
     }
@@ -125,8 +111,14 @@ final class TunnelingJdkSocket extends Socket {
     if (isConnected()) {
       throw new SocketException("Socket is already connected");
     }
-    inetSocketAddress = (InetSocketAddress) endpoint;
-    unixSocketChannel = SocketChannel.open(unixSocketAddress);
+    InetSocketAddress inetSocketAddress = (InetSocketAddress) endpoint;
+    try {
+      unixSocketChannel.connect(unixSocketAddress);
+      this.inetSocketAddress = inetSocketAddress;
+    } catch (IOException e) {
+      close();
+      throw e;
+    }
   }
 
   @Override
@@ -203,96 +195,101 @@ final class TunnelingJdkSocket extends Socket {
   }
 
   @Override
-  public synchronized InputStream getInputStream() throws IOException {
-    if (isClosed()) {
-      throw new SocketException("Socket is closed");
-    }
-    if (!isConnected()) {
-      throw new SocketException("Socket is not connected");
-    }
-    if (isInputShutdown()) {
-      throw new SocketException("Socket input is shutdown");
-    }
-
-    Selector currentSelector = selector;
-    if (currentSelector == null) {
-      currentSelector = Selector.open();
-      try {
-        unixSocketChannel.configureBlocking(false);
-        unixSocketChannel.register(currentSelector, SelectionKey.OP_READ);
-        selector = currentSelector;
-      } catch (IOException | RuntimeException e) {
-        try {
-          currentSelector.close();
-        } catch (IOException closeException) {
-          e.addSuppressed(closeException);
-        }
-        throw e;
+  public InputStream getInputStream() throws IOException {
+    // Serialize validation and selector publication with close() so close cannot miss a selector
+    // that is still being initialized.
+    synchronized (this) {
+      if (isClosed()) {
+        throw new SocketException("Socket is closed");
       }
-    }
-
-    return new InputStream() {
-      private final ByteBuffer buffer = ByteBuffer.allocate(getStreamBufferSize());
-
-      @Override
-      public int read() throws IOException {
-        byte[] nextByte = new byte[1];
-        return (read(nextByte, 0, 1) == -1) ? -1 : (nextByte[0] & 0xFF);
+      if (!isConnected()) {
+        throw new SocketException("Socket is not connected");
+      }
+      if (isInputShutdown()) {
+        throw new SocketException("Socket input is shutdown");
       }
 
-      @Override
-      public int read(byte[] b, int off, int len) throws IOException {
-        if (isInputShutdown()) {
-          return -1;
-        }
-        buffer.clear();
-
-        Selector currentSelector = selector;
-        SocketChannel currentChannel = unixSocketChannel;
-        if (currentSelector == null || currentChannel == null) {
-          throw new SocketException("Socket is closed");
-        }
-
+      Selector currentSelector = selector;
+      if (currentSelector == null) {
+        currentSelector = Selector.open();
         try {
-          int readyChannels = currentSelector.select(timeout);
-          if (readyChannels == 0) {
-            if (isClosed() || !currentSelector.isOpen()) {
-              throw new SocketException("Socket is closed");
-            }
-            return 0;
+          unixSocketChannel.configureBlocking(false);
+          unixSocketChannel.register(currentSelector, SelectionKey.OP_READ);
+          selector = currentSelector;
+        } catch (IOException | RuntimeException e) {
+          try {
+            currentSelector.close();
+          } catch (IOException closeException) {
+            e.addSuppressed(closeException);
+          }
+          throw e;
+        }
+      }
+
+      return new InputStream() {
+        private final ByteBuffer buffer = ByteBuffer.allocate(getStreamBufferSize());
+
+        @Override
+        public int read() throws IOException {
+          byte[] nextByte = new byte[1];
+          return (read(nextByte, 0, 1) == -1) ? -1 : (nextByte[0] & 0xFF);
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+          if (isInputShutdown()) {
+            return -1;
+          }
+          buffer.clear();
+
+          Selector currentSelector = selector;
+          if (currentSelector == null) {
+            throw new SocketException("Socket is closed");
           }
 
-          Set<SelectionKey> selectedKeys = currentSelector.selectedKeys();
-          synchronized (selectedKeys) {
-            Iterator<SelectionKey> keyIterator = selectedKeys.iterator();
-            while (keyIterator.hasNext()) {
-              SelectionKey key = keyIterator.next();
-              keyIterator.remove();
-              if (key.isReadable()) {
-                int r = currentChannel.read(buffer);
-                if (r == -1) {
-                  return -1;
+          try {
+            int readyChannels = currentSelector.select(timeout);
+            if (readyChannels == 0) {
+              if (isClosed() || !currentSelector.isOpen()) {
+                throw new SocketException("Socket is closed");
+              }
+              return 0;
+            }
+
+            Set<SelectionKey> selectedKeys = currentSelector.selectedKeys();
+            // Multiple input streams share this selector, so serialize iteration and removal from
+            // its non-thread-safe selected-key set.
+            synchronized (selectedKeys) {
+              Iterator<SelectionKey> keyIterator = selectedKeys.iterator();
+              while (keyIterator.hasNext()) {
+                SelectionKey key = keyIterator.next();
+                keyIterator.remove();
+                if (key.isReadable()) {
+                  int r = unixSocketChannel.read(buffer);
+                  if (r == -1) {
+                    return -1;
+                  }
+                  buffer.flip();
+                  len = Math.min(r, len);
+                  buffer.get(b, off, len);
+                  return len;
                 }
-                buffer.flip();
-                len = Math.min(r, len);
-                buffer.get(b, off, len);
-                return len;
               }
             }
+            return 0;
+          } catch (ClosedSelectorException | CancelledKeyException e) {
+            SocketException socketException = new SocketException("Socket is closed");
+            socketException.initCause(e);
+            throw socketException;
           }
-          return 0;
-        } catch (ClosedSelectorException | CancelledKeyException e) {
-          SocketException socketException = new SocketException("Socket is closed");
-          socketException.initCause(e);
-          throw socketException;
         }
-      }
 
-      @Override
-      public void close() throws IOException {
-        TunnelingJdkSocket.this.close();
-      }
-    };
+        @Override
+        public void close() throws IOException {
+          TunnelingJdkSocket.this.close();
+        }
+      };
+    }
   }
 
   @Override
@@ -333,33 +330,39 @@ final class TunnelingJdkSocket extends Socket {
   }
 
   @Override
-  public synchronized void shutdownInput() throws IOException {
-    if (isClosed()) {
-      throw new SocketException("Socket is closed");
+  public void shutdownInput() throws IOException {
+    // Keep validation, channel shutdown, and state publication atomic with close().
+    synchronized (this) {
+      if (isClosed()) {
+        throw new SocketException("Socket is closed");
+      }
+      if (!isConnected()) {
+        throw new SocketException("Socket is not connected");
+      }
+      if (isInputShutdown()) {
+        throw new SocketException("Socket input is already shutdown");
+      }
+      unixSocketChannel.shutdownInput();
+      shutIn = true;
     }
-    if (!isConnected()) {
-      throw new SocketException("Socket is not connected");
-    }
-    if (isInputShutdown()) {
-      throw new SocketException("Socket input is already shutdown");
-    }
-    unixSocketChannel.shutdownInput();
-    shutIn = true;
   }
 
   @Override
-  public synchronized void shutdownOutput() throws IOException {
-    if (isClosed()) {
-      throw new SocketException("Socket is closed");
+  public void shutdownOutput() throws IOException {
+    // Keep validation, channel shutdown, and state publication atomic with close().
+    synchronized (this) {
+      if (isClosed()) {
+        throw new SocketException("Socket is closed");
+      }
+      if (!isConnected()) {
+        throw new SocketException("Socket is not connected");
+      }
+      if (isOutputShutdown()) {
+        throw new SocketException("Socket output is already shutdown");
+      }
+      unixSocketChannel.shutdownOutput();
+      shutOut = true;
     }
-    if (!isConnected()) {
-      throw new SocketException("Socket is not connected");
-    }
-    if (isOutputShutdown()) {
-      throw new SocketException("Socket output is already shutdown");
-    }
-    unixSocketChannel.shutdownOutput();
-    shutOut = true;
   }
 
   @Override
@@ -371,24 +374,28 @@ final class TunnelingJdkSocket extends Socket {
   }
 
   @Override
-  public synchronized void close() {
-    if (isClosed()) {
-      return;
+  public void close() {
+    Selector currentSelector;
+    // Publish the terminal state and snapshot the selector atomically with selector creation and
+    // half-close operations. The resources are closed after releasing this monitor.
+    synchronized (this) {
+      if (isClosed()) {
+        return;
+      }
+      shutIn = true;
+      shutOut = true;
+      closed = true;
+      currentSelector = selector;
     }
-    closed = true;
-    shutIn = true;
-    shutOut = true;
     // Ignore possible exceptions so that we continue closing the socket
     try {
-      if (selector != null) {
-        selector.close();
+      if (currentSelector != null) {
+        currentSelector.close();
       }
     } catch (IOException ignored) {
     }
     try {
-      if (unixSocketChannel != null) {
-        unixSocketChannel.close();
-      }
+      unixSocketChannel.close();
     } catch (IOException ignored) {
     }
   }

--- a/utils/socket-utils/src/main/java17/datadog/common/socket/TunnelingJdkSocket.java
+++ b/utils/socket-utils/src/main/java17/datadog/common/socket/TunnelingJdkSocket.java
@@ -1,5 +1,6 @@
 package datadog.common.socket;
 
+import datadog.trace.api.internal.VisibleForTesting;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -10,6 +11,8 @@ import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.UnixDomainSocketAddress;
 import java.nio.ByteBuffer;
+import java.nio.channels.CancelledKeyException;
+import java.nio.channels.ClosedSelectorException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.SocketChannel;
@@ -28,13 +31,13 @@ final class TunnelingJdkSocket extends Socket {
   private final SocketAddress unixSocketAddress;
   private InetSocketAddress inetSocketAddress;
 
-  private SocketChannel unixSocketChannel;
-  private Selector selector;
+  private volatile SocketChannel unixSocketChannel;
+  @VisibleForTesting volatile Selector selector;
 
-  private int timeout;
-  private boolean shutIn;
-  private boolean shutOut;
-  private boolean closed;
+  private volatile int timeout;
+  private volatile boolean shutIn;
+  private volatile boolean shutOut;
+  private volatile boolean closed;
 
   static final int DEFAULT_BUFFER_SIZE = 8192;
   // Indicate that the buffer size is not set by initializing to -1
@@ -90,7 +93,7 @@ final class TunnelingJdkSocket extends Socket {
   }
 
   @Override
-  public void connect(final SocketAddress endpoint) throws IOException {
+  public synchronized void connect(final SocketAddress endpoint) throws IOException {
     if (endpoint == null) {
       throw new IllegalArgumentException("Endpoint cannot be null");
     }
@@ -108,7 +111,8 @@ final class TunnelingJdkSocket extends Socket {
   // See:
   // https://github.com/jnr/jnr-unixsocket/blob/master/src/main/java/jnr/unixsocket/UnixSocket.java#L89-L97
   @Override
-  public void connect(final SocketAddress endpoint, final int timeout) throws IOException {
+  public synchronized void connect(final SocketAddress endpoint, final int timeout)
+      throws IOException {
     if (endpoint == null) {
       throw new IllegalArgumentException("Endpoint cannot be null");
     }
@@ -199,7 +203,7 @@ final class TunnelingJdkSocket extends Socket {
   }
 
   @Override
-  public InputStream getInputStream() throws IOException {
+  public synchronized InputStream getInputStream() throws IOException {
     if (isClosed()) {
       throw new SocketException("Socket is closed");
     }
@@ -210,10 +214,21 @@ final class TunnelingJdkSocket extends Socket {
       throw new SocketException("Socket input is shutdown");
     }
 
-    if (selector == null) {
-      selector = Selector.open();
-      unixSocketChannel.configureBlocking(false);
-      unixSocketChannel.register(selector, SelectionKey.OP_READ);
+    Selector currentSelector = selector;
+    if (currentSelector == null) {
+      currentSelector = Selector.open();
+      try {
+        unixSocketChannel.configureBlocking(false);
+        unixSocketChannel.register(currentSelector, SelectionKey.OP_READ);
+        selector = currentSelector;
+      } catch (IOException | RuntimeException e) {
+        try {
+          currentSelector.close();
+        } catch (IOException closeException) {
+          e.addSuppressed(closeException);
+        }
+        throw e;
+      }
     }
 
     return new InputStream() {
@@ -232,30 +247,45 @@ final class TunnelingJdkSocket extends Socket {
         }
         buffer.clear();
 
-        int readyChannels = selector.select(timeout);
-        if (readyChannels == 0) {
-          return 0;
+        Selector currentSelector = selector;
+        SocketChannel currentChannel = unixSocketChannel;
+        if (currentSelector == null || currentChannel == null) {
+          throw new SocketException("Socket is closed");
         }
 
-        Set<SelectionKey> selectedKeys = selector.selectedKeys();
-        synchronized (selectedKeys) {
-          Iterator<SelectionKey> keyIterator = selectedKeys.iterator();
-          while (keyIterator.hasNext()) {
-            SelectionKey key = keyIterator.next();
-            keyIterator.remove();
-            if (key.isReadable()) {
-              int r = unixSocketChannel.read(buffer);
-              if (r == -1) {
-                return -1;
+        try {
+          int readyChannels = currentSelector.select(timeout);
+          if (readyChannels == 0) {
+            if (isClosed() || !currentSelector.isOpen()) {
+              throw new SocketException("Socket is closed");
+            }
+            return 0;
+          }
+
+          Set<SelectionKey> selectedKeys = currentSelector.selectedKeys();
+          synchronized (selectedKeys) {
+            Iterator<SelectionKey> keyIterator = selectedKeys.iterator();
+            while (keyIterator.hasNext()) {
+              SelectionKey key = keyIterator.next();
+              keyIterator.remove();
+              if (key.isReadable()) {
+                int r = currentChannel.read(buffer);
+                if (r == -1) {
+                  return -1;
+                }
+                buffer.flip();
+                len = Math.min(r, len);
+                buffer.get(b, off, len);
+                return len;
               }
-              buffer.flip();
-              len = Math.min(r, len);
-              buffer.get(b, off, len);
-              return len;
             }
           }
+          return 0;
+        } catch (ClosedSelectorException | CancelledKeyException e) {
+          SocketException socketException = new SocketException("Socket is closed");
+          socketException.initCause(e);
+          throw socketException;
         }
-        return 0;
       }
 
       @Override
@@ -303,7 +333,7 @@ final class TunnelingJdkSocket extends Socket {
   }
 
   @Override
-  public void shutdownInput() throws IOException {
+  public synchronized void shutdownInput() throws IOException {
     if (isClosed()) {
       throw new SocketException("Socket is closed");
     }
@@ -318,7 +348,7 @@ final class TunnelingJdkSocket extends Socket {
   }
 
   @Override
-  public void shutdownOutput() throws IOException {
+  public synchronized void shutdownOutput() throws IOException {
     if (isClosed()) {
       throw new SocketException("Socket is closed");
     }
@@ -341,36 +371,25 @@ final class TunnelingJdkSocket extends Socket {
   }
 
   @Override
-  public void close() throws IOException {
+  public synchronized void close() {
     if (isClosed()) {
       return;
     }
+    closed = true;
+    shutIn = true;
+    shutOut = true;
     // Ignore possible exceptions so that we continue closing the socket
-    try {
-      if (!isInputShutdown()) {
-        shutdownInput();
-      }
-    } catch (IOException e) {
-    }
-    try {
-      if (!isOutputShutdown()) {
-        shutdownOutput();
-      }
-    } catch (IOException e) {
-    }
     try {
       if (selector != null) {
         selector.close();
-        selector = null;
       }
-    } catch (IOException e) {
+    } catch (IOException ignored) {
     }
     try {
       if (unixSocketChannel != null) {
         unixSocketChannel.close();
       }
-    } catch (IOException e) {
+    } catch (IOException ignored) {
     }
-    closed = true;
   }
 }

--- a/utils/socket-utils/src/test/java/datadog/common/socket/TunnelingJdkSocketTest.java
+++ b/utils/socket-utils/src/test/java/datadog/common/socket/TunnelingJdkSocketTest.java
@@ -65,6 +65,8 @@ public class TunnelingJdkSocketTest {
     startServer(socketAddress);
     TunnelingJdkSocket clientSocket = new TunnelingJdkSocket(socketPath);
 
+    assertNotNull(clientSocket.getChannel());
+    assertTrue(clientSocket.getChannel().isOpen());
     assertFalse(clientSocket.isConnected());
     assertFalse(clientSocket.isClosed());
 
@@ -83,6 +85,7 @@ public class TunnelingJdkSocketTest {
 
     assertTrue(clientSocket.isConnected());
     assertTrue(clientSocket.isClosed());
+    assertFalse(clientSocket.getChannel().isOpen());
     assertTrue(clientSocket.isInputShutdown());
     assertTrue(clientSocket.isOutputShutdown());
     assertEquals(-1, inputStream.read());
@@ -90,6 +93,23 @@ public class TunnelingJdkSocketTest {
     assertThrows(SocketException.class, clientSocket::getInputStream);
     assertThrows(SocketException.class, clientSocket::getOutputStream);
     clientSocket.close();
+  }
+
+  @Test
+  public void testConnectFailureClosesSocket() throws Exception {
+    Path missingSocketPath = getSocketPath();
+    TunnelingJdkSocket clientSocket = new TunnelingJdkSocket(missingSocketPath);
+
+    assertThrows(
+        IOException.class, () -> clientSocket.connect(new InetSocketAddress("localhost", 0)));
+
+    assertFalse(clientSocket.isConnected());
+    assertTrue(clientSocket.isClosed());
+    assertTrue(clientSocket.isInputShutdown());
+    assertTrue(clientSocket.isOutputShutdown());
+    assertFalse(clientSocket.getChannel().isOpen());
+    assertThrows(
+        SocketException.class, () -> clientSocket.connect(new InetSocketAddress("localhost", 0)));
   }
 
   @Test

--- a/utils/socket-utils/src/test/java/datadog/common/socket/TunnelingJdkSocketTest.java
+++ b/utils/socket-utils/src/test/java/datadog/common/socket/TunnelingJdkSocketTest.java
@@ -2,6 +2,8 @@ package datadog.common.socket;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -11,26 +13,52 @@ import static org.junit.jupiter.api.condition.JRE.JAVA_16;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.management.ManagementFactory;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;
+import java.nio.channels.CancelledKeyException;
+import java.nio.channels.ClosedSelectorException;
+import java.nio.channels.SelectableChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.channels.spi.SelectorProvider;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 
+@EnabledForJreRange(min = JAVA_16)
 public class TunnelingJdkSocketTest {
 
-  private static final AtomicBoolean isServerRunning = new AtomicBoolean(false);
+  private TestUnixSocketServer server;
+
+  @BeforeAll
+  static void assumeUnixDomainSocketsAreSupported() {
+    Assumptions.assumeTrue(udsSupported());
+  }
+
+  @AfterEach
+  void closeServer() throws Exception {
+    if (server != null) {
+      server.close();
+      server = null;
+    }
+  }
 
   @Test
-  @EnabledForJreRange(min = JAVA_16)
   public void testSocketConnectAndClose() throws Exception {
     Path socketPath = getSocketPath();
     UnixDomainSocketAddress socketAddress = UnixDomainSocketAddress.of(socketPath);
@@ -62,12 +90,9 @@ public class TunnelingJdkSocketTest {
     assertThrows(SocketException.class, clientSocket::getInputStream);
     assertThrows(SocketException.class, clientSocket::getOutputStream);
     clientSocket.close();
-
-    isServerRunning.set(false);
   }
 
   @Test
-  @EnabledForJreRange(min = JAVA_16)
   public void testInputStreamClose() throws Exception {
     TunnelingJdkSocket clientSocket = createClient();
     InputStream inputStream = clientSocket.getInputStream();
@@ -86,12 +111,9 @@ public class TunnelingJdkSocketTest {
     assertThrows(IOException.class, () -> outputStream.write(1));
     assertThrows(SocketException.class, clientSocket::getInputStream);
     assertThrows(SocketException.class, clientSocket::getOutputStream);
-
-    isServerRunning.set(false);
   }
 
   @Test
-  @EnabledForJreRange(min = JAVA_16)
   public void testOutputStreamClose() throws Exception {
     TunnelingJdkSocket clientSocket = createClient();
     InputStream inputStream = clientSocket.getInputStream();
@@ -110,12 +132,9 @@ public class TunnelingJdkSocketTest {
     assertThrows(IOException.class, () -> outputStream.write(1));
     assertThrows(SocketException.class, clientSocket::getInputStream);
     assertThrows(SocketException.class, clientSocket::getOutputStream);
-
-    isServerRunning.set(false);
   }
 
   @Test
-  @EnabledForJreRange(min = JAVA_16)
   public void testTimeout() throws Exception {
     TunnelingJdkSocket clientSocket = createClient();
     InputStream inputStream = clientSocket.getInputStream();
@@ -155,12 +174,9 @@ public class TunnelingJdkSocketTest {
     clientSocket.close();
     assertThrows(SocketException.class, () -> clientSocket.setSoTimeout(testTimeout));
     assertThrows(SocketException.class, clientSocket::getSoTimeout);
-
-    isServerRunning.set(false);
   }
 
   @Test
-  @EnabledForJreRange(min = JAVA_16)
   public void testBufferSizes() throws Exception {
     TunnelingJdkSocket clientSocket = createClient();
 
@@ -191,12 +207,9 @@ public class TunnelingJdkSocketTest {
     assertThrows(SocketException.class, clientSocket::getSendBufferSize);
     assertThrows(SocketException.class, clientSocket::getReceiveBufferSize);
     assertThrows(SocketException.class, clientSocket::getStreamBufferSize);
-
-    isServerRunning.set(false);
   }
 
   @Test
-  @EnabledForJreRange(min = JAVA_16)
   public void testFileDescriptorLeak() throws Exception {
     long initialCount = getFileDescriptorCount();
 
@@ -209,15 +222,100 @@ public class TunnelingJdkSocketTest {
     }
 
     clientSocket.close();
-    isServerRunning.set(false);
+    closeServer();
 
     long finalCount = getFileDescriptorCount();
     assertTrue(finalCount <= initialCount + 3);
   }
 
+  @Test
+  public void testClosedSelectorIsReportedAsSocketException() throws Exception {
+    try (TunnelingJdkSocket clientSocket = createClient()) {
+      InputStream inputStream = clientSocket.getInputStream();
+      clientSocket.selector.close();
+
+      SocketException exception = assertThrows(SocketException.class, inputStream::read);
+
+      assertInstanceOf(ClosedSelectorException.class, exception.getCause());
+    }
+  }
+
+  @Test
+  public void testSelectorClosedBetweenSelectAndSelectedKeysIsReportedAsSocketException()
+      throws Exception {
+    try (TunnelingJdkSocket clientSocket = createClient()) {
+      InputStream inputStream = clientSocket.getInputStream();
+      clientSocket.selector.close();
+      clientSocket.selector = new ClosedAfterSelectSelector();
+
+      SocketException exception = assertThrows(SocketException.class, inputStream::read);
+
+      assertInstanceOf(ClosedSelectorException.class, exception.getCause());
+    }
+  }
+
+  @Test
+  public void testCancelledKeyIsReportedAsSocketException() throws Exception {
+    try (TunnelingJdkSocket clientSocket = createClient()) {
+      InputStream inputStream = clientSocket.getInputStream();
+      clientSocket.selector.close();
+      clientSocket.selector = new CancelledKeySelector();
+
+      SocketException exception = assertThrows(SocketException.class, inputStream::read);
+
+      assertInstanceOf(CancelledKeyException.class, exception.getCause());
+    }
+  }
+
+  @Test
+  public void testAsynchronousCloseInterruptsBlockedReadWithIOException() throws Exception {
+    TunnelingJdkSocket clientSocket = createClient();
+    Thread reader = null;
+    try {
+      InputStream inputStream = clientSocket.getInputStream();
+      clientSocket.selector.close();
+      BlockingCloseSelector selector = new BlockingCloseSelector();
+      clientSocket.selector = selector;
+      AtomicReference<Throwable> readFailure = new AtomicReference<>();
+
+      reader =
+          new Thread(
+              () -> {
+                try {
+                  inputStream.read();
+                } catch (Throwable t) {
+                  readFailure.set(t);
+                }
+              },
+              "tunneling-jdk-socket-reader");
+      reader.setDaemon(true);
+      reader.start();
+
+      assertTrue(
+          selector.awaitSelectStarted(5, TimeUnit.SECONDS),
+          "The reader did not block in Selector.select");
+      clientSocket.close();
+      reader.join(TimeUnit.SECONDS.toMillis(5));
+
+      assertFalse(reader.isAlive(), "The blocked read did not terminate after close");
+      Throwable failure = readFailure.get();
+      assertNotNull(failure, "The blocked read should fail when the socket is closed");
+      assertTrue(
+          failure instanceof IOException,
+          () -> "Expected an IOException, but got " + failure.getClass().getName());
+      assertFalse(failure instanceof ClosedSelectorException);
+    } finally {
+      clientSocket.close();
+      if (reader != null && reader.isAlive()) {
+        reader.interrupt();
+        reader.join(TimeUnit.SECONDS.toMillis(5));
+      }
+    }
+  }
+
   private long getFileDescriptorCount() {
     try {
-      Process process = Runtime.getRuntime().exec("lsof -p " + getPid());
+      Process process = Runtime.getRuntime().exec("lsof -p " + ProcessHandle.current().pid());
       int count = 0;
       try (java.io.BufferedReader reader =
           new java.io.BufferedReader(new java.io.InputStreamReader(process.getInputStream()))) {
@@ -231,41 +329,8 @@ public class TunnelingJdkSocketTest {
     }
   }
 
-  private String getPid() {
-    return ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
-  }
-
-  private static void startServer(UnixDomainSocketAddress socketAddress) {
-    Thread serverThread =
-        new Thread(
-            () -> {
-              try (ServerSocketChannel serverChannel =
-                  ServerSocketChannel.open(StandardProtocolFamily.UNIX)) {
-                serverChannel.bind(socketAddress);
-                isServerRunning.set(true);
-
-                synchronized (isServerRunning) {
-                  isServerRunning.notifyAll();
-                }
-
-                while (isServerRunning.get()) {
-                  SocketChannel clientChannel = serverChannel.accept();
-                }
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            });
-    serverThread.start();
-
-    synchronized (isServerRunning) {
-      while (!isServerRunning.get()) {
-        try {
-          isServerRunning.wait();
-        } catch (InterruptedException e) {
-          throw new RuntimeException(e);
-        }
-      }
-    }
+  private void startServer(UnixDomainSocketAddress socketAddress) throws IOException {
+    server = new TestUnixSocketServer(socketAddress);
   }
 
   private Path getSocketPath() throws IOException {
@@ -282,5 +347,280 @@ public class TunnelingJdkSocketTest {
     TunnelingJdkSocket clientSocket = new TunnelingJdkSocket(socketPath);
     clientSocket.connect(new InetSocketAddress("localhost", 0));
     return clientSocket;
+  }
+
+  private static final class TestUnixSocketServer implements AutoCloseable {
+    private final Path socketPath;
+    private final ServerSocketChannel serverChannel;
+    private final AtomicReference<SocketChannel> acceptedChannel = new AtomicReference<>();
+    private final AtomicReference<Throwable> serverFailure = new AtomicReference<>();
+    private final Thread serverThread;
+
+    private TestUnixSocketServer(UnixDomainSocketAddress socketAddress) throws IOException {
+      socketPath = socketAddress.getPath();
+      serverChannel = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
+      boolean bound = false;
+      try {
+        serverChannel.bind(socketAddress);
+        bound = true;
+      } finally {
+        if (!bound) {
+          serverChannel.close();
+        }
+      }
+
+      serverThread =
+          new Thread(
+              () -> {
+                try {
+                  acceptedChannel.set(serverChannel.accept());
+                } catch (IOException e) {
+                  if (serverChannel.isOpen()) {
+                    serverFailure.set(e);
+                  }
+                }
+              },
+              "tunneling-jdk-socket-test-server");
+      serverThread.setDaemon(true);
+      serverThread.start();
+    }
+
+    @Override
+    public void close() throws Exception {
+      serverChannel.close();
+      serverThread.join(TimeUnit.SECONDS.toMillis(5));
+      if (serverThread.isAlive()) {
+        serverThread.interrupt();
+        throw new AssertionError("The Unix-domain test server did not terminate");
+      }
+
+      SocketChannel clientChannel = acceptedChannel.get();
+      if (clientChannel != null) {
+        clientChannel.close();
+      }
+      Files.deleteIfExists(socketPath);
+
+      Throwable failure = serverFailure.get();
+      if (failure != null) {
+        throw new AssertionError("The Unix-domain test server failed", failure);
+      }
+    }
+  }
+
+  private abstract static class SelectorAdapter extends Selector {
+    private volatile boolean open = true;
+
+    @Override
+    public final boolean isOpen() {
+      return open;
+    }
+
+    @Override
+    public final SelectorProvider provider() {
+      return SelectorProvider.provider();
+    }
+
+    @Override
+    public final int selectNow() {
+      return doSelect();
+    }
+
+    @Override
+    public final int select(long timeout) {
+      return doSelect();
+    }
+
+    @Override
+    public final int select() {
+      return doSelect();
+    }
+
+    @Override
+    public final Selector wakeup() {
+      return this;
+    }
+
+    @Override
+    public final void close() {
+      if (open) {
+        open = false;
+        onClose();
+      }
+    }
+
+    abstract int doSelect();
+
+    void onClose() {}
+  }
+
+  /**
+   * Models another thread closing a selector while a socket read is blocked:
+   *
+   * <ol>
+   *   <li>Signals when {@code select()} is entered.
+   *   <li>Blocks until another thread closes the selector.
+   *   <li>Throws {@link ClosedSelectorException} after closure.
+   *   <li>Lets the test verify that the reader receives an {@link IOException} and terminates.
+   * </ol>
+   */
+  private static final class BlockingCloseSelector extends SelectorAdapter {
+    private final CountDownLatch selectStarted = new CountDownLatch(1);
+    private final CountDownLatch closed = new CountDownLatch(1);
+
+    @Override
+    public Set<SelectionKey> keys() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public Set<SelectionKey> selectedKeys() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    int doSelect() {
+      selectStarted.countDown();
+      try {
+        if (!closed.await(5, TimeUnit.SECONDS)) {
+          throw new AssertionError("Selector was not closed");
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError("Interrupted while waiting for the selector to close", e);
+      }
+      throw new ClosedSelectorException();
+    }
+
+    @Override
+    void onClose() {
+      closed.countDown();
+    }
+
+    boolean awaitSelectStarted(long timeout, TimeUnit unit) throws InterruptedException {
+      return selectStarted.await(timeout, unit);
+    }
+  }
+
+  /**
+   * Models a selector closing between selection and selected-key processing:
+   *
+   * <ol>
+   *   <li>Closes itself during {@code select()} and reports one ready channel.
+   *   <li>Throws {@link ClosedSelectorException} when the selected keys are requested.
+   *   <li>Lets the test verify that the exception is reported as a {@link SocketException}.
+   * </ol>
+   */
+  private static final class ClosedAfterSelectSelector extends SelectorAdapter {
+    @Override
+    public Set<SelectionKey> keys() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public Set<SelectionKey> selectedKeys() {
+      if (!isOpen()) {
+        throw new ClosedSelectorException();
+      }
+      return Collections.emptySet();
+    }
+
+    @Override
+    int doSelect() {
+      close();
+      return 1;
+    }
+  }
+
+  /**
+   * Models a key being cancelled before selected-key processing:
+   *
+   * <ol>
+   *   <li>Reports one ready channel from {@code select()}.
+   *   <li>Returns an invalid selected key.
+   *   <li>Throws {@link CancelledKeyException} when the read checks whether the key is readable.
+   *   <li>Lets the test verify that the exception is reported as a {@link SocketException}.
+   * </ol>
+   */
+  private static final class CancelledKeySelector extends SelectorAdapter {
+    private final Set<SelectionKey> selectedKeys =
+        new HashSet<>(Collections.singleton(new CancelledSelectionKey(this)));
+
+    @Override
+    public Set<SelectionKey> keys() {
+      return selectedKeys;
+    }
+
+    @Override
+    public Set<SelectionKey> selectedKeys() {
+      return selectedKeys;
+    }
+
+    @Override
+    int doSelect() {
+      return 1;
+    }
+
+    private static final class CancelledSelectionKey extends SelectionKey {
+      private final Selector selector;
+
+      private CancelledSelectionKey(Selector selector) {
+        this.selector = selector;
+      }
+
+      @Override
+      public SelectableChannel channel() {
+        return null;
+      }
+
+      @Override
+      public Selector selector() {
+        return selector;
+      }
+
+      @Override
+      public boolean isValid() {
+        return false;
+      }
+
+      @Override
+      public void cancel() {}
+
+      @Override
+      public int interestOps() {
+        return OP_READ;
+      }
+
+      @Override
+      public SelectionKey interestOps(int ops) {
+        return this;
+      }
+
+      @Override
+      public int readyOps() {
+        throw new CancelledKeyException();
+      }
+    }
+  }
+
+  private static boolean udsSupported() {
+    Path socketPath = null;
+    try {
+      socketPath = Files.createTempFile("testSocketSupport", null);
+      Files.delete(socketPath);
+      try (ServerSocketChannel serverChannel =
+          ServerSocketChannel.open(StandardProtocolFamily.UNIX)) {
+        serverChannel.bind(UnixDomainSocketAddress.of(socketPath));
+      }
+      return true;
+    } catch (IOException | UnsupportedOperationException e) {
+      return false;
+    } finally {
+      if (socketPath != null) {
+        try {
+          Files.deleteIfExists(socketPath);
+        } catch (IOException ignored) {
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
# What Does This Do

Keeps trace delivery alive when an OkHttp request over a JDK Unix-domain socket times out.

This pull request makes two related but distinct changes:

1. It reports asynchronous selector closure as an I/O failure instead of letting an unchecked selector exception escape the socket boundary.
2. It serializes the compound socket lifecycle transitions that can race with Okio closing a timed-out connection.

It also adds focused selector tests and a writer-level timeout-then-reconnect test over a real Unix-domain socket.

# Motivation

## 1. Keep selector closure on the I/O failure path

OkHttp creates the Agent connection with `UnixDomainSocketFactory`. Okio then wraps that socket and uses `AsyncTimeout.Watchdog` to enforce the read timeout. When a response stalls, the watchdog closes the socket from a different thread to interrupt the blocked read.

Closing `TunnelingJdkSocket` closes its selector. Depending on where the reader is, JDK NIO can then throw `ClosedSelectorException` or `CancelledKeyException`. These are unchecked exceptions, so Okio does not handle them as transport failures. They can escape the send path and stop the single `dd-trace-processor` thread, after which later traces are no longer sent.

```mermaid
flowchart LR
  subgraph DD["dd-trace-java"]
    worker["TraceProcessingWorker"]
    api["DDAgentApi"]
    udsRead["TunnelingJdkSocket.read()"]
    udsClose["TunnelingJdkSocket.close()"]
    nextPayload["next payload<br/>fresh connection"]
  end

  subgraph OkHttp["OkHttp 3.x"]
    codec["Http1Codec"]
    connection["RealConnection"]
  end

  subgraph Okio["Okio 1.x"]
    source["Okio.source(socket)"]
    watchdog["AsyncTimeout.Watchdog"]
  end

  subgraph JDK["JDK NIO"]
    select["Selector.select()"]
    lifecycleException["ClosedSelectorException<br/>or CancelledKeyException"]
  end

  worker --> api --> codec --> source --> udsRead --> select
  watchdog -->|"read timeout closes socket"| udsClose
  udsClose -->|"closes selector"| select
  select --> lifecycleException
  lifecycleException -->|"translated to SocketException"| udsRead
  udsRead -->|"IOException"| source
  source -->|"failed exchange"| codec
  codec -->|"failed send; worker survives"| worker
  worker --> nextPayload --> connection --> udsRead
```

The socket now translates only these selector lifecycle exceptions to `SocketException`. The timed-out POST is not retried because the Agent may already have received it. Instead, that payload fails normally, the processor keeps running, and the next payload uses a fresh connection.

## 2. Serialize socket lifecycle transitions

The exception translation makes asynchronous closure survivable, but the socket also needs a coherent lifetime while OkHttp and Okio use it from different threads.

The synchronization is deliberately narrow. It protects compound lifecycle operations rather than normal I/O:

- `getInputStream()` validates the state and publishes the lazily created selector before `close()` can snapshot it.
- `shutdownInput()` and `shutdownOutput()` keep validation, the channel operation, and the state update atomic with `close()`.
- `close()` publishes the terminal state and snapshots the selector under the socket monitor, then closes the selector and channel after releasing the monitor so a blocked read can wake without extending the critical section.
- The channel is created with the socket and remains stable for its lifetime. A failed connection closes that channel and leaves the socket terminally closed.

```mermaid
flowchart LR
  subgraph OkHttp["OkHttp 3.x"]
    realConnection["RealConnection<br/>one socket per physical connection"]
    halfClose["connection shutdown"]
  end

  subgraph Okio["Okio 1.x"]
    sourceSetup["Okio.source(socket)"]
    timeoutClose["AsyncTimeout.Watchdog<br/>socket.close()"]
  end

  subgraph DD["dd-trace-java"]
    factory["UnixDomainSocketFactory"]
    socket["TunnelingJdkSocket"]
    inputLifecycle["getInputStream()<br/>validate + publish"]
    halfLifecycle["shutdownInput/Output()<br/>validate + update"]
    closeLifecycle["close()<br/>terminal state + snapshot"]
    monitor["synchronized (this)<br/>short lifecycle transition"]
    resourceClose["close resources<br/>outside monitor"]
  end

  subgraph JDK["JDK NIO"]
    channel["final SocketChannel"]
    selector["lazy Selector"]
  end

  factory --> socket -->|"created together"| channel
  realConnection -->|"connect"| socket
  sourceSetup --> inputLifecycle --> monitor -->|"publish"| selector
  halfClose --> halfLifecycle --> monitor -->|"native half-close"| channel
  timeoutClose --> closeLifecycle --> monitor -->|"snapshot"| resourceClose
  resourceClose -->|"wake blocked read"| selector
  resourceClose --> channel
```

Normal bulk reads and writes do not acquire the socket lifecycle monitor. They continue to observe volatile state and operate on the stable channel.

# Additional Notes

The writer-level test uses MockWebServer's `NO_RESPONSE` policy over a JNR Unix-domain server adapter. It verifies that the first request times out, the second request arrives on a new connection, and both callbacks run on the same surviving writer thread.

The focused socket and writer tests pass on JDK 17, 21, and 25.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [APMS-20292](https://datadoghq.atlassian.net/browse/APMS-20292)


[APMS-20292]: https://datadoghq.atlassian.net/browse/APMS-20292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ