### PR TITLE
Run client-side stats through WorkQueue (perf toolbox adoption)

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
@@ -2,13 +2,14 @@ package datadog.trace.common.metrics;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import datadog.common.queue.WorkQueue;
 import datadog.trace.api.metrics.StatsMetrics;
 import datadog.trace.common.metrics.SignalItem.ClearSignal;
 import datadog.trace.common.metrics.SignalItem.StopSignal;
 import datadog.trace.core.monitor.HealthMetrics;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.concurrent.TimeUnit;
-import org.jctools.queues.MessagePassingQueue;
+import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,7 +19,7 @@ final class Aggregator implements Runnable {
 
   private static final Logger log = LoggerFactory.getLogger(Aggregator.class);
 
-  private final MessagePassingQueue<InboxItem> inbox;
+  private final WorkQueue<InboxItem> inbox;
   private final AggregateTable aggregates;
   private final MetricWriter writer;
   private final HealthMetrics healthMetrics;
@@ -45,7 +46,7 @@ final class Aggregator implements Runnable {
 
   Aggregator(
       MetricWriter writer,
-      MessagePassingQueue<InboxItem> inbox,
+      WorkQueue<InboxItem> inbox,
       int maxAggregates,
       long reportingInterval,
       TimeUnit reportingIntervalTimeUnit,
@@ -66,7 +67,7 @@ final class Aggregator implements Runnable {
 
   Aggregator(
       MetricWriter writer,
-      MessagePassingQueue<InboxItem> inbox,
+      WorkQueue<InboxItem> inbox,
       int maxAggregates,
       long reportingInterval,
       TimeUnit reportingIntervalTimeUnit,
@@ -97,9 +98,9 @@ final class Aggregator implements Runnable {
     Drainer drainer = new Drainer();
     while (!currentThread.isInterrupted() && !drainer.stopped) {
       try {
-        if (!inbox.isEmpty()) {
-          inbox.drain(drainer);
-        } else {
+        // process reports whether there was an item to work on; a failing item throws out of it,
+        // into the same catch that has always kept one bad item from ending the drain loop.
+        if (!inbox.process(drainer)) {
           Thread.sleep(sleepMillis);
         }
       } catch (InterruptedException e) {
@@ -111,7 +112,7 @@ final class Aggregator implements Runnable {
     log.debug("metrics aggregator exited");
   }
 
-  private final class Drainer implements MessagePassingQueue.Consumer<InboxItem> {
+  private final class Drainer implements Consumer<InboxItem> {
 
     boolean stopped = false;
 

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
@@ -96,7 +96,7 @@ final class Aggregator implements Runnable {
   public void run() {
     Thread currentThread = Thread.currentThread();
     Drainer drainer = new Drainer();
-    while (!currentThread.isInterrupted() && !drainer.stopped) {
+    while (!currentThread.isInterrupted() && !inbox.isClosed()) {
       try {
         // Take what is there in one pass, the way the old jctools drain did. size() is O(1) on
         // this queue, so asking costs a read, and anything that arrives mid-pass is simply the
@@ -114,9 +114,11 @@ final class Aggregator implements Runnable {
     log.debug("metrics aggregator exited");
   }
 
+  /**
+   * Stateless. Whether the aggregator has stopped is the inbox's closed flag, which the run loop
+   * reads as its own exit condition -- see the {@link StopSignal} branch below.
+   */
   private final class Drainer implements Consumer<InboxItem> {
-
-    boolean stopped = false;
 
     @Override
     public void accept(InboxItem item) {
@@ -135,7 +137,7 @@ final class Aggregator implements Runnable {
         // re-aggregated, and flushed on the next report -- where the agent rejects them again,
         // triggering another DOWNGRADED -> disable() -> CLEAR cycle. Worst case: one extra
         // reporting cycle of wasted work, which we accept for the safety of preserving STOP.
-        if (!stopped) {
+        if (!inbox.isClosed()) {
           aggregates.clear();
           // Clear dirty too -- without this, the next report() would see dirty=true, run
           // expungeStaleAggregates against the (now-empty) table, find isEmpty()=true, and skip
@@ -146,16 +148,21 @@ final class Aggregator implements Runnable {
         ((SignalItem) item).complete();
       } else if (item instanceof SignalItem) {
         SignalItem signal = (SignalItem) item;
-        if (!stopped) {
+        if (!inbox.isClosed()) {
           report(wallClockTime(), signal);
-          stopped = item instanceof StopSignal;
-          if (stopped) {
+          if (item instanceof StopSignal) {
+            // Closing the inbox *is* stopping. It refuses further admission, so producers stop
+            // building snapshots for a consumer that is on its way out, and it is the condition
+            // this loop already reads to leave -- one piece of state rather than two that have to
+            // agree. Deliberately not shutdown(): anything queued behind STOP stays readable, and
+            // the batch this call sits in keeps being walked.
+            inbox.close();
             signal.complete();
           }
         } else {
           signal.ignore();
         }
-      } else if (item instanceof SpanSnapshot && !stopped) {
+      } else if (item instanceof SpanSnapshot && !inbox.isClosed()) {
         SpanSnapshot snapshot = (SpanSnapshot) item;
         AggregateEntry entry = aggregates.findOrInsert(snapshot);
         if (entry != null) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/Aggregator.java
@@ -98,9 +98,11 @@ final class Aggregator implements Runnable {
     Drainer drainer = new Drainer();
     while (!currentThread.isInterrupted() && !drainer.stopped) {
       try {
-        // process reports whether there was an item to work on; a failing item throws out of it,
-        // into the same catch that has always kept one bad item from ending the drain loop.
-        if (!inbox.process(drainer)) {
+        // Take what is there in one pass, the way the old jctools drain did. size() is O(1) on
+        // this queue, so asking costs a read, and anything that arrives mid-pass is simply the
+        // next pass's work. A failing item throws out of process, into the same catch that has
+        // always kept one bad item from ending the drain loop.
+        if (inbox.process(Math.max(1, inbox.size()), drainer) == 0) {
           Thread.sleep(sleepMillis);
         }
       } catch (InterruptedException e) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ClientStatsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ClientStatsAggregator.java
@@ -16,7 +16,7 @@ import static datadog.trace.util.AgentThreadFactory.newAgentThread;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import datadog.common.queue.Producer;
+import datadog.common.queue.ContextualProducer;
 import datadog.common.queue.WorkQueue;
 import datadog.common.queue.WorkQueues;
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
@@ -110,6 +110,13 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
    * only on the aggregator thread.
    */
   private volatile PeerTagSchema cachedPeerTagSchema;
+
+  /**
+   * Builds the snapshot for a span once the inbox has reserved a slot for it. Bound to this
+   * aggregator once, at construction, so admission costs no allocation at all: the span is the
+   * context, and everything else the snapshot needs is reachable from one or the other.
+   */
+  private final ContextualProducer<CoreSpan<?>, InboxItem> snapshotProducer = this::snapshotOf;
 
   /**
    * Previous peer-tag schema, kept until the next reporting cycle.
@@ -407,9 +414,6 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
       // ignoredResources is fixed for the lifetime of the aggregator and typically empty; hoist the
       // check so the common case skips both the lookup and the getResourceName() call per span.
       final boolean hasIgnoredResources = !ignoredResources.isEmpty();
-      // One request per trace rather than one per span: it carries the arguments the deferred
-      // snapshot needs, and is dead by the time this method returns.
-      SnapshotRequest request = null;
       for (CoreSpan<?> span : trace) {
         boolean isTopLevel = span.isTopLevel();
         if (shouldComputeMetric(span, isTopLevel)) {
@@ -421,10 +425,7 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
             }
           }
           counted++;
-          if (request == null) {
-            request = new SnapshotRequest();
-          }
-          forceKeep |= publish(request, span, isTopLevel, peerTagSchema);
+          forceKeep |= publish(span);
         }
       }
       healthMetrics.onClientStatTraceComputed(counted, trace.size(), !forceKeep);
@@ -439,33 +440,25 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
         && span.getDurationNano() > 0;
   }
 
-  private boolean publish(
-      SnapshotRequest request, CoreSpan<?> span, boolean isTopLevel, PeerTagSchema peerTagSchema) {
-    request.span = span;
-    request.isTopLevel = isTopLevel;
-    request.peerTagSchema = peerTagSchema;
+  private boolean publish(CoreSpan<?> span) {
     // The inbox reserves a slot before calling back, so a full inbox costs nothing beyond this
     // call: none of the tag lookups, no peer/additional tag arrays, no SpanSnapshot. The old racy
     // size() >= capacity() pre-check is gone with it.
-    if (!inbox.tryPut(request)) {
+    if (!inbox.tryPut(span, snapshotProducer)) {
       healthMetrics.onStatsInboxFull();
     }
     return span.getError() > 0;
   }
 
   /**
-   * Builds a {@link SpanSnapshot} once the inbox has reserved a slot for it. Mutable and reused
-   * across the spans of one trace so deferral costs one allocation per trace, not one per span.
+   * Re-derives what the publish loop had already computed, rather than carrying it into the
+   * producer: {@code isTopLevel} is a field read on the span's context, and the peer tag schema is
+   * non-null forever once {@link #bootstrapPeerTagSchema()} has run, which {@link #publish(List)}
+   * guarantees before it reaches any span. The cost is one extra volatile read per span, and a
+   * schema change mid-trace is now visible to the spans after it rather than to the next trace.
    */
-  private final class SnapshotRequest implements Producer<InboxItem> {
-    CoreSpan<?> span;
-    boolean isTopLevel;
-    PeerTagSchema peerTagSchema;
-
-    @Override
-    public InboxItem produce() {
-      return snapshot(span, isTopLevel, peerTagSchema);
-    }
+  private InboxItem snapshotOf(CoreSpan<?> span) {
+    return snapshot(span, span.isTopLevel(), cachedPeerTagSchema);
   }
 
   private SpanSnapshot snapshot(CoreSpan<?> span, boolean isTopLevel, PeerTagSchema peerTagSchema) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ClientStatsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ClientStatsAggregator.java
@@ -16,7 +16,9 @@ import static datadog.trace.util.AgentThreadFactory.newAgentThread;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import datadog.common.queue.Queues;
+import datadog.common.queue.Producer;
+import datadog.common.queue.WorkQueue;
+import datadog.common.queue.WorkQueues;
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.communication.ddagent.SharedCommunicationObjects;
 import datadog.trace.api.Config;
@@ -39,7 +41,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import org.jctools.queues.MessagePassingQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,7 +78,7 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
 
   private final Set<String> ignoredResources;
   private final Thread thread;
-  private final MessagePassingQueue<InboxItem> inbox;
+  private final WorkQueue<InboxItem> inbox;
   private final Sink sink;
   private final MetricWriter metricWriter;
   private final Aggregator aggregator;
@@ -274,7 +275,7 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
     this.additionalTagsSchema = additionalTagsSchema;
     this.includeEndpointInMetrics = includeEndpointInMetrics;
     this.otlpStatsExportEnabled = metricWriter instanceof OtlpStatsMetricWriter;
-    this.inbox = Queues.mpscArrayQueue(queueSize);
+    this.inbox = WorkQueues.createMpscQueue(queueSize);
     this.features = features;
     this.healthMetrics = healthMetric;
     this.sink = sink;
@@ -346,7 +347,7 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
     boolean published;
     int attempts = 0;
     do {
-      published = inbox.offer(REPORT);
+      published = inbox.tryPut(REPORT);
       ++attempts;
     } while (!published && attempts < 10);
     if (!published) {
@@ -373,7 +374,7 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
     ReportSignal reportSignal = new ReportSignal();
     boolean published = false;
     while (thread.isAlive() && !published) {
-      published = inbox.offer(reportSignal);
+      published = inbox.tryPut(reportSignal);
       if (!published) {
         try {
           Thread.sleep(10);
@@ -406,6 +407,9 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
       // ignoredResources is fixed for the lifetime of the aggregator and typically empty; hoist the
       // check so the common case skips both the lookup and the getResourceName() call per span.
       final boolean hasIgnoredResources = !ignoredResources.isEmpty();
+      // One request per trace rather than one per span: it carries the arguments the deferred
+      // snapshot needs, and is dead by the time this method returns.
+      SnapshotRequest request = null;
       for (CoreSpan<?> span : trace) {
         boolean isTopLevel = span.isTopLevel();
         if (shouldComputeMetric(span, isTopLevel)) {
@@ -417,7 +421,10 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
             }
           }
           counted++;
-          forceKeep |= publish(span, isTopLevel, peerTagSchema);
+          if (request == null) {
+            request = new SnapshotRequest();
+          }
+          forceKeep |= publish(request, span, isTopLevel, peerTagSchema);
         }
       }
       healthMetrics.onClientStatTraceComputed(counted, trace.size(), !forceKeep);
@@ -432,13 +439,37 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
         && span.getDurationNano() > 0;
   }
 
-  private boolean publish(CoreSpan<?> span, boolean isTopLevel, PeerTagSchema peerTagSchema) {
-    boolean error = span.getError() > 0;
-    // size() is approximate on jctools MPSC queues but good enough for a fast-path overflow check.
-    if (inbox.size() >= inbox.capacity()) {
+  private boolean publish(
+      SnapshotRequest request, CoreSpan<?> span, boolean isTopLevel, PeerTagSchema peerTagSchema) {
+    request.span = span;
+    request.isTopLevel = isTopLevel;
+    request.peerTagSchema = peerTagSchema;
+    // The inbox reserves a slot before calling back, so a full inbox costs nothing beyond this
+    // call: none of the tag lookups, no peer/additional tag arrays, no SpanSnapshot. The old racy
+    // size() >= capacity() pre-check is gone with it.
+    if (!inbox.tryPut(request)) {
       healthMetrics.onStatsInboxFull();
-      return error;
     }
+    return span.getError() > 0;
+  }
+
+  /**
+   * Builds a {@link SpanSnapshot} once the inbox has reserved a slot for it. Mutable and reused
+   * across the spans of one trace so deferral costs one allocation per trace, not one per span.
+   */
+  private final class SnapshotRequest implements Producer<InboxItem> {
+    CoreSpan<?> span;
+    boolean isTopLevel;
+    PeerTagSchema peerTagSchema;
+
+    @Override
+    public InboxItem produce() {
+      return snapshot(span, isTopLevel, peerTagSchema);
+    }
+  }
+
+  private SpanSnapshot snapshot(CoreSpan<?> span, boolean isTopLevel, PeerTagSchema peerTagSchema) {
+    boolean error = span.getError() > 0;
     // Extract HTTP method and endpoint only if the feature is enabled
     String httpMethod = null;
     String httpEndpoint = null;
@@ -503,11 +534,7 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
             grpcStatusCode,
             additionalTagValues,
             tagAndDuration);
-    if (!inbox.offer(snapshot)) {
-      healthMetrics.onStatsInboxFull();
-    }
-    // force keep keys if there are errors
-    return error;
+    return snapshot;
   }
 
   /** Returns the first non-null span tag among {@code keys}, in order, or {@code null} if none. */
@@ -679,7 +706,7 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
     if (null != cancellation) {
       cancellation.cancel();
     }
-    inbox.offer(STOP);
+    inbox.tryPut(STOP);
   }
 
   @Override
@@ -732,7 +759,7 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
       // the aggregator drains existing snapshots and ships them on the next report cycle; the
       // sink rejects that payload and fires DOWNGRADED again, which retries disable() against a
       // now-empty inbox. Worst case: one extra reporting cycle of stale data.
-      inbox.offer(CLEAR);
+      inbox.tryPut(CLEAR);
     }
   }
 
@@ -746,6 +773,6 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
 
   @VisibleForTesting
   boolean isEmpty() {
-    return inbox.isEmpty();
+    return inbox.size() == 0;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ClientStatsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ClientStatsAggregator.java
@@ -382,7 +382,10 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
     // Try to send the report signal
     ReportSignal reportSignal = new ReportSignal();
     boolean published = false;
-    while (thread.isAlive() && !published) {
+    // isClosed() as well as isAlive(): the inbox closes the moment STOP is taken, which is
+    // strictly before the thread finishes exiting, so this stops sleeping through that window
+    // waiting on a signal that can no longer be admitted.
+    while (thread.isAlive() && !inbox.isClosed() && !published) {
       published = inbox.tryPut(reportSignal);
       if (!published) {
         try {
@@ -404,7 +407,12 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
   public boolean publish(List<? extends CoreSpan<?>> trace) {
     boolean forceKeep = false;
     int counted = 0;
-    if (statsExportEnabled()) {
+    // Closed before enabled: closed is a volatile read, where statsExportEnabled() can reach into
+    // feature discovery. Once the aggregator thread has taken STOP the inbox refuses everything,
+    // so asking once here is the whole publish path after shutdown -- rather than a capacity's
+    // worth of snapshots built for a consumer that has already exited, followed by an unbounded
+    // run of inbox-full reports for a queue nobody is draining.
+    if (!inbox.isClosed() && statsExportEnabled()) {
       // Producer-side fast path: one volatile read and use whatever schema is currently cached.
       // The aggregator thread keeps this schema in sync with feature discovery in
       // resetCardinalityHandlers(). The only producer-side rebuild is the one-time bootstrap on
@@ -446,6 +454,10 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
     // The inbox reserves a slot before calling back, so a full inbox costs nothing beyond this
     // call: none of the tag lookups, no peer/additional tag arrays, no SpanSnapshot. The old racy
     // size() >= capacity() pre-check is gone with it.
+    //
+    // A refusal is read as capacity rather than closure because the caller checked isClosed() once
+    // for the trace. A close landing mid-trace mis-attributes that trace's remaining spans, which
+    // is worth not re-reading the flag per span.
     if (!inbox.tryPut(span, peerTagSchema, snapshotProducer)) {
       healthMetrics.onStatsInboxFull();
     }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ClientStatsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ClientStatsAggregator.java
@@ -112,13 +112,22 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
   private volatile PeerTagSchema cachedPeerTagSchema;
 
   /**
-   * Builds the snapshot for a span once the inbox has reserved a slot for it. Bound to this
-   * aggregator once, at construction, so admission costs no allocation at all: the span and the
-   * schema the publish loop hoisted are the two contexts, and everything else the snapshot needs is
-   * reachable from this aggregator.
+   * Builds the snapshot for a span once the inbox has reserved a place for it, or declines the span
+   * if it is not one metrics are computed for. Bound to this aggregator once, at construction, so
+   * admission costs no allocation at all: the span and the schema the publish loop hoisted are the
+   * two contexts, and everything else the snapshot needs is reachable from this aggregator.
+   *
+   * <p>The eligibility test runs here as well as in the first pass of {@link #publish(List)},
+   * because the inbox walks the trace itself and has no way to be handed a filtered view of it
+   * without materialising one. Four field reads a second time is the price of not allocating a list
+   * per trace, and the reason the decision pass can stay separate from the admission pass.
    */
   private final BiContextualProducer<CoreSpan<?>, PeerTagSchema, InboxItem> snapshotProducer =
-      this::snapshot;
+      this::snapshotIfEligible;
+
+  private InboxItem snapshotIfEligible(CoreSpan<?> span, PeerTagSchema peerTagSchema) {
+    return shouldComputeMetric(span, span.isTopLevel()) ? snapshot(span, peerTagSchema) : null;
+  }
 
   /**
    * Previous peer-tag schema, kept until the next reporting cycle.
@@ -424,21 +433,38 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
       // ignoredResources is fixed for the lifetime of the aggregator and typically empty; hoist the
       // check so the common case skips both the lookup and the getResourceName() call per span.
       final boolean hasIgnoredResources = !ignoredResources.isEmpty();
+      // Two passes, because this loop answers two questions with different scopes. counted and
+      // forceKeep are about the trace: every eligible span contributes, whether or not the inbox
+      // had room for it. Admission is about the inbox: only the spans there was room for. Fused
+      // into one pass they read as one thing; separated, each pass says what it is for.
+      int limit = trace.size();
+      int position = 0;
       for (CoreSpan<?> span : trace) {
-        boolean isTopLevel = span.isTopLevel();
-        if (shouldComputeMetric(span, isTopLevel)) {
+        if (shouldComputeMetric(span, span.isTopLevel())) {
           if (hasIgnoredResources) {
             final CharSequence resourceName = span.getResourceName();
             if (resourceName != null && ignoredResources.contains(resourceName.toString())) {
               // skip publishing all children
+              limit = position;
               break;
             }
           }
           counted++;
-          forceKeep |= publish(span, peerTagSchema);
+          forceKeep |= span.getError() > 0;
         }
+        position++;
       }
       healthMetrics.onClientStatTraceComputed(counted, trace.size(), !forceKeep);
+      // The inbox reserves a place before calling back, so a full inbox costs nothing beyond the
+      // claim: none of the tag lookups, no peer/additional tag arrays, no SpanSnapshot. Ineligible
+      // spans are declined by the producer, which is not a drop and not counted as admitted --
+      // so counted minus admitted is exactly the eligible spans that did not fit.
+      List<? extends CoreSpan<?>> admissible =
+          limit == trace.size() ? trace : trace.subList(0, limit);
+      int admitted = inbox.tryPutBatch(admissible, peerTagSchema, snapshotProducer);
+      for (int refused = counted - admitted; refused > 0; refused--) {
+        healthMetrics.onStatsInboxFull();
+      }
     }
     return forceKeep;
   }
@@ -448,20 +474,6 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
         && span.getLongRunningVersion()
             <= 0 // either not long-running or unpublished long-running span
         && span.getDurationNano() > 0;
-  }
-
-  private boolean publish(CoreSpan<?> span, PeerTagSchema peerTagSchema) {
-    // The inbox reserves a slot before calling back, so a full inbox costs nothing beyond this
-    // call: none of the tag lookups, no peer/additional tag arrays, no SpanSnapshot. The old racy
-    // size() >= capacity() pre-check is gone with it.
-    //
-    // A refusal is read as capacity rather than closure because the caller checked isClosed() once
-    // for the trace. A close landing mid-trace mis-attributes that trace's remaining spans, which
-    // is worth not re-reading the flag per span.
-    if (!inbox.tryPut(span, peerTagSchema, snapshotProducer)) {
-      healthMetrics.onStatsInboxFull();
-    }
-    return span.getError() > 0;
   }
 
   /**

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ClientStatsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ClientStatsAggregator.java
@@ -761,8 +761,13 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
     }
   }
 
+  /**
+   * Whether the aggregator thread has taken everything the inbox held. Named for consumption rather
+   * than contents: {@code size()} counts capacity in use, which includes any place claimed but not
+   * yet filled, so "drained" is the question this can actually answer.
+   */
   @VisibleForTesting
-  boolean isEmpty() {
+  boolean isDrained() {
     return inbox.size() == 0;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/metrics/ClientStatsAggregator.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/metrics/ClientStatsAggregator.java
@@ -16,7 +16,7 @@ import static datadog.trace.util.AgentThreadFactory.newAgentThread;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import datadog.common.queue.ContextualProducer;
+import datadog.common.queue.BiContextualProducer;
 import datadog.common.queue.WorkQueue;
 import datadog.common.queue.WorkQueues;
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
@@ -113,10 +113,12 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
 
   /**
    * Builds the snapshot for a span once the inbox has reserved a slot for it. Bound to this
-   * aggregator once, at construction, so admission costs no allocation at all: the span is the
-   * context, and everything else the snapshot needs is reachable from one or the other.
+   * aggregator once, at construction, so admission costs no allocation at all: the span and the
+   * schema the publish loop hoisted are the two contexts, and everything else the snapshot needs is
+   * reachable from this aggregator.
    */
-  private final ContextualProducer<CoreSpan<?>, InboxItem> snapshotProducer = this::snapshotOf;
+  private final BiContextualProducer<CoreSpan<?>, PeerTagSchema, InboxItem> snapshotProducer =
+      this::snapshot;
 
   /**
    * Previous peer-tag schema, kept until the next reporting cycle.
@@ -425,7 +427,7 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
             }
           }
           counted++;
-          forceKeep |= publish(span);
+          forceKeep |= publish(span, peerTagSchema);
         }
       }
       healthMetrics.onClientStatTraceComputed(counted, trace.size(), !forceKeep);
@@ -440,28 +442,23 @@ public final class ClientStatsAggregator implements MetricsAggregator, EventList
         && span.getDurationNano() > 0;
   }
 
-  private boolean publish(CoreSpan<?> span) {
+  private boolean publish(CoreSpan<?> span, PeerTagSchema peerTagSchema) {
     // The inbox reserves a slot before calling back, so a full inbox costs nothing beyond this
     // call: none of the tag lookups, no peer/additional tag arrays, no SpanSnapshot. The old racy
     // size() >= capacity() pre-check is gone with it.
-    if (!inbox.tryPut(span, snapshotProducer)) {
+    if (!inbox.tryPut(span, peerTagSchema, snapshotProducer)) {
       healthMetrics.onStatsInboxFull();
     }
     return span.getError() > 0;
   }
 
   /**
-   * Re-derives what the publish loop had already computed, rather than carrying it into the
-   * producer: {@code isTopLevel} is a field read on the span's context, and the peer tag schema is
-   * non-null forever once {@link #bootstrapPeerTagSchema()} has run, which {@link #publish(List)}
-   * guarantees before it reaches any span. The cost is one extra volatile read per span, and a
-   * schema change mid-trace is now visible to the spans after it rather than to the next trace.
+   * The schema rides along as the second context so the publish loop can keep reading it once per
+   * trace rather than once per span, which is what it did before admission became a callback.
+   * {@code isTopLevel} needs no such carriage: it is a field read on the span itself.
    */
-  private InboxItem snapshotOf(CoreSpan<?> span) {
-    return snapshot(span, span.isTopLevel(), cachedPeerTagSchema);
-  }
-
-  private SpanSnapshot snapshot(CoreSpan<?> span, boolean isTopLevel, PeerTagSchema peerTagSchema) {
+  private SpanSnapshot snapshot(CoreSpan<?> span, PeerTagSchema peerTagSchema) {
+    boolean isTopLevel = span.isTopLevel();
     boolean error = span.getError() > 0;
     // Extract HTTP method and endpoint only if the feature is enabled
     String httpMethod = null;

--- a/dd-trace-core/src/test/java/datadog/trace/common/metrics/ClientStatsAggregatorInboxFullTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/metrics/ClientStatsAggregatorInboxFullTest.java
@@ -4,6 +4,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -15,10 +16,9 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 /**
- * Coverage for the inbox-full fast-path in {@code ClientStatsAggregator.publish}: when the
- * producer-side inbox is at capacity, the next {@code publish} call short-circuits before any tag
- * extraction or {@code SpanSnapshot} allocation and reports {@code onStatsInboxFull()} to health
- * metrics.
+ * Coverage for publishing into a full inbox: the {@link datadog.common.queue.WorkQueue} reserves a
+ * slot before it calls back, so a rejected span costs no tag extraction and no {@code SpanSnapshot}
+ * allocation, and the rejection is reported to health metrics.
  */
 class ClientStatsAggregatorInboxFullTest {
 
@@ -31,10 +31,9 @@ class ClientStatsAggregatorInboxFullTest {
     when(features.supportsMetrics()).thenReturn(true);
     when(features.peerTags()).thenReturn(Collections.<String>emptySet());
 
-    // Small inbox; jctools MPSC array queue rounds up to the next power of two, so use a power of
+    // Small inbox; the MPSC array backing rounds up to the next power of two, so use a power of
     // two directly. Note: we deliberately do NOT call aggregator.start() so the consumer thread
-    // never drains -- snapshots accumulate in the inbox until capacity, then the next publish hits
-    // the size-vs-capacity fast path.
+    // never drains -- snapshots accumulate in the inbox until capacity, then admission rejects.
     int queueSize = 8;
     ClientStatsAggregator aggregator =
         new ClientStatsAggregator(
@@ -49,13 +48,51 @@ class ClientStatsAggregatorInboxFullTest {
             SECONDS,
             /* includeEndpointInMetrics */ false);
 
-    // Publish well past capacity. The first `queueSize` calls land in the inbox; subsequent calls
-    // see size >= capacity and hit the fast path.
+    // Publish well past capacity. The first `queueSize` calls land in the inbox; the rest are
+    // rejected.
     for (int i = 0; i < queueSize * 4; i++) {
       aggregator.publish(Collections.<CoreSpan<?>>singletonList(metricsEligibleSpan()));
     }
 
     verify(healthMetrics, atLeastOnce()).onStatsInboxFull();
+    aggregator.close();
+  }
+
+  /** The point of the reserve-first admission: a rejected span is never turned into a snapshot. */
+  @Test
+  void publishBuildsNoSnapshotOnceInboxIsAtCapacity() {
+    HealthMetrics healthMetrics = mock(HealthMetrics.class);
+    MetricWriter writer = mock(MetricWriter.class);
+    Sink sink = mock(Sink.class);
+    DDAgentFeaturesDiscovery features = mock(DDAgentFeaturesDiscovery.class);
+    when(features.supportsMetrics()).thenReturn(true);
+    when(features.peerTags()).thenReturn(Collections.<String>emptySet());
+
+    int queueSize = 8;
+    ClientStatsAggregator aggregator =
+        new ClientStatsAggregator(
+            Collections.<String>emptySet(),
+            features,
+            healthMetrics,
+            sink,
+            writer,
+            /* maxAggregates */ 16,
+            queueSize,
+            /* reportingInterval */ 10,
+            SECONDS,
+            /* includeEndpointInMetrics */ false);
+
+    for (int i = 0; i < queueSize; i++) {
+      aggregator.publish(Collections.<CoreSpan<?>>singletonList(metricsEligibleSpan()));
+    }
+
+    // A fresh span published into the now-full inbox: only the eligibility checks should touch it.
+    CoreSpan<?> rejected = metricsEligibleSpan();
+    aggregator.publish(Collections.<CoreSpan<?>>singletonList(rejected));
+
+    verify(rejected, never()).getServiceName();
+    verify(rejected, never()).getOperationName();
+    verify(rejected, never()).getSpanKindString();
     aggregator.close();
   }
 

--- a/dd-trace-core/src/test/java/datadog/trace/common/metrics/ClientStatsAggregatorInboxFullTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/metrics/ClientStatsAggregatorInboxFullTest.java
@@ -2,9 +2,12 @@ package datadog.trace.common.metrics;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -16,9 +19,13 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 /**
- * Coverage for publishing into a full inbox: the {@link datadog.common.queue.WorkQueue} reserves a
- * slot before it calls back, so a rejected span costs no tag extraction and no {@code SpanSnapshot}
- * allocation, and the rejection is reported to health metrics.
+ * Coverage for publishing into an inbox that refuses admission, which happens for two reasons: it
+ * is at capacity, or the aggregator has stopped and closed it.
+ *
+ * <p>Either way the {@link datadog.common.queue.WorkQueue} reserves a slot before it calls back, so
+ * a rejected span costs no tag extraction and no {@code SpanSnapshot} allocation. A capacity
+ * refusal is reported to health metrics; a closed inbox is not reported at all, because publishing
+ * to a stopped aggregator is not a pressure signal.
  */
 class ClientStatsAggregatorInboxFullTest {
 
@@ -94,6 +101,58 @@ class ClientStatsAggregatorInboxFullTest {
     verify(rejected, never()).getOperationName();
     verify(rejected, never()).getSpanKindString();
     aggregator.close();
+  }
+
+  /**
+   * Once the aggregator thread has taken STOP the inbox is closed, and that closed flag is the only
+   * thing publish reads for the whole trace -- no cached-schema read, no per-span eligibility
+   * checks, no health-metric traffic.
+   *
+   * <p>What this pins is the reason the stopped state lives in the queue rather than beside it.
+   * When it was a private flag on the drainer, producers could not see it: they went on building a
+   * capacity's worth of snapshots for a consumer that had already exited, and then reported
+   * inbox-full for the rest of the process lifetime against a queue nobody was draining.
+   */
+  @Test
+  void publishTouchesNothingOnceTheAggregatorHasStopped() {
+    HealthMetrics healthMetrics = mock(HealthMetrics.class);
+    MetricWriter writer = mock(MetricWriter.class);
+    Sink sink = mock(Sink.class);
+    DDAgentFeaturesDiscovery features = mock(DDAgentFeaturesDiscovery.class);
+    when(features.supportsMetrics()).thenReturn(true);
+    when(features.peerTags()).thenReturn(Collections.<String>emptySet());
+
+    ClientStatsAggregator aggregator =
+        new ClientStatsAggregator(
+            Collections.<String>emptySet(),
+            features,
+            healthMetrics,
+            sink,
+            writer,
+            /* maxAggregates */ 16,
+            /* queueSize */ 8,
+            /* reportingInterval */ 10,
+            SECONDS,
+            /* includeEndpointInMetrics */ false);
+
+    // start() so a thread is there to take STOP; close() posts it and joins, so by the time close()
+    // returns the thread has exited -- and the only way out of the run loop is inbox.close(). The
+    // inbox is empty and the drain loop sleeps 10ms, well inside the 800ms join.
+    aggregator.start();
+    aggregator.close();
+
+    // Anything the lifecycle itself recorded is not the subject.
+    reset(healthMetrics);
+
+    CoreSpan<?> afterStop = metricsEligibleSpan();
+    aggregator.publish(Collections.<CoreSpan<?>>singletonList(afterStop));
+
+    // getDurationNano is part of the eligibility check, which sits inside the loop: if it was not
+    // called, the refusal happened once for the trace rather than once per span.
+    verify(afterStop, never()).getDurationNano();
+    verify(afterStop, never()).getServiceName();
+    verify(healthMetrics, never()).onStatsInboxFull();
+    verify(healthMetrics, never()).onClientStatTraceComputed(anyInt(), anyInt(), anyBoolean());
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})

--- a/dd-trace-core/src/test/java/datadog/trace/common/metrics/ClientStatsAggregatorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/metrics/ClientStatsAggregatorTest.java
@@ -81,7 +81,7 @@ class ClientStatsAggregatorTest {
           Collections.singletonList(
               new SimpleSpan("", "", "", "", false, false, false, 0, 0, HTTP_OK)));
 
-      waitUntilAggregatorIsEmpty(aggregator);
+      waitUntilAggregatorIsDrained(aggregator);
       clearInvocations(sink);
       aggregator.forceReport().get(2, SECONDS);
 
@@ -2010,7 +2010,7 @@ class ClientStatsAggregatorTest {
       verify(writer, times(1)).finishBucket();
 
       // second cycle - no updates at all
-      waitUntilAggregatorIsEmpty(aggregator);
+      waitUntilAggregatorIsDrained(aggregator);
       clearInvocations(writer);
       aggregator.forceReport().get(2, SECONDS);
 
@@ -2858,10 +2858,10 @@ class ClientStatsAggregatorTest {
     }
   }
 
-  private void waitUntilAggregatorIsEmpty(ClientStatsAggregator aggregator)
+  private void waitUntilAggregatorIsDrained(ClientStatsAggregator aggregator)
       throws InterruptedException {
     int i = 0;
-    while (!aggregator.isEmpty() && i++ < 100) {
+    while (!aggregator.isDrained() && i++ < 100) {
       Thread.sleep(10);
     }
   }


### PR DESCRIPTION
Stacked on #12313. **Trial branch — not a merge candidate as it stands.** Its purpose is to give #12313 a real caller, so the API is reviewed against use rather than on its own terms.

Client-side stats is currently the *only* prospective adopter of `WorkQueue` anywhere in the tree: every other queue user (`TraceProcessingWorker`, `SpanSamplingWorker`, `PendingTraceBuffer`, `OkHttpSink`, `DefaultDataStreamsMonitoring`, `LLMObsIntakeWorker`, `BuildIdCollector`, both feature-flagging writers) imports only `Queues` or `MessagePassingBlockingQueue`, i.e. the raw jctools factory. So this branch is the entirety of the evidence that #12313's surface is usable.

## What it exercises

| `WorkQueue` member | exercised here |
|---|---|
| `tryPut(element)` | ✔ control signals (STOP / REPORT / CLEAR) |
| `tryPutBatch(source, context, producer)` | ✔ the publish path |
| `process(limit, consumer)` | ✔ the aggregator drain loop |
| `close` / `isClosed` / `size` / `dropped` | ✔ |
| `tryPutBatch(Collection)`, `tryPutBatch(T...)` | ✘ |
| `RejectHandler` overload | ✘ |
| `tryReserve` / `Reservation` | ✘ |
| `RetryStrategy` / `RetryQueue` / `MaxRetries`, `processOrRetry` / `processOrHandle` | ✘ |

The unexercised rows are the honest reason this PR exists.

## The commits

1. **Run client-side stats through WorkQueue** — replaces the hand-rolled jctools inbox.
2. **Bind one producer per aggregator instead of one per trace** — `snapshotProducer` becomes a non-capturing bound-once field, so admission allocates nothing.
3. **Carry the hoisted peer tag schema as a second context** — the schema is read once per trace, not once per span; this is what `BiContextualProducer` exists for.
4. **Drain the inbox in one batched pass again** — restores the old jctools `drain(size())` shape.
5. **Rename the drain barrier to isDrained.**
6. **Let the inbox hold the stopped state instead of the drainer** — `Drainer.stopped` is deleted; STOP calls `inbox.close()`, and the run loop and drainer guards read that one flag. Also makes `publish(List)` ask `isClosed()` once per trace before `statsExportEnabled()`, so post-shutdown publishing costs one volatile read instead of a capacity's worth of snapshots built for a consumer that has already exited.
7. **Split the publish loop into a decision pass and an admission pass** — the one to look at. See below.

## On the last commit: it works, and I don't think it's an improvement

`publish(List)` was one fused loop doing three jobs — filter spans, accumulate `counted` / `forceKeep`, admit. `tryPutBatch` means the queue owns the admission walk, and the queue stops walking when it runs out of room. Two of those jobs need every eligible span regardless of admission, and the ignored-resource case is a `break` that a producer returning `null` cannot express. So using `tryPutBatch` at all forces two passes; there is no lighter version.

**What it gets right:** ineligible spans are *declined* (the producer returns `null`), which is neither an admission nor a drop — so `counted - admitted` is exactly the eligible spans that did not fit, which is precisely what `onStatsInboxFull()` wants. A rejected-elements return could not have given that, because a place is claimed before the producer is asked, so a full queue cannot tell a genuine refusal from an element the producer would have declined. That is why #12313's transforming form returns a count.

**What it costs:** +34/−22 for the same three jobs. Twelve fused lines become thirty unfused ones, plus `limit`/`position` index bookkeeping, a `subList` ternary, a loop to report a metric that used to be one inline call, and a duplicated eligibility test in `snapshotIfEligible` that has to stay in agreement with the first pass with nothing enforcing it. The fusion was the compression.

**Latent, not a regression:** `inbox.dropped()` now over-counts, because an ineligible span past the fill point claims a place and fails before the producer can decline it. Nothing reads `dropped()` in `dd-trace-core` today.

So commit 7 is offered as a thing to look at, not a thing to agree with. Reverting it leaves commits 1–6, which stand on their own.

## Verification

`:dd-trace-core:test --tests 'datadog.trace.common.metrics.*'` — 151 tests, 0 failures, no test changed by commit 7. `:utils:queue-utils:test` — 84 tests. `spotlessCheck` clean on both modules.
