### PR TITLE
Update Spotless to 8.10.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ google-java-format = "1.36.1"
 greclipse = "4.27" # Pinned. See: https://github.com/diffplug/spotless/issues/3013
 ktlint = "1.8.0"
 scalafmt = "3.11.5"
-spotless = "8.10.0"
+spotless = "8.10.1"
 tabletest-formatter = "1.1.2"
 
 # DataDog libs and forks

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -5,7 +5,7 @@ def configPath = rootProject.hasProperty('sharedConfigDirectory') ? sharedConfig
 // This is necessary for some projects that set a special groovy target which can't coexist with excludeJava
 boolean groovySkipJavaExclude = project.hasProperty('groovySkipJavaExclude') ? groovySkipJavaExclude : false
 
-def buildDirectoryFiles = project.layout.buildDirectory.asFileTree
+def buildDirectory = project.layout.buildDirectory
 
 // Temporary exclusions as conventions are properly setup for these projects.
 def javaGradleApplyExceptions = [
@@ -50,7 +50,7 @@ spotless {
       // set explicit target to workaround https://github.com/diffplug/spotless/issues/1163
       target 'src/**/*.java'
       // ignore embedded test projects and everything in build dir, e.g. generated sources
-      targetExclude('src/test/resources/**', buildDirectoryFiles)
+      targetExclude('src/test/resources/**', buildDirectory)
       removeUnusedImports()
       forbidWildcardImports()
       tableTestFormatter(libs.versions.tabletest.formatter.get())
@@ -93,7 +93,7 @@ spotless {
         // the Groovy Eclipse formatter extends the Java Eclipse formatter,
         // so it formats Java files by default (unless `excludeJava` is used).
       }
-      targetExclude(buildDirectoryFiles)
+      targetExclude(buildDirectory)
       greclipse(libs.versions.greclipse.get()).configFile(configPath + '/enforcement/spotless-groovy.properties')
     }
   }
@@ -101,7 +101,7 @@ spotless {
   project.pluginManager.withPlugin('scala') {
     scala {
       toggleOffOn()
-      targetExclude(buildDirectoryFiles)
+      targetExclude(buildDirectory)
       scalafmt(libs.versions.scalafmt.get()).configFile(configPath + '/enforcement/spotless-scalafmt.conf')
     }
   }
@@ -124,7 +124,7 @@ spotless {
   project.pluginManager.withPlugin('kotlin') {
     kotlin {
       toggleOffOn()
-      targetExclude(buildDirectoryFiles)
+      targetExclude(buildDirectory)
       ktlint(libs.versions.ktlint.get()).editorConfigOverride([
         // Disable trailing comma rules to minimize diff.
         'ktlint_standard_trailing-comma-on-call-site': 'disabled',


### PR DESCRIPTION
## What Does This Do

Updates Spotless to 8.10.1 and uses the build directory provider for exclusions.

## Motivation

Keep the build tooling current and compatible with the updated Spotless API.

## Additional Notes

Validation: `./gradlew spotlessCheck`

## Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-for-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]