### PR TITLE
Remove unnecessary local variable from RuntimeExecStringAdvice

### DIFF
--- a/dd-java-agent/instrumentation/java/java-lang/java-lang-1.8/src/main/java/datadog/trace/instrumentation/java/lang/RuntimeExecStringAdvice.java
+++ b/dd-java-agent/instrumentation/java/java-lang/java-lang-1.8/src/main/java/datadog/trace/instrumentation/java/lang/RuntimeExecStringAdvice.java
@@ -6,18 +6,15 @@ import net.bytebuddy.asm.Advice;
 
 class RuntimeExecStringAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
-  public static boolean beforeExec(@Advice.Argument(0) final String command) {
+  public static void beforeExec(@Advice.Argument(0) final String command) {
     if (command == null || !AgentTracer.isRegistered()) {
-      return false;
+      return;
     }
     ProcessImplInstrumentationHelpers.shiRaspCheck(command);
-    return true;
   }
 
   @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-  public static void afterExec(@Advice.Enter boolean checking) {
-    if (checking) {
-      ProcessImplInstrumentationHelpers.resetCheckShi();
-    }
+  public static void afterExec() {
+    ProcessImplInstrumentationHelpers.resetCheckShi();
   }
 }


### PR DESCRIPTION
# Motivation

Avoid potential confusion about the default value of this local variable when an exception happens during method entry.

Since we don't actually need to gate the exit advice (only the entry call) it's simpler to just remove the local variable.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [APPSEC-69939]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APPSEC-69939]: https://datadoghq.atlassian.net/browse/APPSEC-69939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ