### PR TITLE
Abstract OT-Baggage Tests

### DIFF
--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/AbstractBaggageLimitsTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/AbstractBaggageLimitsTest.java
@@ -1,0 +1,111 @@
+package datadog.trace.core.propagation;
+
+import static datadog.trace.api.config.TracerConfig.TRACE_BAGGAGE_MAX_BYTES;
+import static datadog.trace.api.config.TracerConfig.TRACE_BAGGAGE_MAX_ITEMS;
+import static datadog.trace.bootstrap.instrumentation.api.ContextVisitors.stringValuesMap;
+import static datadog.trace.core.propagation.HttpCodecTestHelper.baggageItems;
+import static datadog.trace.core.propagation.HttpCodecTestHelper.generateBaggageItems;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.bootstrap.instrumentation.api.TagContext;
+import datadog.trace.test.junit.utils.config.WithConfig;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Behavior contract for the baggage limits enforced by {@link ContextInterpreter#addBaggageItem}.
+ * The limits are applied after the propagation style has parsed the key and value, so they are
+ * style independent: every codec carrying caller baggage runs this suite as a {@code @Nested} class
+ * of its extractor test, supplying only the wire format.
+ */
+abstract class AbstractBaggageLimitsTest {
+
+  /** Returns the extractor under test, built by the enclosing extractor test. */
+  protected abstract HttpCodec.Extractor extractor();
+
+  /**
+   * Returns the given baggage items, in order, in this style's wire format. A repeated key must be
+   * spelled so that the style reads it back as the same baggage key.
+   */
+  protected abstract Map<String, String> baggageHeaders(List<Entry<String, String>> items);
+
+  /** Returns the headers carrying {@code itemCount} generated baggage items. */
+  protected final Map<String, String> generateBaggageHeaders(int itemCount) {
+    return baggageHeaders(generateBaggageItems(itemCount));
+  }
+
+  /**
+   * Extracts the given headers and returns the baggage of the resulting context. Headers carrying
+   * nothing but baggage create no context at all once every item is dropped, which is reported as
+   * empty baggage rather than as a missing context.
+   */
+  protected final Map<String, String> extractBaggage(Map<String, String> headers) {
+    TagContext context = this.extractor().extract(headers, stringValuesMap());
+    return context == null ? emptyMap() : context.getBaggage();
+  }
+
+  @Test
+  @WithConfig(key = TRACE_BAGGAGE_MAX_ITEMS, value = "3")
+  void stopsAtItemLimit() {
+    assertEquals(3, extractBaggage(generateBaggageHeaders(50)).size());
+  }
+
+  @Test
+  @WithConfig(key = TRACE_BAGGAGE_MAX_BYTES, value = "24")
+  void stopsAtByteLimit() {
+    // with single digit indices each stored item is "keyN" + "valueN" = 10 bytes, so 2 fit in 24
+    // bytes and a third would take the total to 30
+    assertEquals(2, extractBaggage(generateBaggageHeaders(10)).size());
+  }
+
+  @Test
+  @WithConfig(key = TRACE_BAGGAGE_MAX_BYTES, value = "24")
+  @WithConfig(key = TRACE_BAGGAGE_MAX_ITEMS, value = "2")
+  void chargesRepeatedKeyOnce() {
+    Map<String, String> baggage =
+        extractBaggage(
+            baggageHeaders(baggageItems("key0", "val0", "key0", "val0", "a", "0123456789")));
+
+    Map<String, String> expected = new HashMap<>();
+    expected.put("key0", "val0");
+    expected.put("a", "0123456789");
+    assertEquals(expected, baggage);
+  }
+
+  @Test
+  @WithConfig(key = TRACE_BAGGAGE_MAX_BYTES, value = "8")
+  void chargesEncodedValueSize() {
+    // the budget is charged before decoding, so the 9 character raw value does not fit
+    Map<String, String> baggage =
+        extractBaggage(baggageHeaders(baggageItems("a", "b", "c", "%E2%99%A5")));
+
+    assertEquals(singletonMap("a", "b"), baggage);
+  }
+
+  @Test
+  @WithConfig(key = TRACE_BAGGAGE_MAX_BYTES, value = "3")
+  void chargesLiteralUtf8ByCharacterCount() {
+    // "a" + "♥" is 2 characters, so the 2 characters of "b" + "c" no longer fit
+    Map<String, String> baggage = extractBaggage(baggageHeaders(baggageItems("a", "♥", "b", "c")));
+
+    assertEquals(singletonMap("a", "♥"), baggage);
+  }
+
+  @Test
+  @WithConfig(key = TRACE_BAGGAGE_MAX_ITEMS, value = "0")
+  void dropsAllBaggageWhenItemLimitIsZero() {
+    assertTrue(extractBaggage(generateBaggageHeaders(10)).isEmpty());
+  }
+
+  @Test
+  @WithConfig(key = TRACE_BAGGAGE_MAX_BYTES, value = "0")
+  void dropsAllBaggageWhenByteLimitIsZero() {
+    assertTrue(extractBaggage(generateBaggageHeaders(10)).isEmpty());
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/AbstractOTBaggageTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/AbstractOTBaggageTest.java
@@ -70,10 +70,10 @@ abstract class AbstractOTBaggageTest {
   void chargesRepeatedKeyOnce() {
     Map<String, String> baggage =
         extractBaggage(
-            baggageHeaders(baggageItems("key0", "val0", "key0", "val0", "a", "0123456789")));
+            baggageHeaders(baggageItems("key0", "val0", "a", "0123456789", "key0", "val1")));
 
     Map<String, String> expected = new HashMap<>();
-    expected.put("key0", "val0");
+    expected.put("key0", "val1");
     expected.put("a", "0123456789");
     assertEquals(expected, baggage);
   }

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/AbstractOTBaggageTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/AbstractOTBaggageTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
  * style independent: every codec carrying caller baggage runs this suite as a {@code @Nested} class
  * of its extractor test, supplying only the wire format.
  */
-abstract class AbstractBaggageLimitsTest {
+abstract class AbstractOTBaggageTest {
 
   /** Returns the extractor under test, built by the enclosing extractor test. */
   protected abstract HttpCodec.Extractor extractor();

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/DatadogHttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/DatadogHttpExtractorTest.java
@@ -1,7 +1,6 @@
 package datadog.trace.core.propagation;
 
 import static datadog.trace.api.config.TracerConfig.REQUEST_HEADER_TAGS_COMMA_ALLOWED;
-import static datadog.trace.api.config.TracerConfig.TRACE_BAGGAGE_MAX_BYTES;
 import static datadog.trace.api.config.TracerConfig.TRACE_BAGGAGE_MAX_ITEMS;
 import static datadog.trace.api.sampling.PrioritySampling.UNSET;
 import static datadog.trace.bootstrap.instrumentation.api.ContextVisitors.stringValuesMap;
@@ -12,13 +11,16 @@ import static datadog.trace.core.propagation.DatadogHttpCodec.SAMPLING_PRIORITY_
 import static datadog.trace.core.propagation.DatadogHttpCodec.SPAN_ID_KEY;
 import static datadog.trace.core.propagation.DatadogHttpCodec.TRACE_ID_KEY;
 import static datadog.trace.core.propagation.HttpCodecTestHelper.headers;
+import static datadog.trace.core.propagation.HttpCodecTestHelper.otBaggageHeaders;
 import static datadog.trace.test.junit.utils.converter.TraceIdConverter.TRACE_ID_MAX_PLUS_1;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DD128bTraceId;
@@ -33,9 +35,11 @@ import datadog.trace.test.junit.utils.config.WithConfig;
 import datadog.trace.test.junit.utils.converter.PrioritySamplingConverter;
 import datadog.trace.test.junit.utils.converter.TraceIdConverter;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.Supplier;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.converter.ConvertWith;
@@ -329,116 +333,34 @@ class DatadogHttpExtractorTest extends AbstractHttpExtractorTest {
   }
 
   @Test
-  @WithConfig(key = TRACE_BAGGAGE_MAX_ITEMS, value = "3")
-  void extractOtBaggageStopsAtItemLimit() {
-    Map<String, String> headers = otBaggageHeaders(50);
-    headers.put(SOME_CUSTOM_BAGGAGE_HEADER, "mappedBaggageValue");
-
-    TagContext context = this.extractor.extract(headers, stringValuesMap());
-
-    assertEquals(3, context.getBaggage().size());
-  }
-
-  @Test
   @WithConfig(key = TRACE_BAGGAGE_MAX_ITEMS, value = "1")
-  void extractMappedBaggageStopsAtItemLimit() {
-    Map<String, String> headers = otBaggageHeaders(50);
-    headers.put(SOME_CUSTOM_BAGGAGE_HEADER, "mappedBaggageValue");
+  void extractMappedBaggageIsSubjectToTheItemLimit() {
+    // mapped baggage shares the budget with the baggage read off the wire, so only one of the two
+    // mapped headers is kept
+    Map<String, String> headers =
+        headers(
+            SOME_CUSTOM_BAGGAGE_HEADER, "mappedBaggageValue",
+            SOME_CUSTOM_BAGGAGE_HEADER_2, "otherMappedBaggageValue");
 
     TagContext context = this.extractor.extract(headers, stringValuesMap());
 
     assertEquals(1, context.getBaggage().size());
+    assertTrue(
+        asList(SOME_BAGGAGE, SOME_CASE_SENSITIVE_BAGGAGE)
+            .containsAll(context.getBaggage().keySet()));
   }
 
-  @Test
-  @WithConfig(key = TRACE_BAGGAGE_MAX_BYTES, value = "24")
-  void extractOtBaggageStopsAtByteLimit() {
-    // with single digit indices each stored item is "keyN" + "valueN" = 10 bytes, so 2 fit in 24
-    // bytes and a third would take the total to 30
-    TagContext context = this.extractor.extract(otBaggageHeaders(10), stringValuesMap());
-
-    assertEquals(2, context.getBaggage().size());
-  }
-
-  @Test
-  @WithConfig(key = TRACE_BAGGAGE_MAX_BYTES, value = "24")
-  void extractOtBaggageChargesRepeatedKeyOnce() {
-    // headers are visited in insertion order, so the duplicate key is seen before the last item
-    Map<String, String> headers = new LinkedHashMap<>();
-    // "key0" + "val0" is 8 bytes, and the duplicate refunds the value it replaces, so the total
-    // stays at 8 rather than doubling
-    headers.put(OT_BAGGAGE_PREFIX + "key0", "val0");
-    headers.put(OT_BAGGAGE_PREFIX + "KEY0", "val0");
-    // leaving room for these 11 bytes, taking the total to 19
-    headers.put(OT_BAGGAGE_PREFIX + "a", "0123456789");
-
-    TagContext context = this.extractor.extract(headers, stringValuesMap());
-
-    Map<String, String> expected = new HashMap<>();
-    expected.put("key0", "val0");
-    expected.put("a", "0123456789");
-    assertEquals(expected, context.getBaggage());
-  }
-
-  @Test
-  @WithConfig(key = TRACE_BAGGAGE_MAX_ITEMS, value = "1")
-  void extractOtBaggageAllowsReplacementAtItemLimit() {
-    Map<String, String> headers = new LinkedHashMap<>();
-    headers.put(OT_BAGGAGE_PREFIX + "key0", "old");
-    headers.put(OT_BAGGAGE_PREFIX + "KEY0", "replacement");
-
-    TagContext context = this.extractor.extract(headers, stringValuesMap());
-
-    assertEquals(singletonMap("key0", "replacement"), context.getBaggage());
-  }
-
-  @Test
-  @WithConfig(key = TRACE_BAGGAGE_MAX_BYTES, value = "24")
-  void extractOtBaggageChargesOnlyTheDeltaWhenReplacingAValue() {
-    Map<String, String> headers = new LinkedHashMap<>();
-    headers.put(OT_BAGGAGE_PREFIX + "key0", "val0"); // 8 bytes
-    // replaces the value, charging the 8 byte difference rather than another 16 bytes
-    headers.put(OT_BAGGAGE_PREFIX + "KEY0", "012345678901");
-    headers.put(OT_BAGGAGE_PREFIX + "a", "0123456"); // 8 bytes, taking the total to exactly 24
-
-    TagContext context = this.extractor.extract(headers, stringValuesMap());
-
-    Map<String, String> expected = new HashMap<>();
-    expected.put("key0", "012345678901");
-    expected.put("a", "0123456");
-    assertEquals(expected, context.getBaggage());
-  }
-
-  @Test
-  @WithConfig(key = TRACE_BAGGAGE_MAX_BYTES, value = "8")
-  void extractOtBaggageChargesEncodedValueSize() {
-    Map<String, String> headers = new LinkedHashMap<>();
-    headers.put(OT_BAGGAGE_PREFIX + "a", "b"); // 2 characters
-    headers.put(OT_BAGGAGE_PREFIX + "c", "%E2%99%A5"); // 1 character key + 9 character raw value
-
-    TagContext context = this.extractor.extract(headers, stringValuesMap());
-
-    assertEquals(singletonMap("a", "b"), context.getBaggage());
-  }
-
-  @Test
-  @WithConfig(key = TRACE_BAGGAGE_MAX_BYTES, value = "3")
-  void extractOtBaggageChargesLiteralUtf8ByCharacterCount() {
-    Map<String, String> headers = new LinkedHashMap<>();
-    headers.put(OT_BAGGAGE_PREFIX + "a", "♥"); // 2 characters
-    headers.put(OT_BAGGAGE_PREFIX + "b", "c"); // 2 more characters, no longer fits
-
-    TagContext context = this.extractor.extract(headers, stringValuesMap());
-
-    assertEquals(singletonMap("a", "♥"), context.getBaggage());
-  }
-
-  private static Map<String, String> otBaggageHeaders(int count) {
-    Map<String, String> headers = new HashMap<>();
-    for (int i = 0; i < count; i++) {
-      headers.put(OT_BAGGAGE_PREFIX + "key" + i, "value" + i);
+  @Nested
+  class BaggageLimits extends AbstractBaggageLimitsTest {
+    @Override
+    protected HttpCodec.Extractor extractor() {
+      return DatadogHttpExtractorTest.this.extractor;
     }
-    return headers;
+
+    @Override
+    protected Map<String, String> baggageHeaders(List<Entry<String, String>> items) {
+      return otBaggageHeaders(OT_BAGGAGE_PREFIX, items);
+    }
   }
 
   private static String asString(CharSequence cs) {

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/DatadogHttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/DatadogHttpExtractorTest.java
@@ -351,7 +351,7 @@ class DatadogHttpExtractorTest extends AbstractHttpExtractorTest {
   }
 
   @Nested
-  class BaggageLimits extends AbstractBaggageLimitsTest {
+  class BaggageLimits extends AbstractOTBaggageTest {
     @Override
     protected HttpCodec.Extractor extractor() {
       return DatadogHttpExtractorTest.this.extractor;

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/DatadogHttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/DatadogHttpExtractorTest.java
@@ -13,14 +13,12 @@ import static datadog.trace.core.propagation.DatadogHttpCodec.TRACE_ID_KEY;
 import static datadog.trace.core.propagation.HttpCodecTestHelper.headers;
 import static datadog.trace.core.propagation.HttpCodecTestHelper.otBaggageHeaders;
 import static datadog.trace.test.junit.utils.converter.TraceIdConverter.TRACE_ID_MAX_PLUS_1;
-import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.DD128bTraceId;
@@ -35,6 +33,7 @@ import datadog.trace.test.junit.utils.config.WithConfig;
 import datadog.trace.test.junit.utils.converter.PrioritySamplingConverter;
 import datadog.trace.test.junit.utils.converter.TraceIdConverter;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -335,19 +334,15 @@ class DatadogHttpExtractorTest extends AbstractHttpExtractorTest {
   @Test
   @WithConfig(key = TRACE_BAGGAGE_MAX_ITEMS, value = "1")
   void extractMappedBaggageIsSubjectToTheItemLimit() {
-    // mapped baggage shares the budget with the baggage read off the wire, so only one of the two
-    // mapped headers is kept
-    Map<String, String> headers =
-        headers(
-            SOME_CUSTOM_BAGGAGE_HEADER, "mappedBaggageValue",
-            SOME_CUSTOM_BAGGAGE_HEADER_2, "otherMappedBaggageValue");
+    // mapped baggage shares the item budget with the baggage read off the wire, so the wire item
+    // is dropped once the mapped header has claimed the only slot
+    Map<String, String> headers = new LinkedHashMap<>();
+    headers.put(SOME_CUSTOM_BAGGAGE_HEADER, "mappedBaggageValue");
+    headers.put(OT_BAGGAGE_PREFIX + "wireKey", "wireValue");
 
     TagContext context = this.extractor.extract(headers, stringValuesMap());
 
-    assertEquals(1, context.getBaggage().size());
-    assertTrue(
-        asList(SOME_BAGGAGE, SOME_CASE_SENSITIVE_BAGGAGE)
-            .containsAll(context.getBaggage().keySet()));
+    assertEquals(singletonMap(SOME_BAGGAGE, "mappedBaggageValue"), context.getBaggage());
   }
 
   @Nested

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/HaystackHttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/HaystackHttpExtractorTest.java
@@ -45,7 +45,7 @@ class HaystackHttpExtractorTest extends AbstractHttpExtractorTest {
   }
 
   @Nested
-  class BaggageLimits extends AbstractBaggageLimitsTest {
+  class BaggageLimits extends AbstractOTBaggageTest {
     @Override
     protected HttpCodec.Extractor extractor() {
       return HaystackHttpExtractorTest.this.extractor;

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/HaystackHttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/HaystackHttpExtractorTest.java
@@ -10,7 +10,9 @@ import static datadog.trace.core.propagation.HaystackHttpCodec.OT_BAGGAGE_PREFIX
 import static datadog.trace.core.propagation.HaystackHttpCodec.PARENT_ID_KEY;
 import static datadog.trace.core.propagation.HaystackHttpCodec.SPAN_ID_KEY;
 import static datadog.trace.core.propagation.HaystackHttpCodec.TRACE_ID_KEY;
+import static datadog.trace.core.propagation.HttpCodecTestHelper.generateBaggageItems;
 import static datadog.trace.core.propagation.HttpCodecTestHelper.headers;
+import static datadog.trace.core.propagation.HttpCodecTestHelper.otBaggageHeaders;
 import static datadog.trace.test.junit.utils.converter.TraceIdConverter.TRACE_ID_MAX_PLUS_1;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,8 +28,11 @@ import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.test.junit.utils.config.WithConfig;
 import datadog.trace.test.junit.utils.converter.TraceIdConverter;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.Supplier;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.converter.ConvertWith;
 import org.tabletest.junit.TableTest;
@@ -39,17 +44,17 @@ class HaystackHttpExtractorTest extends AbstractHttpExtractorTest {
     return HaystackHttpCodec.newExtractor(config, traceConfigSupplier);
   }
 
-  @Test
-  @WithConfig(key = TRACE_BAGGAGE_MAX_ITEMS, value = "3")
-  void extractBaggageStopsAtItemLimit() {
-    Map<String, String> headers = new HashMap<>();
-    for (int i = 0; i < 50; i++) {
-      headers.put(OT_BAGGAGE_PREFIX + "key" + i, "value" + i);
+  @Nested
+  class BaggageLimits extends AbstractBaggageLimitsTest {
+    @Override
+    protected HttpCodec.Extractor extractor() {
+      return HaystackHttpExtractorTest.this.extractor;
     }
 
-    TagContext context = this.extractor.extract(headers, stringValuesMap());
-
-    assertEquals(3, context.getBaggage().size());
+    @Override
+    protected Map<String, String> baggageHeaders(List<Entry<String, String>> items) {
+      return otBaggageHeaders(OT_BAGGAGE_PREFIX, items);
+    }
   }
 
   @Test
@@ -57,10 +62,8 @@ class HaystackHttpExtractorTest extends AbstractHttpExtractorTest {
   void extractKeepsHaystackIdsWhenBaggageLimitReached() {
     // the Haystack ids are recorded by the tracer for lossless injection, so caller supplied
     // Baggage-* headers must not be able to evict them by exhausting the item limit
-    Map<String, String> headers = new HashMap<>();
-    for (int i = 0; i < 50; i++) {
-      headers.put(OT_BAGGAGE_PREFIX + "key" + i, "value" + i);
-    }
+    Map<String, String> headers =
+        new HashMap<>(otBaggageHeaders(OT_BAGGAGE_PREFIX, generateBaggageItems(50)));
     headers.put(TRACE_ID_KEY, "44617461-646f-6721-0000-000000000001");
     headers.put(SPAN_ID_KEY, "44617461-646f-6721-0000-000000000002");
 

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/HttpCodecTestHelper.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/HttpCodecTestHelper.java
@@ -2,8 +2,13 @@ package datadog.trace.core.propagation;
 
 import datadog.trace.api.Config;
 import datadog.trace.api.TraceConfig;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.Supplier;
 
 /** Helper class used only for tests to bridge package-private classes */
@@ -15,6 +20,52 @@ public class HttpCodecTestHelper {
   public static HttpCodec.Extractor newW3cHttpCodecExtractor(
       Config config, Supplier<TraceConfig> traceConfigSupplier) {
     return W3CHttpCodec.newExtractor(config, traceConfigSupplier);
+  }
+
+  /**
+   * Returns the given baggage key and value pairs, in order. A key may be repeated to exercise the
+   * replacement of a value already recorded.
+   */
+  static List<Entry<String, String>> baggageItems(String... keysAndValues) {
+    List<Entry<String, String>> items = new ArrayList<>();
+    for (int i = 0; i < keysAndValues.length; i += 2) {
+      items.add(new SimpleImmutableEntry<>(keysAndValues[i], keysAndValues[i + 1]));
+    }
+    return items;
+  }
+
+  /**
+   * Returns {@code itemCount} generated baggage items, mapping {@code key0} to {@code value0}
+   * through {@code key(itemCount-1)} to {@code value(itemCount-1)}.
+   *
+   * <p>While the indices stay below 10, every item is exactly 10 characters of key plus value,
+   * which is what lets the byte limit cases state a limit as a number of items.
+   */
+  static List<Entry<String, String>> generateBaggageItems(int itemCount) {
+    List<Entry<String, String>> items = new ArrayList<>();
+    for (int i = 0; i < itemCount; i++) {
+      items.add(new SimpleImmutableEntry<>("key" + i, "value" + i));
+    }
+    return items;
+  }
+
+  /**
+   * Returns the given baggage items as one prefixed header per item, preserving order.
+   *
+   * <p>Each item needs its own header, so a repeated key is spelled by upper casing it: this only
+   * carries the same baggage key for the propagation styles that lowercase the keys they read.
+   */
+  static Map<String, String> otBaggageHeaders(String prefix, List<Entry<String, String>> items) {
+    Map<String, String> headers = new LinkedHashMap<>();
+    for (Entry<String, String> item : items) {
+      String key = item.getKey();
+      String header = prefix + (headers.containsKey(prefix + key) ? key.toUpperCase() : key);
+      if (headers.containsKey(header)) {
+        throw new IllegalArgumentException("Cannot repeat the baggage key " + key + " any further");
+      }
+      headers.put(header, item.getValue());
+    }
+    return headers;
   }
 
   static Map<String, String> headers(String... headerKeysAndValues) {

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/W3CHttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/W3CHttpExtractorTest.java
@@ -1,9 +1,8 @@
 package datadog.trace.core.propagation;
 
-import static datadog.trace.api.config.TracerConfig.TRACE_BAGGAGE_MAX_BYTES;
-import static datadog.trace.api.config.TracerConfig.TRACE_BAGGAGE_MAX_ITEMS;
 import static datadog.trace.bootstrap.instrumentation.api.ContextVisitors.stringValuesMap;
 import static datadog.trace.core.propagation.HttpCodecTestHelper.headers;
+import static datadog.trace.core.propagation.HttpCodecTestHelper.otBaggageHeaders;
 import static datadog.trace.core.propagation.W3CHttpCodec.OT_BAGGAGE_PREFIX;
 import static datadog.trace.core.propagation.W3CHttpCodec.TRACE_PARENT_KEY;
 import static datadog.trace.core.propagation.W3CHttpCodec.TRACE_STATE_KEY;
@@ -21,13 +20,15 @@ import datadog.trace.api.DDSpanId;
 import datadog.trace.api.DDTraceId;
 import datadog.trace.api.TraceConfig;
 import datadog.trace.bootstrap.instrumentation.api.TagContext;
-import datadog.trace.test.junit.utils.config.WithConfig;
 import datadog.trace.test.junit.utils.converter.PrioritySamplingConverter;
 import datadog.trace.test.junit.utils.converter.SamplingMechanismConverter;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.Supplier;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -52,32 +53,17 @@ class W3CHttpExtractorTest extends AbstractHttpExtractorTest {
     return W3CHttpCodec.newExtractor(config, traceConfigSupplier);
   }
 
-  @Test
-  @WithConfig(key = TRACE_BAGGAGE_MAX_ITEMS, value = "3")
-  void extractOtBaggageStopsAtItemLimit() {
-    Map<String, String> headers = new HashMap<>();
-    for (int i = 0; i < 50; i++) {
-      headers.put(OT_BAGGAGE_PREFIX + "key" + i, "value" + i);
+  @Nested
+  class BaggageLimits extends AbstractBaggageLimitsTest {
+    @Override
+    protected HttpCodec.Extractor extractor() {
+      return W3CHttpExtractorTest.this.extractor;
     }
 
-    TagContext context = this.extractor.extract(headers, stringValuesMap());
-
-    assertEquals(3, context.getBaggage().size());
-  }
-
-  @Test
-  @WithConfig(key = TRACE_BAGGAGE_MAX_BYTES, value = "24")
-  void extractOtBaggageStopsAtByteLimit() {
-    // with single digit indices each stored item is "keyN" + "valueN" = 10 bytes, so 2 fit in 24
-    // bytes and a third would take the total to 30
-    Map<String, String> headers = new HashMap<>();
-    for (int i = 0; i < 10; i++) {
-      headers.put(OT_BAGGAGE_PREFIX + "key" + i, "value" + i);
+    @Override
+    protected Map<String, String> baggageHeaders(List<Entry<String, String>> items) {
+      return otBaggageHeaders(OT_BAGGAGE_PREFIX, items);
     }
-
-    TagContext context = this.extractor.extract(headers, stringValuesMap());
-
-    assertEquals(2, context.getBaggage().size());
   }
 
   @TableTest({

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/W3CHttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/W3CHttpExtractorTest.java
@@ -54,7 +54,7 @@ class W3CHttpExtractorTest extends AbstractHttpExtractorTest {
   }
 
   @Nested
-  class BaggageLimits extends AbstractBaggageLimitsTest {
+  class BaggageLimits extends AbstractOTBaggageTest {
     @Override
     protected HttpCodec.Extractor extractor() {
       return W3CHttpExtractorTest.this.extractor;

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/XRayHttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/XRayHttpExtractorTest.java
@@ -37,7 +37,7 @@ class XRayHttpExtractorTest extends AbstractHttpExtractorTest {
   }
 
   @Nested
-  class BaggageLimits extends AbstractBaggageLimitsTest {
+  class BaggageLimits extends AbstractOTBaggageTest {
     @Override
     protected HttpCodec.Extractor extractor() {
       return XRayHttpExtractorTest.this.extractor;

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/XRayHttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/XRayHttpExtractorTest.java
@@ -1,9 +1,9 @@
 package datadog.trace.core.propagation;
 
-import static datadog.trace.api.config.TracerConfig.TRACE_BAGGAGE_MAX_BYTES;
 import static datadog.trace.api.config.TracerConfig.TRACE_BAGGAGE_MAX_ITEMS;
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP;
 import static datadog.trace.bootstrap.instrumentation.api.ContextVisitors.stringValuesMap;
+import static datadog.trace.core.propagation.HttpCodecTestHelper.generateBaggageItems;
 import static datadog.trace.core.propagation.HttpCodecTestHelper.headers;
 import static datadog.trace.core.propagation.XRayHttpCodec.X_AMZN_TRACE_ID;
 import static datadog.trace.core.propagation.XRayTestHelper.zeroPadId;
@@ -20,8 +20,11 @@ import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.test.junit.utils.config.WithConfig;
 import datadog.trace.test.junit.utils.converter.PrioritySamplingConverter;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.Supplier;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.converter.ConvertWith;
 import org.tabletest.junit.TableTest;
@@ -33,24 +36,17 @@ class XRayHttpExtractorTest extends AbstractHttpExtractorTest {
     return XRayHttpCodec.newExtractor(config, traceConfigSupplier);
   }
 
-  @Test
-  @WithConfig(key = TRACE_BAGGAGE_MAX_ITEMS, value = "3")
-  void extractTraceHeaderBaggageStopsAtItemLimit() {
-    TagContext context =
-        this.extractor.extract(headers(X_AMZN_TRACE_ID, baggageHeader(50)), stringValuesMap());
+  @Nested
+  class BaggageLimits extends AbstractBaggageLimitsTest {
+    @Override
+    protected HttpCodec.Extractor extractor() {
+      return XRayHttpExtractorTest.this.extractor;
+    }
 
-    assertEquals(3, context.getBaggage().size());
-  }
-
-  @Test
-  @WithConfig(key = TRACE_BAGGAGE_MAX_BYTES, value = "24")
-  void extractTraceHeaderBaggageStopsAtByteLimit() {
-    // with single digit indices each stored item is "keyN" + "valueN" = 10 bytes, so 2 fit in 24
-    // bytes and a third would take the total to 30
-    TagContext context =
-        this.extractor.extract(headers(X_AMZN_TRACE_ID, baggageHeader(9)), stringValuesMap());
-
-    assertEquals(2, context.getBaggage().size());
+    @Override
+    protected Map<String, String> baggageHeaders(List<Entry<String, String>> items) {
+      return headers(X_AMZN_TRACE_ID, traceHeader(items));
+    }
   }
 
   @Test
@@ -61,7 +57,8 @@ class XRayHttpExtractorTest extends AbstractHttpExtractorTest {
     TagContext context =
         this.extractor.extract(
             headers(
-                X_AMZN_TRACE_ID, baggageHeader(50) + ";Parent=" + zeroPadId("2") + ";Sampled=1"),
+                X_AMZN_TRACE_ID,
+                traceHeader(generateBaggageItems(50)) + ";Parent=" + zeroPadId("2") + ";Sampled=1"),
             stringValuesMap());
 
     assertEquals(3, context.getBaggage().size());
@@ -70,11 +67,12 @@ class XRayHttpExtractorTest extends AbstractHttpExtractorTest {
     assertEquals(SAMPLER_KEEP, context.getSamplingPriority());
   }
 
-  private static String baggageHeader(int itemCount) {
-    // a single X-Amzn-Trace-Id header carries an arbitrary number of `key=value` segments
+  private static String traceHeader(List<Entry<String, String>> baggage) {
+    // a single X-Amzn-Trace-Id header carries an arbitrary number of `key=value` segments, and can
+    // repeat a key outright
     StringBuilder header = new StringBuilder("Root=1-00000000-00000000").append(zeroPadId("1"));
-    for (int i = 0; i < itemCount; i++) {
-      header.append(";key").append(i).append("=value").append(i);
+    for (Entry<String, String> item : baggage) {
+      header.append(';').append(item.getKey()).append('=').append(item.getValue());
     }
     return header.toString();
   }


### PR DESCRIPTION
# What Does This Do
This PR removes the deduplication logic in OpenTracing Baggage unit tests by centralizing the test logic in `AbstractOTBaggageTest.java`. Individual propagation style tests extend this abstract test class and feed propagation style specific extractors to validate extraction behavior for its propagation style. 
# Motivation
#12303 introduced duplication of test class logic for OT Baggage.
# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
