### PR TITLE
Support OpenTelemetry deployment environment names

### DIFF
--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -589,7 +589,7 @@ class ConfigTest extends DDSpecification {
   def "otel generic config via system properties - metrics enabled"() {
     setup:
     System.setProperty(DD_METRICS_OTEL_ENABLED_PROP, "true")
-    System.setProperty(OTEL_RESOURCE_ATTRIBUTES_PROP, "service.name=my=app,service.version=1.0.0,deployment.environment=production, message=blahblah")
+    System.setProperty(OTEL_RESOURCE_ATTRIBUTES_PROP, "service.name=my=app,service.version=1.0.0,deployment.environment.name=production, message=blahblah")
     System.setProperty("otel.log.level", "warning")
 
     when:

--- a/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/OtelEnvironmentConfigSourceTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/bootstrap/config/provider/OtelEnvironmentConfigSourceTest.groovy
@@ -324,7 +324,7 @@ class OtelEnvironmentConfigSourceTest extends DDSpecification {
       'key4=four,' +
       'key5=five,' +
       'key6=six,' +
-      'deployment.environment=staging,' +
+      'deployment.environment.name=staging,' +
       'key7=seven,' +
       'key8=eight,' +
       'key9=nine,' +
@@ -373,5 +373,24 @@ class OtelEnvironmentConfigSourceTest extends DDSpecification {
     source.get(VERSION) == '42'
     // only the first 10 custom attributes are mapped to tags
     source.get(TAGS) == 'key1:one,key2:two,key3:three,key4:four,key5:five,key6:six,key7:seven,key8:eight,key9:nine,key10:ten'
+  }
+
+  def "named deployment environment takes precedence over legacy attribute"() {
+    setup:
+    injectSysConfig('dd.trace.otel.enabled', 'true', false)
+    injectSysConfig('otel.resource.attributes', resourceAttributes, false)
+
+    when:
+    def source = new OtelEnvironmentConfigSource()
+
+    then:
+    source.get(ENV) == 'production'
+    source.get(TAGS) == null
+
+    where:
+    resourceAttributes << [
+      'deployment.environment.name=production,deployment.environment=staging',
+      'deployment.environment=staging,deployment.environment.name=production'
+    ]
   }
 }

--- a/utils/config-utils/src/main/java/datadog/trace/bootstrap/config/provider/OtelEnvironmentConfigSource.java
+++ b/utils/config-utils/src/main/java/datadog/trace/bootstrap/config/provider/OtelEnvironmentConfigSource.java
@@ -128,7 +128,9 @@ final class OtelEnvironmentConfigSource extends ConfigProvider.Source {
       Map<String, String> attributeMap = parseOtelMap(resourceAttributes);
       capture(SERVICE_NAME, attributeMap.remove("service.name"));
       capture(VERSION, attributeMap.remove("service.version"));
-      capture(ENV, attributeMap.remove("deployment.environment"));
+      String environment = attributeMap.remove("deployment.environment");
+      String namedEnvironment = attributeMap.remove("deployment.environment.name");
+      capture(ENV, namedEnvironment != null ? namedEnvironment : environment);
       capture(TAGS, renderDatadogMap(attributeMap, 10));
     }
     capture(LOG_LEVEL, logLevel);


### PR DESCRIPTION
# What Does This Do

Maps the stable OpenTelemetry `deployment.environment.name` resource attribute to the Datadog environment while retaining `deployment.environment` as a legacy fallback. When both attributes are present, the stable name takes precedence.

# Motivation

OpenTelemetry deprecated `deployment.environment` in favor of `deployment.environment.name`. Applications using the current semantic convention were not assigned the expected Datadog environment.

# Additional Notes

Validated with focused configuration tests and Spotless checks.

# Contributor Checklist

- [x] Format the title according to the contribution guidelines
- [x] Assign the required type, component, and AI-generated labels
- [x] Preserve compatibility with the deprecated resource attribute
