### PR TITLE
Bump ddprof to 1.50.0

### DIFF
--- a/dd-java-agent/ddprof-lib/gradle.lockfile
+++ b/dd-java-agent/ddprof-lib/gradle.lockfile
@@ -5,7 +5,7 @@
 ch.qos.logback:logback-classic:1.2.13=testCompileClasspath,testRuntimeClasspath
 ch.qos.logback:logback-core:1.2.13=testCompileClasspath,testRuntimeClasspath
 com.datadoghq:dd-javac-plugin-client:0.2.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.datadoghq:ddprof:1.49.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.datadoghq:ddprof:1.50.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.github.javaparser:javaparser-core:3.25.6=codenarc
 com.github.spotbugs:spotbugs-annotations:4.10.3=compileClasspath,spotbugs
 com.github.spotbugs:spotbugs:4.10.3=spotbugs

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ spotless = "8.10.0"
 tabletest-formatter = "1.1.2"
 
 # DataDog libs and forks
-ddprof = "1.49.0"
+ddprof = "1.50.0"
 dogstatsd = "4.4.5"
 datadog-okhttp = "3.12.15" # Datadog fork
 datadog-okio = "1.17.6" # Datadog fork


### PR DESCRIPTION
# What Does This Do

Bumps the `ddprof` dependency from `1.49.0` to `1.50.0` in `gradle/libs.versions.toml` and the `dd-java-agent/ddprof-lib/gradle.lockfile` lockfile.

# Motivation

Keep the ddprof dependency current.

# Additional Notes

[Java Profiler 1.50.0 Release Notes](https://github.com/DataDog/java-profiler/releases/tag/v_1.50.0)

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]