### PR TITLE
Update Gradle to 9.7.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,7 +53,7 @@ variables:
   BUILD_JOB_NAME: "build"
   DEPENDENCY_CACHE_POLICY: pull
   BUILD_CACHE_POLICY: pull
-  GRADLE_VERSION: "9.7.0" # must match gradle-wrapper.properties
+  GRADLE_VERSION: "9.7.1" # must match gradle-wrapper.properties
   MASS_READ_URL: "https://mass-read.us1.ddbuild.io"
   MAVEN_REPOSITORY_PROXY: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
   GRADLE_PLUGIN_PROXY: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"

--- a/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/build.gradle
+++ b/dd-java-agent/instrumentation/sofarpc/sofarpc-5.0/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   latestDepTestImplementation group: "com.alipay.sofa", name: "sofa-rpc-all", version: "+"
 
   constraints {
-    // Regression fix for Gradle 9.6.0 (should be fixed in 9.7.0)
+    // Regression fix for Gradle 9.6.0.
     //
     // The `sofa-rpc-all:5.14.2` brings `netty-all:4.1.44.Final`, which is a fat jar,
     // while `grpc-netty:1.53.0` brings individual `netty-*:4.1.79.Final` modules.
@@ -41,8 +41,8 @@ dependencies {
     // produces a `NoSuchMethodError` at runtime in netty's `AbstractReferenceCountedByteBuf`.
     //
     // The workaround is to force `netty-all` to `4.1.79` so the fat jar and the individual
-    // modules are aligned on the same version. This should be fixed in 9.7.0 and consequently
-    // removed from the constraints.
+    // modules are aligned on the same version. The fix is behind Gradle 9.7's
+    // ENHANCED_GRAPH_ORDERING preview, which currently exposes other fat-jar conflicts.
     // See https://github.com/gradle/gradle/issues/38057 for more details.
     testImplementation("io.netty:netty-all:4.1.79.Final") {
       because "sofa-rpc-all brings netty-all:4.1.44.Final (fat jar) while grpc-netty brings individual netty-*:4.1.79.Final modules; Gradle 9.6.0 classpath ordering regression causes 4.1.44 classes to shadow 4.1.79, producing NoSuchMethodError"

--- a/dd-smoke-tests/gradle/src/test/resources/latest-tool-versions.properties
+++ b/dd-smoke-tests/gradle/src/test/resources/latest-tool-versions.properties
@@ -1,6 +1,6 @@
 # Pinned latest eligible stable versions (>=48h old) for CI Visibility Gradle smoke tests.
 # Updated automatically by the update-smoke-test-latest-versions workflow.
-gradle.latest=9.7.0
+gradle.latest=9.7.1
 # Latest eligible stable patch per Gradle major release. Used to resolve the "oldest" smoke-test
 # Gradle version (the latest patch of the oldest major the current TestKit supports).
 gradle.latest.3=3.5.1
@@ -9,4 +9,4 @@ gradle.latest.5=5.6.4
 gradle.latest.6=6.9.4
 gradle.latest.7=7.6.6
 gradle.latest.8=8.14.5
-gradle.latest.9=9.7.0
+gradle.latest.9=9.7.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=84fbba45c7f4c64abc77460e1c00f541e9f960e3c7ed2538f1ede19eacd873ae
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionSha256Sum=acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
# What Does This Do

- Updates the Gradle wrapper from 9.7.0 to 9.7.1 using the official binary distribution checksum.
- Aligns the GitLab Gradle cache version and Gradle smoke-test version fixtures with 9.7.1.
- Retains the SofaRPC Netty alignment constraint and updates its comment to document why Gradle 9.7's enhanced graph ordering is not enabled globally yet.

# Motivation

Adopt the Gradle 9.7.1 patch release while keeping every Gradle version pin synchronized.

Gradle fixed the dependency traversal issue tracked in https://github.com/gradle/gradle/issues/38057 behind the `ENHANCED_GRAPH_ORDERING` feature preview. Enabling that preview globally is not safe for this build yet because several tests intentionally use fat JARs alongside newer modular dependencies.

# Additional Notes

Validation of the feature preview exposed deterministic classpath collisions outside SofaRPC. One representative failure was:

```text
java.lang.NoSuchMethodError:
  org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder(...)
```

MockServer's no-dependencies fat JAR contains an older JUnit Platform class which shadowed JUnit Platform 1.14.1 under enhanced ordering. OpenAI latest-dependency tests independently loaded incompatible OkHttp classes for the same reason. The preview was therefore removed, while the existing SofaRPC-local Netty alignment remains in place. Adopting enhanced graph ordering should be handled separately with a repository-wide fat-JAR collision audit before Gradle 10 makes it the default.

The Gradle 9.7.1 wrapper JAR is unchanged from 9.7.0 and still matches Gradle's published wrapper JAR checksum. The binary distribution checksum was updated to the official 9.7.1 value.

Validation:

- `./gradlew help`
- `./gradlew spotlessCheck`
- `./gradlew :components:http:http-api:test :components:http:http-api:forkedTest --rerun-tasks`
- `./gradlew :dd-java-agent:instrumentation:openai-java:openai-java-3.0:latestDepTest -PtestJvm=17 --rerun-tasks` (95 tests passed)
- `./gradlew :dd-java-agent:instrumentation:sofarpc:sofarpc-5.0:test :dd-java-agent:instrumentation:sofarpc:sofarpc-5.0:forkedTest :dd-java-agent:instrumentation:sofarpc:sofarpc-5.0:latestDepTest -PtestJvm=17 --rerun-tasks` (7 tests passed, including the forked gRPC regression test)

Precedent: https://github.com/DataDog/dd-trace-java/pull/12162

# Contributor Checklist

- [x] Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [x] Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion (not applicable; no source files were added, migrated, or deleted)
- [x] Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors (not applicable; this is a build configuration change)
- [ ] Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
