### PR TITLE
Parse Lambda AppSec request bodies according to their content type

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
@@ -1,13 +1,17 @@
 package datadog.trace.lambda;
 
 import datadog.trace.api.appsec.MediaType;
+import datadog.trace.lambda.MultipartSplitter.Part;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.StringTokenizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,19 +28,79 @@ final class ContentTypeBodyParser {
 
   private static final Logger log = LoggerFactory.getLogger(ContentTypeBodyParser.class);
 
-  // These bound the work done in this parser only. The WAF truncates its inputs independently, so
-  // exceeding them is wasteful rather than incorrect.
+  // These bound the work done in this parser only. Exceeding any of them degrades the body to a raw
+  // string rather than dropping content, and the WAF truncates its inputs independently anyway.
   static final int MAX_DEPTH = 20;
   static final int MAX_ELEMENTS = 256;
+  static final int MAX_PARTS = 256;
+  static final int MAX_MULTIPART_SIZE = 1_000_000;
 
   private ContentTypeBodyParser() {}
 
-  /** Parses a decoded request body according to its {@code Content-Type}. */
-  static Object parseBody(final String body, final String contentType) {
-    return dispatch(body, contentType, 0);
+  /**
+   * State shared across a whole parse: the element and part allowances, and the filenames collected
+   * along the way. A multipart part may itself hold an urlencoded or multipart body, so a per-call
+   * cap would multiply across nesting levels and a per-call list would lose nested file parts.
+   */
+  static final class ParseContext {
+    private int parts = MAX_PARTS;
+    private int elements = MAX_ELEMENTS;
+
+    /** Allocated only once a file part is seen, which most bodies never do. */
+    private List<String> filenames;
+
+    int remainingParts() {
+      return parts;
+    }
+
+    void consumeParts(final int count) {
+      parts -= count;
+    }
+
+    /**
+     * @return {@code false} once the element allowance is spent
+     */
+    boolean takeElement() {
+      if (elements == 0) {
+        return false;
+      }
+      elements--;
+      return true;
+    }
+
+    void addFilename(final String filename) {
+      if (filenames == null) {
+        filenames = new ArrayList<>(2);
+      }
+      filenames.add(filename);
+    }
+
+    /**
+     * @return the filenames of the multipart file parts found, in body order, empty when there were
+     *     none
+     */
+    List<String> filenames() {
+      return filenames == null ? Collections.emptyList() : filenames;
+    }
   }
 
-  static Object dispatch(final String body, final String contentType, final int depth) {
+  /** Parses a decoded request body according to its {@code Content-Type}. */
+  static Object parseBody(final String body, final String contentType) {
+    return parseBody(body, contentType, new ParseContext());
+  }
+
+  /**
+   * Parses a decoded request body according to its {@code Content-Type}.
+   *
+   * @param context also collects the filenames of any multipart file parts found, which the caller
+   *     reports separately from the body
+   */
+  static Object parseBody(final String body, final String contentType, final ParseContext context) {
+    return dispatch(body, contentType, 0, context);
+  }
+
+  static Object dispatch(
+      final String body, final String contentType, final int depth, final ParseContext context) {
     if (body == null) {
       return null;
     }
@@ -51,11 +115,15 @@ final class ContentTypeBodyParser {
     final MediaType mediaType = MediaType.parse(contentType);
     if ("application".equals(mediaType.getType())
         && "x-www-form-urlencoded".equals(mediaType.getSubtype())) {
-      final Object parsed = parseUrlEncoded(body);
+      final Object parsed = parseUrlEncoded(body, context);
       return parsed != null ? parsed : body;
     }
-    // text/*, multipart/* and everything else stay raw strings. In particular a text/plain body of
-    // "12345" must reach the WAF as a String, not as the Double a JSON parse would produce.
+    if ("multipart".equals(mediaType.getType())) {
+      final Object parsed = parseMultipart(body, contentType, depth, context, MAX_MULTIPART_SIZE);
+      return parsed != null ? parsed : body;
+    }
+    // text/* and everything else stay raw strings. In particular a text/plain body of "12345" must
+    // reach the WAF as a String, not as the Double a JSON parse would produce.
     return body;
   }
 
@@ -63,26 +131,38 @@ final class ContentTypeBodyParser {
     if (contentType == null) {
       return false;
     }
-    final String lower = contentType.toLowerCase(Locale.ROOT);
-    return lower.contains("json") || lower.contains("javascript");
+    // Match on the type and subtype only. Parameters such as a multipart boundary are chosen by
+    // the client, so "multipart/form-data; boundary=--json" must not reach the JSON parser and
+    // thereby skip multipart parsing entirely.
+    final int semicolon = contentType.indexOf(';');
+    final String essence =
+        (semicolon == -1 ? contentType : contentType.substring(0, semicolon))
+            .toLowerCase(Locale.ROOT);
+    return essence.contains("json") || essence.contains("javascript");
   }
 
   /**
    * Parses an {@code application/x-www-form-urlencoded} body into a multimap, matching the shape
    * produced for query parameters.
    *
-   * @return the parsed parameters, or {@code null} if nothing usable was found
+   * @return the parsed parameters, or {@code null} if nothing usable was found or the body exhausts
+   *     the element allowance
    */
-  private static Map<String, List<String>> parseUrlEncoded(final String body) {
+  private static Map<String, List<String>> parseUrlEncoded(
+      final String body, final ParseContext context) {
     if (body.isEmpty()) {
       return null;
     }
     final Map<String, List<String>> parameters = new LinkedHashMap<>();
-    int pairs = 0;
     final StringTokenizer tokenizer = new StringTokenizer(body, "&");
-    while (tokenizer.hasMoreTokens() && pairs < MAX_ELEMENTS) {
+    while (tokenizer.hasMoreTokens()) {
+      if (!context.takeElement()) {
+        // Bail out rather than hand the WAF a truncated map: a parameter dropped here would be
+        // invisible to every rule, whereas the raw body can still be string-matched.
+        log.debug("Element allowance exhausted, keeping urlencoded body as a raw string");
+        return null;
+      }
       final String pair = tokenizer.nextToken();
-      pairs++;
       final int equals = pair.indexOf('=');
       final String name = decode(equals == -1 ? pair : pair.substring(0, equals));
       if (!name.isEmpty()) {
@@ -96,6 +176,98 @@ final class ContentTypeBodyParser {
     }
     log.debug("Body parsed as {} urlencoded parameters", parameters.size());
     return parameters;
+  }
+
+  /**
+   * Parses a {@code multipart/*} body into its form fields.
+   *
+   * @param sizeLimit the largest body to attempt, or {@code 0} to disable multipart parsing
+   * @return the fields found, or {@code null} if the body is too large, has no usable boundary,
+   *     holds more parts than the allowance, or yields no field
+   */
+  static Object parseMultipart(
+      final String body,
+      final String contentType,
+      final int depth,
+      final ParseContext context,
+      final int sizeLimit) {
+    if (sizeLimit <= 0 || body.length() > sizeLimit) {
+      log.debug("Multipart body of {} chars not parsed, keeping raw string", body.length());
+      return null;
+    }
+    final String boundary = MultipartSplitter.extractBoundary(contentType);
+    if (boundary == null) {
+      log.debug("Multipart body without a usable boundary, keeping raw string");
+      return null;
+    }
+    // One over the allowance, so that a body holding more parts than may be read is distinguishable
+    // from one holding exactly the allowance
+    final int allowance = context.remainingParts();
+    final List<Part> parts = MultipartSplitter.split(body, boundary, allowance + 1);
+    if (parts.size() > allowance) {
+      // Bail out rather than hand the WAF a truncated map, as the urlencoded path does:
+      // the raw body can still be string-matched.
+      log.debug("Part allowance exhausted, keeping multipart body as a raw string");
+      return null;
+    }
+    context.consumeParts(parts.size());
+
+    final Map<String, Object> fields = new LinkedHashMap<>();
+    final Set<String> promoted = new HashSet<>();
+    for (final Part part : parts) {
+      final String disposition = part.header("content-disposition");
+      if (disposition == null) {
+        continue;
+      }
+      final String filename = MultipartSplitter.parameter(disposition, "filename");
+      if (filename != null) {
+        if (!filename.isEmpty()) {
+          context.addFilename(filename);
+        }
+        continue;
+      }
+      final String name = MultipartSplitter.parameter(disposition, "name");
+      if (name == null || name.isEmpty()) {
+        continue;
+      }
+      final Object value =
+          dispatch(
+              body.substring(part.contentStart, part.contentEnd),
+              part.header("content-type"),
+              depth + 1,
+              context);
+      addField(fields, promoted, name, value);
+    }
+    return fields.isEmpty() ? null : fields;
+  }
+
+  /**
+   * Accumulates a field as a scalar on first sight and promotes it to a list on repeat.
+   * Deliberately a different shape from urlencoded's always-a-list, matching the peer tracers.
+   *
+   * @param promoted the names already promoted to a list, mutated as fields are promoted
+   */
+  @SuppressWarnings("unchecked")
+  private static void addField(
+      final Map<String, Object> fields,
+      final Set<String> promoted,
+      final String name,
+      final Object value) {
+    // A part value is never null, so an absent key is exactly a null lookup
+    final Object existing = fields.get(name);
+    if (existing == null) {
+      fields.put(name, value);
+    } else if (promoted.contains(name)) {
+      ((List<Object>) existing).add(value);
+    } else {
+      // Promotion is tracked rather than inferred from the stored value's type: a part whose body
+      // parsed as a JSON array is itself a List, and appending to it would flatten the two apart.
+      final List<Object> values = new ArrayList<>(2);
+      values.add(existing);
+      values.add(value);
+      fields.put(name, values);
+      promoted.add(name);
+    }
   }
 
   /** Percent-decodes a single token, keeping it undecoded rather than dropping it on failure. */

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
@@ -1,0 +1,112 @@
+package datadog.trace.lambda;
+
+import datadog.trace.api.appsec.MediaType;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.StringTokenizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Turns a Lambda request body into the shape the AppSec WAF expects. The declared {@code
+ * Content-Type} decides how the body is structured; a best-effort JSON parse handles both the
+ * JSON-ish types and the case where no type is declared at all.
+ *
+ * <p>A body is never dropped: any type we cannot structure — and any parse failure — degrades to
+ * the raw {@link String}, which the WAF can still match string rules against.
+ */
+final class ContentTypeBodyParser {
+
+  private static final Logger log = LoggerFactory.getLogger(ContentTypeBodyParser.class);
+
+  // These bound the work done in this parser only. The WAF truncates its inputs independently, so
+  // exceeding them is wasteful rather than incorrect.
+  static final int MAX_DEPTH = 20;
+  static final int MAX_ELEMENTS = 256;
+
+  private ContentTypeBodyParser() {}
+
+  /** Parses a decoded request body according to its {@code Content-Type}. */
+  static Object parseBody(final String body, final String contentType) {
+    return dispatch(body, contentType, 0);
+  }
+
+  static Object dispatch(final String body, final String contentType, final int depth) {
+    if (body == null) {
+      return null;
+    }
+    if (depth >= MAX_DEPTH) {
+      log.debug("Body nesting depth {} reached, keeping raw string", depth);
+      return body;
+    }
+    if (contentType == null || contentType.trim().isEmpty() || isJsonLike(contentType)) {
+      final Object parsed = LambdaEventParser.parseBodyAsJson(body);
+      return parsed != null ? parsed : body;
+    }
+    final MediaType mediaType = MediaType.parse(contentType);
+    if ("application".equals(mediaType.getType())
+        && "x-www-form-urlencoded".equals(mediaType.getSubtype())) {
+      final Object parsed = parseUrlEncoded(body);
+      return parsed != null ? parsed : body;
+    }
+    // text/*, multipart/* and everything else stay raw strings. In particular a text/plain body of
+    // "12345" must reach the WAF as a String, not as the Double a JSON parse would produce.
+    return body;
+  }
+
+  static boolean isJsonLike(final String contentType) {
+    if (contentType == null) {
+      return false;
+    }
+    final String lower = contentType.toLowerCase(Locale.ROOT);
+    return lower.contains("json") || lower.contains("javascript");
+  }
+
+  /**
+   * Parses an {@code application/x-www-form-urlencoded} body into a multimap, matching the shape
+   * produced for query parameters.
+   *
+   * @return the parsed parameters, or {@code null} if nothing usable was found
+   */
+  private static Map<String, List<String>> parseUrlEncoded(final String body) {
+    if (body.isEmpty()) {
+      return null;
+    }
+    final Map<String, List<String>> parameters = new LinkedHashMap<>();
+    int pairs = 0;
+    final StringTokenizer tokenizer = new StringTokenizer(body, "&");
+    while (tokenizer.hasMoreTokens() && pairs < MAX_ELEMENTS) {
+      final String pair = tokenizer.nextToken();
+      pairs++;
+      final int equals = pair.indexOf('=');
+      final String name = decode(equals == -1 ? pair : pair.substring(0, equals));
+      if (!name.isEmpty()) {
+        parameters
+            .computeIfAbsent(name, k -> new ArrayList<>(1))
+            .add(equals == -1 ? "" : decode(pair.substring(equals + 1)));
+      }
+    }
+    if (parameters.isEmpty()) {
+      return null;
+    }
+    log.debug("Body parsed as {} urlencoded parameters", parameters.size());
+    return parameters;
+  }
+
+  /** Percent-decodes a single token, keeping it undecoded rather than dropping it on failure. */
+  private static String decode(final String value) {
+    if (value.isEmpty()) {
+      return value;
+    }
+    try {
+      return URLDecoder.decode(value, "UTF-8");
+    } catch (final UnsupportedEncodingException | IllegalArgumentException e) {
+      return value;
+    }
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
@@ -9,7 +9,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -29,22 +28,38 @@ final class ContentTypeBodyParser {
   private static final Logger log = LoggerFactory.getLogger(ContentTypeBodyParser.class);
 
   // These bound the work done in this parser only. Exceeding any of them degrades the body to a raw
-  // string rather than dropping content, and the WAF truncates its inputs independently anyway.
-  static final int MAX_DEPTH = 20;
-  static final int MAX_ELEMENTS = 256;
+  // string rather than dropping content.
+  //
+  // The depth and part limits mirror the WAF's own (WAFModule.MAX_DEPTH / MAX_ELEMENTS): structure
+  // beyond them is discarded by ObjectIntrospection before the WAF ever sees it, so producing it
+  // would be wasted work. The byte allowance answers a different question — how much reading and
+  // copying one event may cost us — and AWS already caps a synchronous payload at 6 MiB.
+  static final int MAX_BYTES = 1024 * 1024;
   static final int MAX_PARTS = 256;
-  static final int MAX_MULTIPART_SIZE = 1_000_000;
+  static final int MAX_DEPTH = 20;
 
   private ContentTypeBodyParser() {}
 
   /**
-   * State shared across a whole parse: the element and part allowances, and the filenames collected
+   * State shared across a whole parse: the byte and part allowances, and the filenames collected
    * along the way. A multipart part may itself hold an urlencoded or multipart body, so a per-call
-   * cap would multiply across nesting levels and a per-call list would lose nested file parts.
+   * allowance would be re-satisfied at every nesting level and a per-call list would lose nested
+   * file parts.
    */
   static final class ParseContext {
+    private int bytes;
     private int parts = MAX_PARTS;
-    private int elements = MAX_ELEMENTS;
+
+    ParseContext() {
+      this(MAX_BYTES);
+    }
+
+    /**
+     * @param byteAllowance the total number of characters this parse may read, nesting included
+     */
+    ParseContext(final int byteAllowance) {
+      this.bytes = byteAllowance;
+    }
 
     /** Allocated only once a file part is seen, which most bodies never do. */
     private List<String> filenames;
@@ -58,13 +73,26 @@ final class ContentTypeBodyParser {
     }
 
     /**
-     * @return {@code false} once the element allowance is spent
+     * @return {@code false} when the parse can no longer afford to read {@code count} characters
      */
-    boolean takeElement() {
-      if (elements == 0) {
+    boolean takeBytes(final int count) {
+      if (bytes < count) {
         return false;
       }
-      elements--;
+      bytes -= count;
+      return true;
+    }
+
+    /**
+     * @return {@code false} once the part allowance is spent. A multipart part and an urlencoded
+     *     parameter both draw from it: they are the same question, how many values one body may
+     *     yield.
+     */
+    boolean takePart() {
+      if (parts == 0) {
+        return false;
+      }
+      parts--;
       return true;
     }
 
@@ -82,11 +110,6 @@ final class ContentTypeBodyParser {
     List<String> filenames() {
       return filenames == null ? Collections.emptyList() : filenames;
     }
-  }
-
-  /** Parses a decoded request body according to its {@code Content-Type}. */
-  static Object parseBody(final String body, final String contentType) {
-    return parseBody(body, contentType, new ParseContext());
   }
 
   /**
@@ -108,18 +131,24 @@ final class ContentTypeBodyParser {
       log.debug("Body nesting depth {} reached, keeping raw string", depth);
       return body;
     }
-    if (contentType == null || contentType.trim().isEmpty() || isJsonLike(contentType)) {
-      final Object parsed = LambdaEventParser.parseBodyAsJson(body);
-      return parsed != null ? parsed : body;
+    if (!context.takeBytes(body.length())) {
+      log.debug(
+          "Byte allowance cannot cover a body of {} chars, keeping raw string", body.length());
+      return body;
     }
     final MediaType mediaType = MediaType.parse(contentType);
+    // A null type is one MediaType could not read: the header was absent, blank, or nothing but
+    // parameters. Such a body gets the same best-effort JSON parse as a JSON-ish one.
+    if (mediaType.getType() == null || isJsonLike(mediaType)) {
+      return jsonOrRaw(body);
+    }
     if ("application".equals(mediaType.getType())
         && "x-www-form-urlencoded".equals(mediaType.getSubtype())) {
       final Object parsed = parseUrlEncoded(body, context);
       return parsed != null ? parsed : body;
     }
     if ("multipart".equals(mediaType.getType())) {
-      final Object parsed = parseMultipart(body, contentType, depth, context, MAX_MULTIPART_SIZE);
+      final Object parsed = parseMultipart(body, contentType, depth, context);
       return parsed != null ? parsed : body;
     }
     // text/* and everything else stay raw strings. In particular a text/plain body of "12345" must
@@ -127,18 +156,34 @@ final class ContentTypeBodyParser {
     return body;
   }
 
-  static boolean isJsonLike(final String contentType) {
-    if (contentType == null) {
-      return false;
-    }
-    // Match on the type and subtype only. Parameters such as a multipart boundary are chosen by
-    // the client, so "multipart/form-data; boundary=--json" must not reach the JSON parser and
-    // thereby skip multipart parsing entirely.
-    final int semicolon = contentType.indexOf(';');
-    final String essence =
-        (semicolon == -1 ? contentType : contentType.substring(0, semicolon))
-            .toLowerCase(Locale.ROOT);
-    return essence.contains("json") || essence.contains("javascript");
+  /**
+   * Applies the "no declared type, or a JSON-ish one" rule to a body the caller does not structure
+   * any further. This is the whole of how a response body is handled; the request path shares the
+   * rule through {@link #dispatch} and additionally structures urlencoded and multipart bodies.
+   */
+  static Object jsonOrRaw(final String body, final String contentType) {
+    final MediaType mediaType = MediaType.parse(contentType);
+    return mediaType.getType() == null || isJsonLike(mediaType) ? jsonOrRaw(body) : body;
+  }
+
+  /** A best-effort JSON parse, degrading to the raw string rather than dropping the body. */
+  private static Object jsonOrRaw(final String body) {
+    final Object parsed = LambdaEventParser.parseBodyAsJson(body);
+    return parsed != null ? parsed : body;
+  }
+
+  /**
+   * Matches on the type and subtype only. Parameters such as a multipart boundary are chosen by the
+   * client, so {@code multipart/form-data; boundary=--json} must not reach the JSON parser and
+   * thereby skip multipart parsing entirely; {@link MediaType#parse} strips them, and lowercases
+   * what is left.
+   */
+  private static boolean isJsonLike(final MediaType mediaType) {
+    return jsonLike(mediaType.getType()) || jsonLike(mediaType.getSubtype());
+  }
+
+  private static boolean jsonLike(final String essence) {
+    return essence != null && (essence.contains("json") || essence.contains("javascript"));
   }
 
   /**
@@ -146,7 +191,7 @@ final class ContentTypeBodyParser {
    * produced for query parameters.
    *
    * @return the parsed parameters, or {@code null} if nothing usable was found or the body exhausts
-   *     the element allowance
+   *     the part allowance
    */
   private static Map<String, List<String>> parseUrlEncoded(
       final String body, final ParseContext context) {
@@ -156,10 +201,10 @@ final class ContentTypeBodyParser {
     final Map<String, List<String>> parameters = new LinkedHashMap<>();
     final StringTokenizer tokenizer = new StringTokenizer(body, "&");
     while (tokenizer.hasMoreTokens()) {
-      if (!context.takeElement()) {
+      if (!context.takePart()) {
         // Bail out rather than hand the WAF a truncated map: a parameter dropped here would be
         // invisible to every rule, whereas the raw body can still be string-matched.
-        log.debug("Element allowance exhausted, keeping urlencoded body as a raw string");
+        log.debug("Part allowance exhausted, keeping urlencoded body as a raw string");
         return null;
       }
       final String pair = tokenizer.nextToken();
@@ -181,20 +226,11 @@ final class ContentTypeBodyParser {
   /**
    * Parses a {@code multipart/*} body into its form fields.
    *
-   * @param sizeLimit the largest body to attempt, or {@code 0} to disable multipart parsing
-   * @return the fields found, or {@code null} if the body is too large, has no usable boundary,
-   *     holds more parts than the allowance, or yields no field
+   * @return the fields found, or {@code null} if the body has no usable boundary, it holds more
+   *     parts than the allowance, or it yields no field
    */
-  static Object parseMultipart(
-      final String body,
-      final String contentType,
-      final int depth,
-      final ParseContext context,
-      final int sizeLimit) {
-    if (sizeLimit <= 0 || body.length() > sizeLimit) {
-      log.debug("Multipart body of {} chars not parsed, keeping raw string", body.length());
-      return null;
-    }
+  private static Object parseMultipart(
+      final String body, final String contentType, final int depth, final ParseContext context) {
     final String boundary = MultipartSplitter.extractBoundary(contentType);
     if (boundary == null) {
       log.debug("Multipart body without a usable boundary, keeping raw string");
@@ -215,7 +251,7 @@ final class ContentTypeBodyParser {
     final Map<String, Object> fields = new LinkedHashMap<>();
     final Set<String> promoted = new HashSet<>();
     for (final Part part : parts) {
-      final String disposition = part.header("content-disposition");
+      final String disposition = part.contentDisposition;
       if (disposition == null) {
         continue;
       }
@@ -230,11 +266,14 @@ final class ContentTypeBodyParser {
       if (name == null || name.isEmpty()) {
         continue;
       }
-      final String partContentType = part.header("content-type");
+      // Already trimmed by MultipartSplitter, so a whitespace-only header arrives as ""
+      final String partContentType = part.contentType;
       final String content = body.substring(part.contentStart, part.contentEnd);
-      // A part that declares no type is kept as a raw string
+      // A part that declares no type is kept as a raw string, the opposite of what a whole body
+      // with no type gets: RFC 7578, section 4.4 defaults a part to text/plain rather than leaving
+      // its type unknown.
       final Object value =
-          partContentType == null || partContentType.trim().isEmpty()
+          partContentType == null || partContentType.isEmpty()
               ? content
               : dispatch(content, partContentType, depth + 1, context);
       addField(fields, promoted, name, value);

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
@@ -18,8 +18,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Turns a Lambda request body into the shape the AppSec WAF expects. The declared {@code
- * Content-Type} decides how the body is structured; a best-effort JSON parse handles both the
- * JSON-ish types and the case where no type is declared at all.
+ * Content-Type} decides how the body is structured; a best-effort JSON parse handles the JSON-ish
+ * types and a top-level body that declares no type at all.
  *
  * <p>A body is never dropped: any type we cannot structure — and any parse failure — degrades to
  * the raw {@link String}, which the WAF can still match string rules against.
@@ -230,12 +230,13 @@ final class ContentTypeBodyParser {
       if (name == null || name.isEmpty()) {
         continue;
       }
+      final String partContentType = part.header("content-type");
+      final String content = body.substring(part.contentStart, part.contentEnd);
+      // A part that declares no type is kept as a raw string
       final Object value =
-          dispatch(
-              body.substring(part.contentStart, part.contentEnd),
-              part.header("content-type"),
-              depth + 1,
-              context);
+          partContentType == null || partContentType.trim().isEmpty()
+              ? content
+              : dispatch(content, partContentType, depth + 1, context);
       addField(fields, promoted, name, value);
     }
     return fields.isEmpty() ? null : fields;

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
@@ -6,11 +6,10 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.StringTokenizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,9 +27,7 @@ final class ContentTypeBodyParser {
   private static final Logger log = LoggerFactory.getLogger(ContentTypeBodyParser.class);
 
   // These bound the work done in this parser only: exceeding any of them degrades the body to a raw
-  // string rather than dropping content. The depth and part limits mirror the WAF's own
-  // (WAFModule.MAX_DEPTH / MAX_ELEMENTS), beyond which ObjectIntrospection discards the structure
-  // anyway. The byte allowance instead bounds what reading one event may cost us.
+  // string rather than dropping content.
   static final int MAX_BYTES = 1024 * 1024;
   static final int MAX_PARTS = 256;
   static final int MAX_DEPTH = 20;
@@ -132,10 +129,9 @@ final class ContentTypeBodyParser {
       return body;
     }
     final MediaType mediaType = MediaType.parse(contentType);
-    // A null type is one MediaType could not read: the header was absent, blank, or nothing but
-    // parameters. Such a body gets the same best-effort JSON parse as a JSON-ish one.
-    if (mediaType.getType() == null || isJsonLike(mediaType)) {
-      return jsonOrRaw(body);
+    if (isJsonOrUntyped(mediaType)) {
+      final Object parsed = LambdaEventParser.parseBodyAsJson(body);
+      return parsed != null ? parsed : body;
     }
     if ("application".equals(mediaType.getType())
         && "x-www-form-urlencoded".equals(mediaType.getSubtype())) {
@@ -151,33 +147,10 @@ final class ContentTypeBodyParser {
     return body;
   }
 
-  /**
-   * Applies the "no declared type, or a JSON-ish one" rule to a body the caller does not structure
-   * any further. This is the whole of how a response body is handled; the request path shares the
-   * rule through {@link #dispatch} and additionally structures urlencoded and multipart bodies.
-   */
-  static Object jsonOrRaw(final String body, final String contentType) {
-    final MediaType mediaType = MediaType.parse(contentType);
-    return mediaType.getType() == null || isJsonLike(mediaType) ? jsonOrRaw(body) : body;
-  }
-
-  /** A best-effort JSON parse, degrading to the raw string rather than dropping the body. */
-  private static Object jsonOrRaw(final String body) {
-    final Object parsed = LambdaEventParser.parseBodyAsJson(body);
-    return parsed != null ? parsed : body;
-  }
-
-  /**
-   * Matches on the type and subtype only, which {@link MediaType#parse} has already stripped of
-   * parameters: a client-chosen {@code multipart/form-data; boundary=--json} must not reach the
-   * JSON parser and thereby skip multipart parsing entirely.
-   */
-  private static boolean isJsonLike(final MediaType mediaType) {
-    return jsonLike(mediaType.getType()) || jsonLike(mediaType.getSubtype());
-  }
-
-  private static boolean jsonLike(final String essence) {
-    return essence != null && (essence.contains("json") || essence.contains("javascript"));
+  static boolean isJsonOrUntyped(final MediaType mediaType) {
+    final String subtype = mediaType.getSubtype();
+    return mediaType.getType() == null
+        || (subtype != null && (subtype.contains("json") || subtype.contains("javascript")));
   }
 
   /**
@@ -196,8 +169,6 @@ final class ContentTypeBodyParser {
     final StringTokenizer tokenizer = new StringTokenizer(body, "&");
     while (tokenizer.hasMoreTokens()) {
       if (!context.takePart()) {
-        // Bail out rather than hand the WAF a truncated map: a parameter dropped here would be
-        // invisible to every rule, whereas the raw body can still be string-matched.
         log.debug("Part allowance exhausted, keeping urlencoded body as a raw string");
         return null;
       }
@@ -235,14 +206,13 @@ final class ContentTypeBodyParser {
     final int allowance = context.remainingParts();
     final List<Part> parts = MultipartSplitter.split(body, boundary, allowance + 1);
     if (parts.size() > allowance) {
-      // Bail out rather than truncate, as the urlencoded path does
       log.debug("Part allowance exhausted, keeping multipart body as a raw string");
       return null;
     }
     context.consumeParts(parts.size());
 
     final Map<String, Object> fields = new LinkedHashMap<>();
-    final Set<String> promoted = new HashSet<>();
+    final Map<String, List<Object>> promoted = new HashMap<>();
     for (final Part part : parts) {
       final String disposition = part.contentDisposition;
       if (disposition == null) {
@@ -259,12 +229,9 @@ final class ContentTypeBodyParser {
       if (name == null || name.isEmpty()) {
         continue;
       }
-      // Already trimmed by MultipartSplitter, so a whitespace-only header arrives as ""
       final String partContentType = part.contentType;
       final String content = body.substring(part.contentStart, part.contentEnd);
-      // A part that declares no type is kept as a raw string, the opposite of what a whole body
-      // with no type gets: RFC 7578, section 4.4 defaults a part to text/plain rather than leaving
-      // its type unknown.
+      // A part that declares no type is kept as a raw string
       final Object value =
           partContentType == null || partContentType.isEmpty()
               ? content
@@ -278,28 +245,30 @@ final class ContentTypeBodyParser {
    * Accumulates a field as a scalar on first sight and promotes it to a list on repeat.
    * Deliberately a different shape from urlencoded's always-a-list, matching the peer tracers.
    *
-   * @param promoted the names already promoted to a list, mutated as fields are promoted
+   * @param promoted the list each promoted field was given, by name, mutated as fields are
+   *     promoted. Tracked rather than inferred from the stored value's type: a part whose body
+   *     parsed as a JSON array is itself a List, and appending to it would flatten the two apart.
    */
-  @SuppressWarnings("unchecked")
   private static void addField(
       final Map<String, Object> fields,
-      final Set<String> promoted,
+      final Map<String, List<Object>> promoted,
       final String name,
       final Object value) {
+    final List<Object> values = promoted.get(name);
+    if (values != null) {
+      values.add(value);
+      return;
+    }
     // A part value is never null, so an absent key is exactly a null lookup
     final Object existing = fields.get(name);
     if (existing == null) {
       fields.put(name, value);
-    } else if (promoted.contains(name)) {
-      ((List<Object>) existing).add(value);
     } else {
-      // Promotion is tracked rather than inferred from the stored value's type: a part whose body
-      // parsed as a JSON array is itself a List, and appending to it would flatten the two apart.
-      final List<Object> values = new ArrayList<>(2);
-      values.add(existing);
-      values.add(value);
-      fields.put(name, values);
-      promoted.add(name);
+      final List<Object> promotion = new ArrayList<>(2);
+      promotion.add(existing);
+      promotion.add(value);
+      fields.put(name, promotion);
+      promoted.put(name, promotion);
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
@@ -4,6 +4,7 @@ import datadog.trace.api.appsec.MediaType;
 import datadog.trace.lambda.MultipartSplitter.Part;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -31,6 +32,9 @@ final class ContentTypeBodyParser {
   static final int MAX_BYTES = 1024 * 1024;
   static final int MAX_PARTS = 256;
   static final int MAX_DEPTH = 20;
+
+  /** What a form body's percent-escapes mean when it declares no charset of its own. */
+  private static final String DEFAULT_CHARSET = "UTF-8";
 
   private ContentTypeBodyParser() {}
 
@@ -135,7 +139,7 @@ final class ContentTypeBodyParser {
     }
     if ("application".equals(mediaType.getType())
         && "x-www-form-urlencoded".equals(mediaType.getSubtype())) {
-      final Object parsed = parseUrlEncoded(body, context);
+      final Object parsed = parseUrlEncoded(body, charsetName(mediaType), context);
       return parsed != null ? parsed : body;
     }
     if ("multipart".equals(mediaType.getType())) {
@@ -161,7 +165,7 @@ final class ContentTypeBodyParser {
    *     the part allowance
    */
   private static Map<String, List<String>> parseUrlEncoded(
-      final String body, final ParseContext context) {
+      final String body, final String charset, final ParseContext context) {
     if (body.isEmpty()) {
       return null;
     }
@@ -176,10 +180,10 @@ final class ContentTypeBodyParser {
       final int equals = pair.indexOf('=');
       // An empty name is kept rather than dropped: the handler still decodes the parameter, so
       // dropping it would hide its value from the WAF. The Netty body collector keeps it too.
-      final String name = decode(equals == -1 ? pair : pair.substring(0, equals));
+      final String name = decode(equals == -1 ? pair : pair.substring(0, equals), charset);
       parameters
           .computeIfAbsent(name, k -> new ArrayList<>(1))
-          .add(equals == -1 ? "" : decode(pair.substring(equals + 1)));
+          .add(equals == -1 ? "" : decode(pair.substring(equals + 1), charset));
     }
     if (parameters.isEmpty()) {
       return null;
@@ -274,13 +278,46 @@ final class ContentTypeBodyParser {
     }
   }
 
+  /**
+   * Resolves the charset a form body declares, which decides what its percent-escapes mean: {@code
+   * %E9} is one character under ISO-8859-1 and an invalid sequence under UTF-8. Reading it the way
+   * the handler does keeps the WAF matching on the same value the application consumes.
+   *
+   * @return the declared charset, or UTF-8 when none is declared or it is not one this JVM has
+   */
+  private static String charsetName(final MediaType mediaType) {
+    String declared = mediaType.getCharset();
+    if (declared == null) {
+      return DEFAULT_CHARSET;
+    }
+    // MediaType keeps everything past "charset=", so a parameter after it, or quotes around the
+    // value, come along with it
+    final int nextParameter = declared.indexOf(';');
+    declared = (nextParameter == -1 ? declared : declared.substring(0, nextParameter)).trim();
+    if (declared.length() > 1 && declared.charAt(0) == '"' && declared.endsWith("\"")) {
+      declared = declared.substring(1, declared.length() - 1);
+    }
+    if (declared.isEmpty()) {
+      return DEFAULT_CHARSET;
+    }
+    try {
+      if (Charset.isSupported(declared)) {
+        return declared;
+      }
+    } catch (final IllegalArgumentException e) {
+      // Not a charset name at all: a body may declare anything
+    }
+    log.debug("Unsupported charset {} declared, decoding the body as UTF-8", declared);
+    return DEFAULT_CHARSET;
+  }
+
   /** Percent-decodes a single token, keeping it undecoded rather than dropping it on failure. */
-  private static String decode(final String value) {
+  private static String decode(final String value, final String charset) {
     if (value.isEmpty()) {
       return value;
     }
     try {
-      return URLDecoder.decode(value, "UTF-8");
+      return URLDecoder.decode(value, charset);
     } catch (final UnsupportedEncodingException | IllegalArgumentException e) {
       return value;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
@@ -174,12 +174,12 @@ final class ContentTypeBodyParser {
       }
       final String pair = tokenizer.nextToken();
       final int equals = pair.indexOf('=');
+      // An empty name is kept rather than dropped: the handler still decodes the parameter, so
+      // dropping it would hide its value from the WAF. The Netty body collector keeps it too.
       final String name = decode(equals == -1 ? pair : pair.substring(0, equals));
-      if (!name.isEmpty()) {
-        parameters
-            .computeIfAbsent(name, k -> new ArrayList<>(1))
-            .add(equals == -1 ? "" : decode(pair.substring(equals + 1)));
-      }
+      parameters
+          .computeIfAbsent(name, k -> new ArrayList<>(1))
+          .add(equals == -1 ? "" : decode(pair.substring(equals + 1)));
     }
     if (parameters.isEmpty()) {
       return null;
@@ -225,8 +225,10 @@ final class ContentTypeBodyParser {
         }
         continue;
       }
+      // A part with no name parameter at all is not a form field, but one named "" is: the handler
+      // decodes it, so it is reported under the empty key rather than dropped, as Netty does.
       final String name = MultipartSplitter.parameter(disposition, "name");
-      if (name == null || name.isEmpty()) {
+      if (name == null) {
         continue;
       }
       final String partContentType = part.contentType;

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
@@ -27,13 +27,10 @@ final class ContentTypeBodyParser {
 
   private static final Logger log = LoggerFactory.getLogger(ContentTypeBodyParser.class);
 
-  // These bound the work done in this parser only. Exceeding any of them degrades the body to a raw
-  // string rather than dropping content.
-  //
-  // The depth and part limits mirror the WAF's own (WAFModule.MAX_DEPTH / MAX_ELEMENTS): structure
-  // beyond them is discarded by ObjectIntrospection before the WAF ever sees it, so producing it
-  // would be wasted work. The byte allowance answers a different question — how much reading and
-  // copying one event may cost us — and AWS already caps a synchronous payload at 6 MiB.
+  // These bound the work done in this parser only: exceeding any of them degrades the body to a raw
+  // string rather than dropping content. The depth and part limits mirror the WAF's own
+  // (WAFModule.MAX_DEPTH / MAX_ELEMENTS), beyond which ObjectIntrospection discards the structure
+  // anyway. The byte allowance instead bounds what reading one event may cost us.
   static final int MAX_BYTES = 1024 * 1024;
   static final int MAX_PARTS = 256;
   static final int MAX_DEPTH = 20;
@@ -42,9 +39,8 @@ final class ContentTypeBodyParser {
 
   /**
    * State shared across a whole parse: the byte and part allowances, and the filenames collected
-   * along the way. A multipart part may itself hold an urlencoded or multipart body, so a per-call
-   * allowance would be re-satisfied at every nesting level and a per-call list would lose nested
-   * file parts.
+   * along the way. A multipart part may itself hold a multipart body, so a per-call allowance would
+   * be re-satisfied at every nesting level.
    */
   static final class ParseContext {
     private int bytes;
@@ -85,8 +81,7 @@ final class ContentTypeBodyParser {
 
     /**
      * @return {@code false} once the part allowance is spent. A multipart part and an urlencoded
-     *     parameter both draw from it: they are the same question, how many values one body may
-     *     yield.
+     *     parameter both draw from it.
      */
     boolean takePart() {
       if (parts == 0) {
@@ -173,10 +168,9 @@ final class ContentTypeBodyParser {
   }
 
   /**
-   * Matches on the type and subtype only. Parameters such as a multipart boundary are chosen by the
-   * client, so {@code multipart/form-data; boundary=--json} must not reach the JSON parser and
-   * thereby skip multipart parsing entirely; {@link MediaType#parse} strips them, and lowercases
-   * what is left.
+   * Matches on the type and subtype only, which {@link MediaType#parse} has already stripped of
+   * parameters: a client-chosen {@code multipart/form-data; boundary=--json} must not reach the
+   * JSON parser and thereby skip multipart parsing entirely.
    */
   private static boolean isJsonLike(final MediaType mediaType) {
     return jsonLike(mediaType.getType()) || jsonLike(mediaType.getSubtype());
@@ -241,8 +235,7 @@ final class ContentTypeBodyParser {
     final int allowance = context.remainingParts();
     final List<Part> parts = MultipartSplitter.split(body, boundary, allowance + 1);
     if (parts.size() > allowance) {
-      // Bail out rather than hand the WAF a truncated map, as the urlencoded path does:
-      // the raw body can still be string-matched.
+      // Bail out rather than truncate, as the urlencoded path does
       log.debug("Part allowance exhausted, keeping multipart body as a raw string");
       return null;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/ContentTypeBodyParser.java
@@ -139,7 +139,7 @@ final class ContentTypeBodyParser {
     }
     if ("application".equals(mediaType.getType())
         && "x-www-form-urlencoded".equals(mediaType.getSubtype())) {
-      final Object parsed = parseUrlEncoded(body, charsetName(mediaType), context);
+      final Object parsed = parseUrlEncoded(body, charsetName(contentType), context);
       return parsed != null ? parsed : body;
     }
     if ("multipart".equals(mediaType.getType())) {
@@ -285,19 +285,9 @@ final class ContentTypeBodyParser {
    *
    * @return the declared charset, or UTF-8 when none is declared or it is not one this JVM has
    */
-  private static String charsetName(final MediaType mediaType) {
-    String declared = mediaType.getCharset();
-    if (declared == null) {
-      return DEFAULT_CHARSET;
-    }
-    // MediaType keeps everything past "charset=", so a parameter after it, or quotes around the
-    // value, come along with it
-    final int nextParameter = declared.indexOf(';');
-    declared = (nextParameter == -1 ? declared : declared.substring(0, nextParameter)).trim();
-    if (declared.length() > 1 && declared.charAt(0) == '"' && declared.endsWith("\"")) {
-      declared = declared.substring(1, declared.length() - 1);
-    }
-    if (declared.isEmpty()) {
+  private static String charsetName(final String contentType) {
+    final String declared = MultipartSplitter.parameter(contentType, "charset");
+    if (declared == null || declared.isEmpty()) {
       return DEFAULT_CHARSET;
     }
     try {

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
@@ -39,6 +39,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -475,6 +476,20 @@ public class LambdaAppSecHandler {
           bodyCallback.apply(requestContext, eventData.body);
         } else {
           log.debug("requestBodyProcessed callback is null");
+        }
+      }
+
+      // Call requestFilesFilenames. Only the names are reported: the file content shares the
+      // body's UTF-8 decode, so for anything that is not text it is already lossy.
+      if (!eventData.filenames.isEmpty()) {
+        BiFunction<RequestContext, List<String>, Flow<Void>> filenamesCallback =
+            tracer
+                .getCallbackProvider(RequestContextSlot.APPSEC)
+                .getCallback(EVENTS.requestFilesFilenames());
+        if (filenamesCallback != null) {
+          filenamesCallback.apply(requestContext, eventData.filenames);
+        } else {
+          log.debug("requestFilesFilenames callback is null");
         }
       }
     }

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaAppSecHandler.java
@@ -59,7 +59,7 @@ public class LambdaAppSecHandler {
   private static final RatelimitedLogger rlLog = new RatelimitedLogger(log, 5, TimeUnit.MINUTES);
 
   /**
-   * Marks an invocation AppSec did not process because the trigger is not HTTP, or if the even is
+   * Marks an invocation AppSec did not process because the trigger is not HTTP, or if the event is
    * unreadable (not a {@code ByteArrayInputStream}, empty, oversized, or unparseable).
    */
   private static final String UNSUPPORTED_EVENT_TYPE_METRIC = "_dd.appsec.unsupported_event_type";

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
@@ -130,19 +130,7 @@ final class LambdaEventParser {
       Map<String, String> headers = extractHeaderMap(response.get("headers"));
 
       // Merge multiValueHeaders if present (API GW v1 / ALB), also lowercasing keys
-      Object multiValueHeadersObj = response.get("multiValueHeaders");
-      if (multiValueHeadersObj instanceof Map) {
-        Map<?, ?> multiValueHeaders = (Map<?, ?>) multiValueHeadersObj;
-        for (Map.Entry<?, ?> entry : multiValueHeaders.entrySet()) {
-          if (entry.getKey() != null && entry.getValue() instanceof List) {
-            String key = String.valueOf(entry.getKey()).toLowerCase(Locale.ROOT);
-            List<?> values = (List<?>) entry.getValue();
-            String joinedValue =
-                values.stream().map(String::valueOf).collect(Collectors.joining(", "));
-            headers.put(key, joinedValue);
-          }
-        }
-      }
+      headers = mergeMultiValueHeaders(headers, response.get("multiValueHeaders"));
 
       // Extract body
       Object body = null;
@@ -232,7 +220,11 @@ final class LambdaEventParser {
 
   /** Extracts data from API Gateway v1 (REST API) event */
   private static LambdaRequestData extractApiGatewayV1Data(Map<String, Object> event) {
-    Map<String, String> headers = extractHeaders(event.get("headers"));
+    // A REST proxy event carries both maps, and the single-value one keeps only the last value of a
+    // repeated header, so the multi-value one is merged over it
+    Map<String, String> headers =
+        mergeMultiValueHeaders(
+            extractHeaders(event.get("headers")), event.get("multiValueHeaders"));
     Map<String, String> pathParameters = extractPathParameters(event.get("pathParameters"));
     // Preferred over queryStringParameters, which keeps only the last value of a repeated key
     Map<String, List<String>> queryParameters =
@@ -373,27 +365,7 @@ final class LambdaEventParser {
     Map<String, String> headers;
 
     if (triggerType == LambdaTriggerType.ALB_MULTI_VALUE) {
-      // Handle multi-value headers (combine multiple values with comma)
-      headers = new HashMap<>();
-      Object multiValueHeadersObj = event.get("multiValueHeaders");
-      if (multiValueHeadersObj instanceof Map) {
-        Map<?, ?> rawHeaders = (Map<?, ?>) multiValueHeadersObj;
-        for (Map.Entry<?, ?> entry : rawHeaders.entrySet()) {
-          if (entry.getKey() != null && entry.getValue() != null) {
-            // Lowercased for the same reason as extractHeaders
-            String key = String.valueOf(entry.getKey()).toLowerCase(Locale.ROOT);
-            if (entry.getValue() instanceof List) {
-              List<?> values = (List<?>) entry.getValue();
-              // Join multiple values with comma
-              String joinedValue =
-                  values.stream().map(String::valueOf).collect(Collectors.joining(", "));
-              headers.put(key, joinedValue);
-            } else {
-              headers.put(key, String.valueOf(entry.getValue()));
-            }
-          }
-        }
-      }
+      headers = mergeMultiValueHeaders(new HashMap<>(), event.get("multiValueHeaders"));
       if (headers.isEmpty()) {
         // multiValueHeaders was present but unusable — fall back to the single-value map
         headers = extractHeaders(event.get("headers"));
@@ -531,6 +503,39 @@ final class LambdaEventParser {
     log.debug("Extracted {} headers", headers.size());
     if (headers.containsKey("cookie")) {
       log.debug("Cookie header found with value length: {}", headers.get("cookie").length());
+    }
+    return headers;
+  }
+
+  /**
+   * Merges a {@code multiValueHeaders} map over headers already extracted from the single-value
+   * map, joining a header's values with {@code ", "} as the HTTP grammar allows. API Gateway v1 and
+   * ALB send both maps, and the single-value one keeps only one value of a repeated header, so
+   * reading it alone would hide the others from the WAF.
+   *
+   * @param headers mutated in place and returned; a value it already holds is overwritten by the
+   *     multi-value reading of the same header
+   * @param multiValueHeadersObj the raw event member, of any shape or absent
+   */
+  private static Map<String, String> mergeMultiValueHeaders(
+      Map<String, String> headers, Object multiValueHeadersObj) {
+    if (!(multiValueHeadersObj instanceof Map)) {
+      return headers;
+    }
+    for (Map.Entry<?, ?> entry : ((Map<?, ?>) multiValueHeadersObj).entrySet()) {
+      if (entry.getKey() == null || entry.getValue() == null) {
+        continue;
+      }
+      // Lowercased for the same reason as extractHeaderMap
+      String key = String.valueOf(entry.getKey()).toLowerCase(Locale.ROOT);
+      if (entry.getValue() instanceof List) {
+        List<?> values = (List<?>) entry.getValue();
+        headers.put(key, values.stream().map(String::valueOf).collect(Collectors.joining(", ")));
+      } else {
+        // Not a shape AWS sends, but reported rather than dropped: the runtime would still deliver
+        // the header
+        headers.put(key, String.valueOf(entry.getValue()));
+      }
     }
     return headers;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
@@ -162,15 +162,10 @@ final class LambdaEventParser {
         }
 
         if (bodyString != null) {
-          String contentType = headers.get("content-type");
-
-          // If JSON content-type or unknown, attempt JSON parsing.
-          if (contentType == null || ContentTypeBodyParser.isJsonLike(contentType)) {
-            Object parsed = parseBodyAsJson(bodyString);
-            body = parsed != null ? parsed : bodyString;
-          } else {
-            body = bodyString;
-          }
+          // A response body is only ever structured as JSON, never as urlencoded or multipart, but
+          // the rule deciding whether to try is shared with the request path so the two cannot
+          // drift
+          body = ContentTypeBodyParser.jsonOrRaw(bodyString, headers.get("content-type"));
         }
       }
 
@@ -782,33 +777,11 @@ final class LambdaEventParser {
             LambdaTriggerType.UNKNOWN,
             Collections.emptyMap(),
             Collections.emptyMap(),
-            null);
-
-    LambdaRequestData(
-        Map<String, String> headers,
-        String method,
-        String path,
-        String sourceIp,
-        Integer sourcePort,
-        LambdaTriggerType triggerType,
-        Map<String, String> pathParameters,
-        Map<String, List<String>> queryParameters,
-        Object body) {
-      this(
-          headers,
-          method,
-          path,
-          sourceIp,
-          sourcePort,
-          triggerType,
-          pathParameters,
-          queryParameters,
-          body,
-          null,
-          null,
-          null,
-          Collections.emptyList());
-    }
+            null,
+            null,
+            null,
+            null,
+            Collections.emptyList());
 
     LambdaRequestData(
         Map<String, String> headers,

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
@@ -162,13 +162,8 @@ final class LambdaEventParser {
         if (bodyString != null) {
           String contentType = headers.get("content-type");
 
-          // If JSON content-type or unknown, attempt JSON parsing
-          // Normalise casing: media type tokens are case-insensitive per RFC 7231
-          String contentTypeLower =
-              contentType == null ? null : contentType.toLowerCase(Locale.ROOT);
-          if (contentTypeLower == null
-              || contentTypeLower.contains("json")
-              || contentTypeLower.contains("javascript")) {
+          // If JSON content-type or unknown, attempt JSON parsing.
+          if (contentType == null || ContentTypeBodyParser.isJsonLike(contentType)) {
             Object parsed = parseBodyAsJson(bodyString);
             body = parsed != null ? parsed : bodyString;
           } else {
@@ -247,7 +242,7 @@ final class LambdaEventParser {
     if (queryParameters.isEmpty()) {
       queryParameters = extractQueryParameters(event.get("queryStringParameters"));
     }
-    Object body = extractBody(event);
+    Object body = extractBody(event, headers);
 
     Map<?, ?> requestContext = (Map<?, ?>) event.get("requestContext");
     String method = (String) requestContext.get("httpMethod");
@@ -283,7 +278,7 @@ final class LambdaEventParser {
     Map<String, String> pathParameters = extractPathParameters(event.get("pathParameters"));
     Map<String, List<String>> queryParameters =
         extractQueryParameters(event.get("queryStringParameters"));
-    Object body = extractBody(event);
+    Object body = extractBody(event, headers);
 
     Map<?, ?> requestContext = (Map<?, ?>) event.get("requestContext");
     Map<?, ?> http = (Map<?, ?>) requestContext.get("http");
@@ -337,7 +332,7 @@ final class LambdaEventParser {
     Map<String, String> pathParameters = extractPathParameters(event.get("pathParameters"));
     Map<String, List<String>> queryParameters =
         extractQueryParameters(event.get("queryStringParameters"));
-    Object body = extractBody(event);
+    Object body = extractBody(event, headers);
 
     Map<?, ?> requestContext = (Map<?, ?>) event.get("requestContext");
 
@@ -418,7 +413,7 @@ final class LambdaEventParser {
       queryParameters = extractQueryParameters(event.get("queryStringParameters"));
     }
 
-    Object body = extractBody(event);
+    Object body = extractBody(event, headers);
 
     String method = (String) event.get("httpMethod");
     String path = (String) event.get("path");
@@ -674,7 +669,7 @@ final class LambdaEventParser {
   }
 
   /** Helper method to extract and parse body from event */
-  private static Object extractBody(Map<String, Object> event) {
+  private static Object extractBody(Map<String, Object> event, Map<String, String> headers) {
     Object bodyObj = event.get("body");
     if (bodyObj == null) {
       return null;
@@ -693,20 +688,11 @@ final class LambdaEventParser {
       }
     }
 
-    // Try to parse as JSON
-    Object parsedBody = parseBodyAsJson(bodyString);
-    if (parsedBody != null) {
-      log.debug("Body parsed as JSON successfully");
-      return parsedBody;
-    }
-
-    // If not JSON, return the raw string
-    log.debug("Body is not JSON, returning raw string");
-    return bodyString;
+    return ContentTypeBodyParser.parseBody(bodyString, headers.get("content-type"));
   }
 
   /** Helper method to parse body as JSON */
-  private static Object parseBodyAsJson(String body) {
+  static Object parseBodyAsJson(String body) {
     if (body == null || body.isEmpty() || "null".equals(body)) {
       return null;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
@@ -95,8 +95,9 @@ final class LambdaEventParser {
         case ALB_MULTI_VALUE:
           return extractAlbData(event, triggerType);
         default:
-          // Unsupported trigger: AppSec skips the invocation entirely, so there is nothing to
-          // extract. The trigger type is carried by the caller, not by this result.
+          // Unsupported trigger: returning EMPTY makes the caller skip the invocation, so there is
+          // nothing to extract. The caller already recorded UNKNOWN as the trigger type, which is
+          // what reports the unsupported event at request end.
           return LambdaRequestData.EMPTY;
       }
     } catch (Exception e) {

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
@@ -3,6 +3,7 @@ package datadog.trace.lambda;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import datadog.trace.api.Config;
+import datadog.trace.lambda.ContentTypeBodyParser.ParseContext;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -242,7 +243,8 @@ final class LambdaEventParser {
     if (queryParameters.isEmpty()) {
       queryParameters = extractQueryParameters(event.get("queryStringParameters"));
     }
-    Object body = extractBody(event, headers);
+    ParseContext parseContext = new ParseContext();
+    Object body = extractBody(event, headers, parseContext);
 
     Map<?, ?> requestContext = (Map<?, ?>) event.get("requestContext");
     String method = (String) requestContext.get("httpMethod");
@@ -268,7 +270,8 @@ final class LambdaEventParser {
         extractHost(requestContext, headers),
         // REST APIs expose the parameterized route as the top-level "resource"
         stringOrNull(event.get("resource")),
-        null);
+        null,
+        parseContext.filenames());
   }
 
   /** Extracts data from API Gateway v2 (HTTP API) or Lambda URL event */
@@ -278,7 +281,8 @@ final class LambdaEventParser {
     Map<String, String> pathParameters = extractPathParameters(event.get("pathParameters"));
     Map<String, List<String>> queryParameters =
         extractQueryParameters(event.get("queryStringParameters"));
-    Object body = extractBody(event, headers);
+    ParseContext parseContext = new ParseContext();
+    Object body = extractBody(event, headers, parseContext);
 
     Map<?, ?> requestContext = (Map<?, ?>) event.get("requestContext");
     Map<?, ?> http = (Map<?, ?>) requestContext.get("http");
@@ -306,7 +310,8 @@ final class LambdaEventParser {
         body,
         extractHost(requestContext, headers),
         extractRouteKey(requestContext),
-        extractRawUri(event));
+        extractRawUri(event),
+        parseContext.filenames());
   }
 
   /**
@@ -332,7 +337,8 @@ final class LambdaEventParser {
     Map<String, String> pathParameters = extractPathParameters(event.get("pathParameters"));
     Map<String, List<String>> queryParameters =
         extractQueryParameters(event.get("queryStringParameters"));
-    Object body = extractBody(event, headers);
+    ParseContext parseContext = new ParseContext();
+    Object body = extractBody(event, headers, parseContext);
 
     Map<?, ?> requestContext = (Map<?, ?>) event.get("requestContext");
 
@@ -360,7 +366,8 @@ final class LambdaEventParser {
         extractHost(requestContext, headers),
         // Verbatim: WebSocket route keys are not "METHOD /path", and $connect is a real route
         routeKey,
-        null);
+        null,
+        parseContext.filenames());
   }
 
   /** Extracts data from ALB event (with or without multi-value headers) */
@@ -413,7 +420,8 @@ final class LambdaEventParser {
       queryParameters = extractQueryParameters(event.get("queryStringParameters"));
     }
 
-    Object body = extractBody(event, headers);
+    ParseContext parseContext = new ParseContext();
+    Object body = extractBody(event, headers, parseContext);
 
     String method = (String) event.get("httpMethod");
     String path = (String) event.get("path");
@@ -437,7 +445,8 @@ final class LambdaEventParser {
         body,
         stripPort(findHeader(headers, "host")),
         null,
-        null);
+        null,
+        parseContext.filenames());
   }
 
   /**
@@ -669,7 +678,8 @@ final class LambdaEventParser {
   }
 
   /** Helper method to extract and parse body from event */
-  private static Object extractBody(Map<String, Object> event, Map<String, String> headers) {
+  private static Object extractBody(
+      Map<String, Object> event, Map<String, String> headers, ParseContext parseContext) {
     Object bodyObj = event.get("body");
     if (bodyObj == null) {
       return null;
@@ -688,7 +698,7 @@ final class LambdaEventParser {
       }
     }
 
-    return ContentTypeBodyParser.parseBody(bodyString, headers.get("content-type"));
+    return ContentTypeBodyParser.parseBody(bodyString, headers.get("content-type"), parseContext);
   }
 
   /** Helper method to parse body as JSON */
@@ -758,6 +768,9 @@ final class LambdaEventParser {
      */
     final String rawUri;
 
+    /** Filenames of the multipart file parts carried by the body, empty when there are none. */
+    final List<String> filenames;
+
     static final LambdaRequestData EMPTY =
         new LambdaRequestData(
             Collections.emptyMap(),
@@ -792,7 +805,8 @@ final class LambdaEventParser {
           body,
           null,
           null,
-          null);
+          null,
+          Collections.emptyList());
     }
 
     LambdaRequestData(
@@ -807,7 +821,8 @@ final class LambdaEventParser {
         Object body,
         String host,
         String route,
-        String rawUri) {
+        String rawUri,
+        List<String> filenames) {
       this.headers = headers;
       this.method = method;
       this.path = path;
@@ -820,6 +835,7 @@ final class LambdaEventParser {
       this.host = host;
       this.route = route;
       this.rawUri = rawUri;
+      this.filenames = filenames;
     }
   }
 

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
@@ -3,6 +3,7 @@ package datadog.trace.lambda;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import datadog.trace.api.Config;
+import datadog.trace.api.appsec.MediaType;
 import datadog.trace.lambda.ContentTypeBodyParser.ParseContext;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -96,8 +97,7 @@ final class LambdaEventParser {
           return extractAlbData(event, triggerType);
         default:
           // Unsupported trigger: returning EMPTY makes the caller skip the invocation, so there is
-          // nothing to extract. The caller already recorded UNKNOWN as the trigger type, which is
-          // what reports the unsupported event at request end.
+          // nothing to extract sinc ethe event is not supported.
           return LambdaRequestData.EMPTY;
       }
     } catch (Exception e) {
@@ -162,10 +162,11 @@ final class LambdaEventParser {
         }
 
         if (bodyString != null) {
-          // A response body is only ever structured as JSON, never as urlencoded or multipart, but
-          // the rule deciding whether to try is shared with the request path so the two cannot
-          // drift
-          body = ContentTypeBodyParser.jsonOrRaw(bodyString, headers.get("content-type"));
+          // A response body is only ever structured as JSON, never as urlencoded or multipart
+          MediaType mediaType = MediaType.parse(headers.get("content-type"));
+          Object parsed =
+              ContentTypeBodyParser.isJsonOrUntyped(mediaType) ? parseBodyAsJson(bodyString) : null;
+          body = parsed != null ? parsed : bodyString;
         }
       }
 

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
@@ -97,7 +97,7 @@ final class LambdaEventParser {
           return extractAlbData(event, triggerType);
         default:
           // Unsupported trigger: returning EMPTY makes the caller skip the invocation, so there is
-          // nothing to extract sinc ethe event is not supported.
+          // nothing to extract since the event is not supported.
           return LambdaRequestData.EMPTY;
       }
     } catch (Exception e) {

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/LambdaEventParser.java
@@ -1,5 +1,7 @@
 package datadog.trace.lambda;
 
+import static java.util.stream.Collectors.joining;
+
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import datadog.trace.api.Config;
@@ -17,7 +19,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -509,9 +510,10 @@ final class LambdaEventParser {
 
   /**
    * Merges a {@code multiValueHeaders} map over headers already extracted from the single-value
-   * map, joining a header's values with {@code ", "} as the HTTP grammar allows. API Gateway v1 and
-   * ALB send both maps, and the single-value one keeps only one value of a repeated header, so
-   * reading it alone would hide the others from the WAF.
+   * map, joining a header's values the way its own grammar rejoins them: {@code "; "} for {@code
+   * Cookie} per RFC 6265, {@code ", "} for every other header. API Gateway v1 and ALB send both
+   * maps, and the single-value one keeps only one value of a repeated header, so reading it alone
+   * would hide the others from the WAF.
    *
    * @param headers mutated in place and returned; a value it already holds is overwritten by the
    *     multi-value reading of the same header
@@ -530,7 +532,10 @@ final class LambdaEventParser {
       String key = String.valueOf(entry.getKey()).toLowerCase(Locale.ROOT);
       if (entry.getValue() instanceof List) {
         List<?> values = (List<?>) entry.getValue();
-        headers.put(key, values.stream().map(String::valueOf).collect(Collectors.joining(", ")));
+        // A cookie value may itself hold a comma, so joining cookies with ", " would let the second
+        // cookie's name be read as part of the first one's value and hide it from the cookie rules
+        String separator = "cookie".equals(key) ? "; " : ", ";
+        headers.put(key, values.stream().map(String::valueOf).collect(joining(separator)));
       } else {
         // Not a shape AWS sends, but reported rather than dropped: the runtime would still deliver
         // the header
@@ -663,8 +668,7 @@ final class LambdaEventParser {
       List<?> cookiesList = (List<?>) cookiesObj;
       if (!cookiesList.isEmpty()) {
         // Join cookies with "; " separator per RFC 6265
-        String cookieValue =
-            cookiesList.stream().map(String::valueOf).collect(Collectors.joining("; "));
+        String cookieValue = cookiesList.stream().map(String::valueOf).collect(joining("; "));
 
         // Merge with existing cookie header if present
         String existingCookie = headers.get("cookie");

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/MultipartSplitter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/MultipartSplitter.java
@@ -1,6 +1,7 @@
 package datadog.trace.lambda;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -39,7 +40,8 @@ final class MultipartSplitter {
   /**
    * Splits a multipart body into at most {@code partBudget} parts.
    *
-   * @return the parts found, in order; empty if the body holds none
+   * @return the parts found, in order; empty if the body holds none or is not parseable as
+   *     multipart
    */
   static List<Part> split(final String body, final String boundary, final int partBudget) {
     final List<Part> parts = new ArrayList<>();
@@ -68,14 +70,12 @@ final class MultipartSplitter {
       String contentType = null;
       int cursor = headerStart;
       boolean headersComplete = false;
-      int malformedPartEnd = -1;
       while (cursor < length) {
         if (body.startsWith(delimiter, cursor) && endsLine(body, cursor + delimiter.length())) {
-          // This part's headers are not followed by a blank line. Stop here: reading on would
-          // consume the next part's delimiter and merge its headers into this part, collapsing
-          // every following part into this one.
-          malformedPartEnd = cursor;
-          break;
+          // This part's headers are not followed by a blank line, so no conforming parser reads
+          // this body as multipart. Report nothing rather than the parts that happen to survive:
+          // the caller then keeps the raw string, and the WAF sees every byte of it.
+          return Collections.emptyList();
         }
         final int newline = body.indexOf('\n', cursor);
         final int lineEnd = newline < 0 ? length : newline;
@@ -100,12 +100,6 @@ final class MultipartSplitter {
           break;
         }
         cursor = newline + 1;
-      }
-      if (malformedPartEnd >= 0) {
-        // Resume at the delimiter the headers ran into. It is past the current position, so the
-        // outer scan still makes progress.
-        position = malformedPartEnd;
-        continue;
       }
       if (!headersComplete) {
         // Body truncated inside the headers: there is no content to report

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/MultipartSplitter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/MultipartSplitter.java
@@ -102,8 +102,10 @@ final class MultipartSplitter {
         cursor = newline + 1;
       }
       if (!headersComplete) {
-        // Body truncated inside the headers: there is no content to report
-        break;
+        // The body ended inside this part's headers. They are content in their own right — a
+        // filename lives there — and no parser accepts a body cut short like this, so report
+        // nothing and let the caller keep the raw string.
+        return Collections.emptyList();
       }
       final int next = nextDelimiter(body, delimiter, cursor);
       parts.add(new Part(contentDisposition, contentType, cursor, contentEnd(body, cursor, next)));
@@ -239,14 +241,16 @@ final class MultipartSplitter {
   }
 
   /**
-   * A delimiter only delimits if its line ends there, RFC 2046 transport padding aside. A content
-   * line that merely starts with it — {@code --x-not-a-boundary} for a boundary of {@code x} — is
-   * data, and must not end the part early and hide the rest from the WAF.
+   * A delimiter only delimits if its line ends there, RFC 2046 transport padding aside — for the
+   * close delimiter, past its trailing {@code --}. A content line that merely starts with one, be
+   * it {@code --x-not-a-boundary} or {@code --x--not-a-close}, is data, and must not end the part
+   * early and hide the rest from the WAF.
    *
    * @param after the index just past the matched delimiter
    */
   private static boolean endsLine(final String body, final int after) {
-    return after == body.length() || body.startsWith("--", after) || lineStart(body, after) >= 0;
+    final int end = body.startsWith("--", after) ? after + 2 : after;
+    return end == body.length() || lineStart(body, end) >= 0;
   }
 
   /**

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/MultipartSplitter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/MultipartSplitter.java
@@ -50,7 +50,7 @@ final class MultipartSplitter {
     }
     final String delimiter = "--" + boundary;
     final int length = body.length();
-    int position = body.startsWith(delimiter) ? 0 : nextDelimiter(body, delimiter, 0);
+    int position = nextDelimiter(body, delimiter, 0);
 
     while (position >= 0 && parts.size() < partBudget) {
       final int afterDelimiter = position + delimiter.length();
@@ -107,7 +107,11 @@ final class MultipartSplitter {
         // nothing and let the caller keep the raw string.
         return Collections.emptyList();
       }
-      final int next = nextDelimiter(body, delimiter, cursor);
+      // The search starts past the first line break of the content, never at the content itself: a
+      // delimiter there would have no line break of its own, having spent the one that terminated
+      // the headers.
+      final int contentBreak = body.indexOf('\n', cursor);
+      final int next = contentBreak < 0 ? -1 : nextDelimiter(body, delimiter, contentBreak + 1);
       parts.add(new Part(contentDisposition, contentType, cursor, contentEnd(body, cursor, next)));
       position = next;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/MultipartSplitter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/MultipartSplitter.java
@@ -70,7 +70,7 @@ final class MultipartSplitter {
       boolean headersComplete = false;
       int malformedPartEnd = -1;
       while (cursor < length) {
-        if (body.startsWith(delimiter, cursor)) {
+        if (body.startsWith(delimiter, cursor) && endsLine(body, cursor + delimiter.length())) {
           // This part's headers are not followed by a blank line. Stop here: reading on would
           // consume the next part's delimiter and merge its headers into this part, collapsing
           // every following part into this one.
@@ -132,11 +132,10 @@ final class MultipartSplitter {
   }
 
   /**
-   * Reads a header parameter, case preserved. The parameter name is matched case-insensitively and
-   * only at a parameter boundary, so {@code filename} does not satisfy a lookup for {@code name}.
-   * Quoted values may contain separators and {@code \"} escapes, and are skipped whole: a field
-   * named {@code "; filename=x"} does not read as a {@code filename} parameter. RFC 7230 optional
-   * whitespace is tolerated on both sides of the {@code =}.
+   * Reads a header parameter, case preserved. The name is matched case-insensitively and only at a
+   * parameter boundary, so {@code filename} does not satisfy a lookup for {@code name}. Quoted
+   * values may hold separators and {@code \"} escapes, and are skipped whole: a field named {@code
+   * "; filename=x"} does not read as a {@code filename} parameter.
    *
    * @return the parameter value, {@code ""} when it is present but empty, or {@code null} when the
    *     parameter is absent
@@ -231,17 +230,29 @@ final class MultipartSplitter {
    * @return the index the delimiter starts at, or {@code -1} if there is none
    */
   private static int nextDelimiter(final String body, final String delimiter, final int from) {
-    if (body.startsWith(delimiter, from)) {
+    if (body.startsWith(delimiter, from) && endsLine(body, from + delimiter.length())) {
       return from;
     }
     for (int newline = body.indexOf('\n', from);
         newline >= 0;
         newline = body.indexOf('\n', newline + 1)) {
-      if (body.startsWith(delimiter, newline + 1)) {
+      if (body.startsWith(delimiter, newline + 1)
+          && endsLine(body, newline + 1 + delimiter.length())) {
         return newline + 1;
       }
     }
     return -1;
+  }
+
+  /**
+   * A delimiter only delimits if its line ends there, RFC 2046 transport padding aside. A content
+   * line that merely starts with it — {@code --x-not-a-boundary} for a boundary of {@code x} — is
+   * data, and must not end the part early and hide the rest from the WAF.
+   *
+   * @param after the index just past the matched delimiter
+   */
+  private static boolean endsLine(final String body, final int after) {
+    return after == body.length() || body.startsWith("--", after) || lineStart(body, after) >= 0;
   }
 
   /**
@@ -305,8 +316,7 @@ final class MultipartSplitter {
     while (end > start && isOptionalWhitespace(body.charAt(end - 1))) {
       end--;
     }
-    // The canonical spelling is tried first: its comparison is intrinsified where the
-    // case-insensitive one walks char by char, and it is what every real client sends.
+    // The canonical spelling first: that comparison is intrinsified, and every real client sends it
     if (end - start != name.length()
         || !(body.regionMatches(start, name, 0, name.length())
             || body.regionMatches(true, start, name, 0, name.length()))) {

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/MultipartSplitter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/MultipartSplitter.java
@@ -1,10 +1,7 @@
 package datadog.trace.lambda;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 
 /**
  * Splits a {@code multipart/*} body into its parts and reads {@code Content-Type} / {@code
@@ -20,21 +17,22 @@ final class MultipartSplitter {
    * One part of a multipart body. Content is an index range into the body passed to {@link #split}.
    */
   static final class Part {
-    private final Map<String, String> headers;
+    /** {@code null} when the part declares no such header. Duplicates keep the last seen value. */
+    final String contentDisposition;
+
+    final String contentType;
     final int contentStart;
     final int contentEnd;
 
-    private Part(final Map<String, String> headers, final int contentStart, final int contentEnd) {
-      this.headers = headers;
+    private Part(
+        final String contentDisposition,
+        final String contentType,
+        final int contentStart,
+        final int contentEnd) {
+      this.contentDisposition = contentDisposition;
+      this.contentType = contentType;
       this.contentStart = contentStart;
       this.contentEnd = contentEnd;
-    }
-
-    /**
-     * @param lowercaseName the header name, lowercased by the caller
-     */
-    String header(final String lowercaseName) {
-      return headers.get(lowercaseName);
     }
   }
 
@@ -64,7 +62,10 @@ final class MultipartSplitter {
         position = nextDelimiter(body, delimiter, afterDelimiter);
         continue;
       }
-      final Map<String, String> headers = new HashMap<>(4);
+      // Only these two headers are ever read, so the others are matched and dropped rather than
+      // collected: a part declaring thousands of them costs nothing but the scan.
+      String contentDisposition = null;
+      String contentType = null;
       int cursor = headerStart;
       boolean headersComplete = false;
       int malformedPartEnd = -1;
@@ -85,7 +86,15 @@ final class MultipartSplitter {
           cursor = newline < 0 ? length : newline + 1;
           break;
         }
-        addHeader(headers, body, cursor, trimmed);
+        final String disposition = headerValue(body, cursor, trimmed, "Content-Disposition");
+        if (disposition != null) {
+          contentDisposition = disposition;
+        } else {
+          final String type = headerValue(body, cursor, trimmed, "Content-Type");
+          if (type != null) {
+            contentType = type;
+          }
+        }
         if (newline < 0) {
           cursor = length;
           break;
@@ -103,7 +112,7 @@ final class MultipartSplitter {
         break;
       }
       final int next = nextDelimiter(body, delimiter, cursor);
-      parts.add(new Part(headers, cursor, contentEnd(body, cursor, next)));
+      parts.add(new Part(contentDisposition, contentType, cursor, contentEnd(body, cursor, next)));
       position = next;
     }
     return parts;
@@ -206,7 +215,7 @@ final class MultipartSplitter {
   private static int skipOptionalWhitespace(final String headerValue, final int from) {
     int i = from;
     final int length = headerValue.length();
-    while (i < length && (headerValue.charAt(i) == ' ' || headerValue.charAt(i) == '\t')) {
+    while (i < length && isOptionalWhitespace(headerValue.charAt(i))) {
       i++;
     }
     return i;
@@ -243,7 +252,7 @@ final class MultipartSplitter {
   private static int lineStart(final String body, final int from) {
     int i = from;
     final int length = body.length();
-    while (i < length && (body.charAt(i) == ' ' || body.charAt(i) == '\t')) {
+    while (i < length && isOptionalWhitespace(body.charAt(i))) {
       i++;
     }
     if (i < length && body.charAt(i) == '\r') {
@@ -267,17 +276,46 @@ final class MultipartSplitter {
     return end;
   }
 
-  private static void addHeader(
-      final Map<String, String> headers, final String body, final int from, final int to) {
+  /**
+   * Reads one header line, without allocating unless the name is the one asked for.
+   *
+   * @param from the first index of the line, {@code to} the index past its last character, the
+   *     trailing {@code \r} already excluded
+   * @param name the header name to match, case-insensitively
+   * @return the trimmed header value, or {@code null} when the line declares another header or is
+   *     not a header line at all — there is no colon, and obs-fold is unsupported
+   */
+  private static String headerValue(
+      final String body, final int from, final int to, final String name) {
+    int colon = -1;
     for (int i = from; i < to; i++) {
       if (body.charAt(i) == ':') {
-        final String name = body.substring(from, i).trim().toLowerCase(Locale.ROOT);
-        if (!name.isEmpty()) {
-          headers.put(name, body.substring(i + 1, to).trim());
-        }
-        return;
+        colon = i;
+        break;
       }
     }
-    // No colon: not a header line, and no obs-fold support, so drop it
+    if (colon < 0) {
+      return null;
+    }
+    int start = from;
+    int end = colon;
+    while (start < end && isOptionalWhitespace(body.charAt(start))) {
+      start++;
+    }
+    while (end > start && isOptionalWhitespace(body.charAt(end - 1))) {
+      end--;
+    }
+    // The canonical spelling is tried first: its comparison is intrinsified where the
+    // case-insensitive one walks char by char, and it is what every real client sends.
+    if (end - start != name.length()
+        || !(body.regionMatches(start, name, 0, name.length())
+            || body.regionMatches(true, start, name, 0, name.length()))) {
+      return null;
+    }
+    return body.substring(colon + 1, to).trim();
+  }
+
+  private static boolean isOptionalWhitespace(final char c) {
+    return c == ' ' || c == '\t';
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/MultipartSplitter.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/MultipartSplitter.java
@@ -1,0 +1,283 @@
+package datadog.trace.lambda;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Splits a {@code multipart/*} body into its parts and reads {@code Content-Type} / {@code
+ * Content-Disposition} parameters.
+ */
+final class MultipartSplitter {
+
+  private static final int MAX_BOUNDARY_LENGTH = 70;
+
+  private MultipartSplitter() {}
+
+  /**
+   * One part of a multipart body. Content is an index range into the body passed to {@link #split}.
+   */
+  static final class Part {
+    private final Map<String, String> headers;
+    final int contentStart;
+    final int contentEnd;
+
+    private Part(final Map<String, String> headers, final int contentStart, final int contentEnd) {
+      this.headers = headers;
+      this.contentStart = contentStart;
+      this.contentEnd = contentEnd;
+    }
+
+    /**
+     * @param lowercaseName the header name, lowercased by the caller
+     */
+    String header(final String lowercaseName) {
+      return headers.get(lowercaseName);
+    }
+  }
+
+  /**
+   * Splits a multipart body into at most {@code partBudget} parts.
+   *
+   * @return the parts found, in order; empty if the body holds none
+   */
+  static List<Part> split(final String body, final String boundary, final int partBudget) {
+    final List<Part> parts = new ArrayList<>();
+    if (body == null || boundary == null || boundary.isEmpty() || partBudget <= 0) {
+      return parts;
+    }
+    final String delimiter = "--" + boundary;
+    final int length = body.length();
+    int position = body.startsWith(delimiter) ? 0 : nextDelimiter(body, delimiter, 0);
+
+    while (position >= 0 && parts.size() < partBudget) {
+      final int afterDelimiter = position + delimiter.length();
+      if (body.startsWith("--", afterDelimiter)) {
+        // Close delimiter: anything past it is the epilogue
+        break;
+      }
+      final int headerStart = lineStart(body, afterDelimiter);
+      if (headerStart < 0) {
+        // Not a part boundary after all — the delimiter was part of some part's content
+        position = nextDelimiter(body, delimiter, afterDelimiter);
+        continue;
+      }
+      final Map<String, String> headers = new HashMap<>(4);
+      int cursor = headerStart;
+      boolean headersComplete = false;
+      int malformedPartEnd = -1;
+      while (cursor < length) {
+        if (body.startsWith(delimiter, cursor)) {
+          // This part's headers are not followed by a blank line. Stop here: reading on would
+          // consume the next part's delimiter and merge its headers into this part, collapsing
+          // every following part into this one.
+          malformedPartEnd = cursor;
+          break;
+        }
+        final int newline = body.indexOf('\n', cursor);
+        final int lineEnd = newline < 0 ? length : newline;
+        final int trimmed =
+            lineEnd > cursor && body.charAt(lineEnd - 1) == '\r' ? lineEnd - 1 : lineEnd;
+        if (trimmed == cursor) {
+          headersComplete = true;
+          cursor = newline < 0 ? length : newline + 1;
+          break;
+        }
+        addHeader(headers, body, cursor, trimmed);
+        if (newline < 0) {
+          cursor = length;
+          break;
+        }
+        cursor = newline + 1;
+      }
+      if (malformedPartEnd >= 0) {
+        // Resume at the delimiter the headers ran into. It is past the current position, so the
+        // outer scan still makes progress.
+        position = malformedPartEnd;
+        continue;
+      }
+      if (!headersComplete) {
+        // Body truncated inside the headers: there is no content to report
+        break;
+      }
+      final int next = nextDelimiter(body, delimiter, cursor);
+      parts.add(new Part(headers, cursor, contentEnd(body, cursor, next)));
+      position = next;
+    }
+    return parts;
+  }
+
+  /**
+   * Reads the {@code boundary} parameter of a {@code Content-Type} header, case preserved.
+   *
+   * @return the boundary, or {@code null} if absent or unusable
+   */
+  static String extractBoundary(final String contentType) {
+    final String boundary = parameter(contentType, "boundary");
+    if (boundary == null || boundary.isEmpty() || boundary.length() > MAX_BOUNDARY_LENGTH) {
+      return null;
+    }
+    return boundary;
+  }
+
+  /**
+   * Reads a header parameter, case preserved. The parameter name is matched case-insensitively and
+   * only at a parameter boundary, so {@code filename} does not satisfy a lookup for {@code name}.
+   * Quoted values may contain separators and {@code \"} escapes, and are skipped whole: a field
+   * named {@code "; filename=x"} does not read as a {@code filename} parameter. RFC 7230 optional
+   * whitespace is tolerated on both sides of the {@code =}.
+   *
+   * @return the parameter value, {@code ""} when it is present but empty, or {@code null} when the
+   *     parameter is absent
+   */
+  static String parameter(final String headerValue, final String paramName) {
+    if (headerValue == null || paramName == null) {
+      return null;
+    }
+    final int length = headerValue.length();
+    final int nameLength = paramName.length();
+    boolean atBoundary = true;
+    for (int i = 0; i < length; i++) {
+      final char c = headerValue.charAt(i);
+      if (c == '"') {
+        i = endOfQuoted(headerValue, i);
+        atBoundary = false;
+        continue;
+      }
+      if (atBoundary && headerValue.regionMatches(true, i, paramName, 0, nameLength)) {
+        final int equals = skipOptionalWhitespace(headerValue, i + nameLength);
+        if (equals < length && headerValue.charAt(equals) == '=') {
+          return value(headerValue, skipOptionalWhitespace(headerValue, equals + 1));
+        }
+      }
+      atBoundary = isParameterSeparator(c);
+    }
+    return null;
+  }
+
+  /**
+   * Walks a quoted value, honouring {@code \"} escapes.
+   *
+   * @param openQuote the index of the opening quote
+   * @return the index of the closing quote, or the body length when the quote is unterminated
+   */
+  private static int endOfQuoted(final String headerValue, final int openQuote) {
+    final int length = headerValue.length();
+    for (int i = openQuote + 1; i < length; i++) {
+      final char c = headerValue.charAt(i);
+      if (c == '\\' && i + 1 < length) {
+        i++;
+      } else if (c == '"') {
+        return i;
+      }
+    }
+    return length;
+  }
+
+  private static String value(final String headerValue, final int from) {
+    final int length = headerValue.length();
+    if (from < length && headerValue.charAt(from) == '"') {
+      // An unterminated quote ends at the body length, so what was read is kept rather than the
+      // parameter being dropped.
+      final int close = endOfQuoted(headerValue, from);
+      final StringBuilder unquoted = new StringBuilder(close - from);
+      for (int i = from + 1; i < close; i++) {
+        final char c = headerValue.charAt(i);
+        if (c == '\\' && i + 1 < length) {
+          unquoted.append(headerValue.charAt(++i));
+        } else {
+          unquoted.append(c);
+        }
+      }
+      return unquoted.toString();
+    }
+    int end = length;
+    for (int i = from; i < length; i++) {
+      if (isParameterSeparator(headerValue.charAt(i))) {
+        end = i;
+        break;
+      }
+    }
+    return headerValue.substring(from, end);
+  }
+
+  private static int skipOptionalWhitespace(final String headerValue, final int from) {
+    int i = from;
+    final int length = headerValue.length();
+    while (i < length && (headerValue.charAt(i) == ' ' || headerValue.charAt(i) == '\t')) {
+      i++;
+    }
+    return i;
+  }
+
+  private static boolean isParameterSeparator(final char c) {
+    return c == ';' || c == ',' || c == ' ' || c == '\t';
+  }
+
+  /**
+   * Finds the next delimiter at or after {@code from}.
+   *
+   * @return the index the delimiter starts at, or {@code -1} if there is none
+   */
+  private static int nextDelimiter(final String body, final String delimiter, final int from) {
+    if (body.startsWith(delimiter, from)) {
+      return from;
+    }
+    for (int newline = body.indexOf('\n', from);
+        newline >= 0;
+        newline = body.indexOf('\n', newline + 1)) {
+      if (body.startsWith(delimiter, newline + 1)) {
+        return newline + 1;
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Skips the linear whitespace and line break that follow a delimiter.
+   *
+   * @return the index the header lines start at, or {@code -1} if no line break follows
+   */
+  private static int lineStart(final String body, final int from) {
+    int i = from;
+    final int length = body.length();
+    while (i < length && (body.charAt(i) == ' ' || body.charAt(i) == '\t')) {
+      i++;
+    }
+    if (i < length && body.charAt(i) == '\r') {
+      i++;
+    }
+    return i < length && body.charAt(i) == '\n' ? i + 1 : -1;
+  }
+
+  /**
+   * Ends a part's content before the line break that introduces the next delimiter, or at the end
+   * of the body when the closing delimiter was truncated away.
+   */
+  private static int contentEnd(final String body, final int contentStart, final int next) {
+    if (next < 0) {
+      return body.length();
+    }
+    int end = next > contentStart ? next - 1 : contentStart;
+    if (end > contentStart && body.charAt(end - 1) == '\r') {
+      end--;
+    }
+    return end;
+  }
+
+  private static void addHeader(
+      final Map<String, String> headers, final String body, final int from, final int to) {
+    for (int i = from; i < to; i++) {
+      if (body.charAt(i) == ':') {
+        final String name = body.substring(from, i).trim().toLowerCase(Locale.ROOT);
+        if (!name.isEmpty()) {
+          headers.put(name, body.substring(i + 1, to).trim());
+        }
+        return;
+      }
+    }
+    // No colon: not a header line, and no obs-fold support, so drop it
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
@@ -29,8 +29,6 @@ class ContentTypeBodyParserTest {
       value = {
         // content type absent or blank: best-effort JSON, as before content-type dispatch existed
         "{\"a\":1}          |                                   | MAP",
-        "{\"a\":1}          | '   '                             | MAP",
-        "{\"a\":1}          | ''                                | MAP",
         "not json           |                                   | STRING",
         // a header holding nothing but parameters declares no type either
         "{\"a\":1}          | '; charset=utf-8'                 | MAP",
@@ -45,7 +43,6 @@ class ContentTypeBodyParserTest {
         "{\"a\":1}          | application/javascript            | MAP",
         // urlencoded
         "a=1                | application/x-www-form-urlencoded | MAP",
-        "a=1                | APPLICATION/X-WWW-FORM-URLENCODED | MAP",
         // a multipart body whose boundary happens to contain "json" must still reach the multipart
         // parser rather than being handed to the JSON parser
         "not multipart      | multipart/x; boundary=--json      | STRING",
@@ -55,16 +52,11 @@ class ContentTypeBodyParserTest {
         // Double, which no string rule can match
         "{\"a\":1}          | text/plain                        | STRING",
         "12345              | text/plain                        | STRING",
-        "{\"a\":1}          | text/html                         | STRING",
         // anything else
         "{\"a\":1}          | application/xml                   | STRING",
-        "{\"a\":1}          | application/octet-stream          | STRING",
         "{\"a\":1}          | garbage                           | STRING",
         // a slashless header declares a type but no subtype, so it is not JSON-ish
         "{\"a\":1}          | json                              | STRING",
-        // known gap: a JSON-carrying type whose name says neither "json" nor "javascript" keeps
-        // the raw string, which the WAF can still match string rules against
-        "{\"a\":1}          | application/csp-report            | STRING",
       })
   void dispatchesOnContentType(String body, String contentType, String expectedKind) {
     Object parsed = parseBody(body, contentType);
@@ -154,16 +146,6 @@ class ContentTypeBodyParserTest {
   }
 
   @Test
-  void parsesUrlEncodedPairsUpToThePartAllowance() {
-    StringBuilder body = new StringBuilder();
-    for (int i = 0; i < MAX_PARTS; i++) {
-      body.append(i == 0 ? "" : "&").append('k').append(i).append("=v");
-    }
-
-    assertEquals(MAX_PARTS, urlEncoded(body.toString()).size());
-  }
-
-  @Test
   void keepsUrlEncodedBodyOverThePartAllowanceAsRawString() {
     StringBuilder body = new StringBuilder();
     for (int i = 0; i < MAX_PARTS; i++) {
@@ -174,20 +156,6 @@ class ContentTypeBodyParserTest {
 
     // Truncating would hide the trailing parameter from every WAF rule, so the whole body is kept
     // as a string instead — still matchable, just unstructured
-    assertEquals(raw, parseBody(raw, "application/x-www-form-urlencoded"));
-  }
-
-  @Test
-  void countsNamelessUrlEncodedPairsTowardsTheCap() {
-    StringBuilder body = new StringBuilder();
-    for (int i = 0; i < MAX_PARTS; i++) {
-      body.append("=v&");
-    }
-    body.append("a=1");
-    String raw = body.toString();
-
-    // Nameless pairs still do decoding work, so they count towards the cap even though none of them
-    // ends up in the map
     assertEquals(raw, parseBody(raw, "application/x-www-form-urlencoded"));
   }
 
@@ -234,24 +202,19 @@ class ContentTypeBodyParserTest {
   }
 
   @Test
-  void keepsMultipartPartsThatDeclareNoContentTypeAsRawStrings() {
+  void keepsMultipartPartsWithoutAUsableContentTypeAsRawStrings() {
     // A part with no Content-Type is text/plain per RFC 7578, section 4.4, not a body of unknown
-    // type: a JSON parse would hand the WAF a Double and a Boolean no string rule can match
+    // type: a JSON parse would hand the WAF a Double no string rule can match. An empty header
+    // reads the same way, and is the only other spelling to reach here — MultipartSplitter trims.
     Map<?, ?> fields =
-        multipart(field("amount", "12345"), field("flag", "true"), field("json", "{\"a\":1}"));
+        multipart(
+            field("amount", "12345"),
+            field("json", "{\"a\":1}"),
+            part("form-data; name=\"empty\"", "", "12345"));
 
     assertEquals("12345", fields.get("amount"));
-    assertEquals("true", fields.get("flag"));
     assertEquals("{\"a\":1}", fields.get("json"));
-  }
-
-  @Test
-  void keepsMultipartPartsWithAnEmptyContentTypeAsRawStrings() {
-    // Only the empty case is worth covering: MultipartSplitter trims header values, so a
-    // whitespace-only Content-Type reaches the parser as "" and not as its original spelling
-    Map<?, ?> fields = multipart(part("form-data; name=\"amount\"", "", "12345"));
-
-    assertEquals("12345", fields.get("amount"));
+    assertEquals("12345", fields.get("empty"));
   }
 
   @Test
@@ -278,13 +241,14 @@ class ContentTypeBodyParserTest {
   }
 
   @Test
-  void parsesNestedMultipartBodiesAndSkipsTheirFileParts() {
+  void parsesNestedMultipartBodiesAndReportsTheirFilePartsByNameOnly() {
     String inner = body("inner", field("nested", "value"), file("upload", "f.txt", "data"));
     String nesting = outer(part("form-data; name=group", "multipart/mixed; boundary=inner", inner));
 
     Map<?, ?> fields = asMap(parseBody(nesting, MULTIPART));
 
     assertEquals(singletonMap("nested", "value"), fields.get("group"));
+    assertEquals(singletonList("f.txt"), filenamesOf(nesting));
   }
 
   @Test
@@ -298,19 +262,6 @@ class ContentTypeBodyParserTest {
 
     assertInstanceOf(Map.class, fields.get("first"));
     assertEquals(urlEncoded, fields.get("second"));
-  }
-
-  @Test
-  void spendsThePartAllowanceOnlyOnPairsItReads() {
-    // Half the allowance each, less their two parts: they only fit if neither is charged upfront
-    String urlEncoded = urlEncodedPairs((MAX_PARTS - 2) / 2);
-    Map<?, ?> fields =
-        multipart(
-            part("form-data; name=first", URL_ENCODED, urlEncoded),
-            part("form-data; name=second", URL_ENCODED, urlEncoded));
-
-    assertInstanceOf(Map.class, fields.get("first"));
-    assertInstanceOf(Map.class, fields.get("second"));
   }
 
   private static String urlEncodedPairs(int count) {
@@ -410,14 +361,6 @@ class ContentTypeBodyParserTest {
 
     assertEquals(emptyList(), filenamesOf(body));
     assertEquals(singletonMap("user", "admin"), multipartBody(body));
-  }
-
-  @Test
-  void reportsFilenamesFromNestedMultipartParts() {
-    String inner = body("inner", file("attachment", "nested.txt", "bytes"));
-    String nesting = outer(part("form-data; name=group", "multipart/mixed; boundary=inner", inner));
-
-    assertEquals(singletonList("nested.txt"), filenamesOf(nesting));
   }
 
   @Test

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
@@ -2,13 +2,19 @@ package datadog.trace.lambda;
 
 import static datadog.trace.lambda.ContentTypeBodyParser.MAX_DEPTH;
 import static datadog.trace.lambda.ContentTypeBodyParser.MAX_ELEMENTS;
+import static datadog.trace.lambda.ContentTypeBodyParser.MAX_PARTS;
+import static datadog.trace.lambda.ContentTypeBodyParser.dispatch;
 import static datadog.trace.lambda.ContentTypeBodyParser.parseBody;
+import static datadog.trace.lambda.ContentTypeBodyParser.parseMultipart;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import datadog.trace.lambda.ContentTypeBodyParser.ParseContext;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -39,8 +45,9 @@ class ContentTypeBodyParserTest {
         // urlencoded
         "a=1                | application/x-www-form-urlencoded | MAP",
         "a=1                | APPLICATION/X-WWW-FORM-URLENCODED | MAP",
-        // multipart is not structured yet
-        "{\"a\":1}          | multipart/form-data; boundary=xy  | STRING",
+        // a multipart body whose boundary happens to contain "json" must still reach the multipart
+        // parser rather than being handed to the JSON parser
+        "not multipart      | multipart/x; boundary=--json      | STRING",
         // text/*: never structured, even when it holds JSON. A JSON parse of "12345" would yield a
         // Double, which no string rule can match
         "{\"a\":1}          | text/plain                        | STRING",
@@ -89,9 +96,9 @@ class ContentTypeBodyParserTest {
   void keepsRawStringOnceMaxDepthIsReached() {
     String body = "{\"a\":1}";
 
-    assertEquals(body, ContentTypeBodyParser.dispatch(body, "application/json", MAX_DEPTH));
+    assertEquals(body, dispatch(body, "application/json", MAX_DEPTH, new ParseContext()));
     assertInstanceOf(
-        Map.class, ContentTypeBodyParser.dispatch(body, "application/json", MAX_DEPTH - 1));
+        Map.class, dispatch(body, "application/json", MAX_DEPTH - 1, new ParseContext()));
   }
 
   @Test
@@ -152,9 +159,9 @@ class ContentTypeBodyParserTest {
   }
 
   @Test
-  void capsUrlEncodedPairsAtMaxElements() {
+  void parsesUrlEncodedPairsUpToMaxElements() {
     StringBuilder body = new StringBuilder();
-    for (int i = 0; i < MAX_ELEMENTS + 1; i++) {
+    for (int i = 0; i < MAX_ELEMENTS; i++) {
       body.append(i == 0 ? "" : "&").append('k').append(i).append("=v");
     }
 
@@ -162,7 +169,21 @@ class ContentTypeBodyParserTest {
   }
 
   @Test
-  void stopsScanningNamelessUrlEncodedPairsAtTheCap() {
+  void keepsUrlEncodedBodyOverMaxElementsAsRawString() {
+    StringBuilder body = new StringBuilder();
+    for (int i = 0; i < MAX_ELEMENTS; i++) {
+      body.append('k').append(i).append("=v&");
+    }
+    body.append("attack=payload");
+    String raw = body.toString();
+
+    // Truncating would hide the trailing parameter from every WAF rule, so the whole body is kept
+    // as a string instead — still matchable, just unstructured
+    assertEquals(raw, parseBody(raw, "application/x-www-form-urlencoded"));
+  }
+
+  @Test
+  void countsNamelessUrlEncodedPairsTowardsTheCap() {
     StringBuilder body = new StringBuilder();
     for (int i = 0; i < MAX_ELEMENTS; i++) {
       body.append("=v&");
@@ -170,8 +191,8 @@ class ContentTypeBodyParserTest {
     body.append("a=1");
     String raw = body.toString();
 
-    // Nameless pairs still do decoding work, so they exhaust the cap and the trailing parameter is
-    // never reached; nothing survives, so the raw body is kept
+    // Nameless pairs still do decoding work, so they count towards the cap even though none of them
+    // ends up in the map
     assertEquals(raw, parseBody(raw, "application/x-www-form-urlencoded"));
   }
 
@@ -179,6 +200,321 @@ class ContentTypeBodyParserTest {
   void keepsUnparseableUrlEncodedBodyAsRawString() {
     // Nothing but separators: no parameter survives, so the raw body is kept
     assertEquals("&&&", parseBody("&&&", "application/x-www-form-urlencoded"));
+  }
+
+  @Test
+  void parsesMultipartFieldsIntoAMap() {
+    Map<String, Object> fields = multipart(field("user", "admin"), field("role", "root"));
+
+    assertEquals("admin", fields.get("user"));
+    assertEquals("root", fields.get("role"));
+    assertEquals(2, fields.size());
+  }
+
+  @Test
+  void skipsMultipartFileParts() {
+    Map<String, Object> fields = multipart(field("user", "admin"), file("upload", "f.txt", "data"));
+
+    assertEquals("admin", fields.get("user"));
+    assertEquals(1, fields.size());
+  }
+
+  @Test
+  void skipsMultipartPartsWithAnEmptyFilename() {
+    // An untouched file input: browsers send filename="", which is a file part all the same
+    Map<String, Object> fields = multipart(field("user", "admin"), file("upload", "", ""));
+
+    assertEquals(1, fields.size());
+  }
+
+  @Test
+  void keepsAFileOnlyMultipartBodyAsARawString() {
+    // A raw string still matches string rules; an empty map would tell the WAF the body was empty
+    String body = outer(file("upload", "f.txt", "data"));
+
+    assertEquals(body, parseBody(body, MULTIPART));
+  }
+
+  @Test
+  void skipsMultipartPartsWithoutAName() {
+    assertEquals(
+        outer(part("form-data", "novalue"), part("form-data; name=", "empty")),
+        parseBody(
+            outer(part("form-data", "novalue"), part("form-data; name=", "empty")), MULTIPART));
+  }
+
+  @Test
+  void skipsMultipartPartsWithoutAContentDisposition() {
+    Map<String, Object> fields = multipart(field("user", "admin"), part(null, "orphan"));
+
+    assertEquals(1, fields.size());
+  }
+
+  @Test
+  void dispatchesOnEachMultipartPartsOwnContentType() {
+    Map<String, Object> fields =
+        multipart(
+            part("form-data; name=payload", "application/json", "{\"a\":1}"),
+            part("form-data; name=plain", "text/plain", "12345"),
+            part("form-data; name=form", "application/x-www-form-urlencoded", "k=v"));
+
+    assertInstanceOf(Map.class, fields.get("payload"));
+    assertEquals("12345", fields.get("plain"));
+    assertEquals(singletonList("v"), ((Map<?, ?>) fields.get("form")).get("k"));
+  }
+
+  @Test
+  void promotesRepeatedMultipartFieldNamesToAList() {
+    Map<String, Object> fields = multipart(field("x", "a"), field("x", "b"), field("x", "c"));
+
+    assertEquals(asList("a", "b", "c"), fields.get("x"));
+  }
+
+  @Test
+  void nestsARepeatedJsonArrayPartValueRatherThanFlatteningIt() {
+    // The first value is itself a List, so a repeat cannot be told from a fresh key by the stored
+    // value's type: appending to it would hand the WAF a structure that was never sent
+    Map<String, Object> fields =
+        multipart(part("form-data; name=x", "application/json", "[1,2]"), field("x", "b"));
+
+    assertEquals(asList(asList(1.0, 2.0), "b"), fields.get("x"));
+  }
+
+  @Test
+  void doesNotTakeAFieldNameThatForgesAFilenameForAFilePart() {
+    Map<String, Object> fields =
+        multipart(outer(part("form-data; name=\"; filename=x\"", "payload")));
+
+    assertEquals("payload", fields.get("; filename=x"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void parsesNestedMultipartBodiesAndSkipsTheirFileParts() {
+    String inner = body("inner", field("nested", "value"), file("upload", "f.txt", "data"));
+    String nesting = outer(part("form-data; name=group", "multipart/mixed; boundary=inner", inner));
+
+    Map<String, Object> fields = (Map<String, Object>) parseBody(nesting, MULTIPART);
+
+    assertEquals(singletonMap("nested", "value"), fields.get("group"));
+  }
+
+  @Test
+  void sharesTheElementAllowanceAcrossNestingLevels() {
+    // Two thirds of the allowance each: the first part fits, the second cannot, which only holds if
+    // both draw from one allowance rather than from a per-part counter
+    String urlEncoded = urlEncodedPairs(MAX_ELEMENTS * 2 / 3);
+    Map<String, Object> fields =
+        multipart(
+            outer(
+                part("form-data; name=first", URL_ENCODED, urlEncoded),
+                part("form-data; name=second", URL_ENCODED, urlEncoded)));
+
+    assertInstanceOf(Map.class, fields.get("first"));
+    assertEquals(urlEncoded, fields.get("second"));
+  }
+
+  @Test
+  void spendsTheElementAllowanceOnlyOnPairsItReads() {
+    // Just under the allowance twice over would exceed it if the whole body were charged upfront
+    String urlEncoded = urlEncodedPairs(MAX_ELEMENTS / 2);
+    Map<String, Object> fields =
+        multipart(
+            outer(
+                part("form-data; name=first", URL_ENCODED, urlEncoded),
+                part("form-data; name=second", URL_ENCODED, urlEncoded)));
+
+    assertInstanceOf(Map.class, fields.get("first"));
+    assertInstanceOf(Map.class, fields.get("second"));
+  }
+
+  private static final String URL_ENCODED = "application/x-www-form-urlencoded";
+
+  private static String urlEncodedPairs(int count) {
+    StringBuilder body = new StringBuilder();
+    for (int i = 0; i < count; i++) {
+      body.append(i == 0 ? "" : "&").append('k').append(i).append("=v");
+    }
+    return body.toString();
+  }
+
+  @Test
+  void parsesMultipartPartsUpToThePartAllowance() {
+    assertEquals(MAX_PARTS, multipart(outer(fieldParts(MAX_PARTS))).size());
+  }
+
+  @Test
+  void keepsMultipartBodyOverThePartAllowanceAsRawString() {
+    // One part over the allowance drops that part from every WAF address, so the whole body
+    // degrades to a raw string instead, as an over-allowance urlencoded body does
+    String body = outer(fieldParts(MAX_PARTS + 1));
+
+    assertEquals(body, parseBody(body, MULTIPART));
+  }
+
+  @Test
+  void sharesThePartAllowanceAcrossNestingLevels() {
+    // The inner body alone is within the allowance, but the outer part it sits in has already
+    // spent one, so it can no longer be read and degrades to a raw string on its own
+    String inner = body("inner", fieldParts(MAX_PARTS));
+    Map<String, Object> fields =
+        multipart(outer(part("form-data; name=group", "multipart/mixed; boundary=inner", inner)));
+
+    assertEquals(inner, fields.get("group"));
+  }
+
+  private static String[] fieldParts(int count) {
+    String[] parts = new String[count];
+    for (int i = 0; i < count; i++) {
+      parts[i] = field("k" + i, "v");
+    }
+    return parts;
+  }
+
+  @Test
+  void keepsRawStringOnceMaxDepthIsReachedInAMultipartPart() {
+    String body = outer(field("user", "admin"));
+
+    assertEquals(body, dispatch(body, MULTIPART, MAX_DEPTH, new ParseContext()));
+  }
+
+  @Test
+  void keepsMultipartBodyAsRawStringWithoutAUsableBoundary() {
+    String body = outer(field("user", "admin"));
+
+    assertEquals(body, parseBody(body, "multipart/form-data"));
+    assertEquals(body, parseBody(body, "multipart/form-data; boundary="));
+  }
+
+  @Test
+  void keepsUnsplittableMultipartBodyAsRawString() {
+    assertEquals("no parts here", parseBody("no parts here", MULTIPART));
+  }
+
+  @Test
+  void keepsMultipartBodyAboveTheSizeLimitAsRawString() {
+    String body = outer(field("user", "admin"));
+
+    assertInstanceOf(
+        Map.class, parseMultipart(body, MULTIPART, 0, new ParseContext(), body.length()));
+    assertNull(parseMultipart(body, MULTIPART, 0, new ParseContext(), body.length() - 1));
+  }
+
+  @Test
+  void disablesMultipartParsingWhenTheSizeLimitIsZero() {
+    String body = outer(field("user", "admin"));
+
+    assertNull(parseMultipart(body, MULTIPART, 0, new ParseContext(), 0));
+  }
+
+  @Test
+  void reportsTheFilenamesOfFileParts() {
+    String body =
+        outer(
+            field("user", "admin"),
+            file("avatar", "cat.png", "bytes"),
+            file("doc", "report.pdf", "bytes"));
+
+    assertEquals(asList("cat.png", "report.pdf"), filenamesOf(body));
+    // The file parts are not fields, so only the field survives into the body map
+    assertEquals(singletonMap("user", "admin"), multipart(body));
+  }
+
+  @Test
+  void marksAFilePartWithoutReportingAnEmptyFilename() {
+    // Browsers send filename="" for an untouched file input: the part is still a file, but the
+    // empty name gives a rule nothing to match
+    String body = outer(file("avatar", "", "bytes"), field("user", "admin"));
+
+    assertEquals(emptyList(), filenamesOf(body));
+    assertEquals(singletonMap("user", "admin"), multipart(body));
+  }
+
+  @Test
+  void reportsFilenamesFromNestedMultipartParts() {
+    String inner = body("inner", file("attachment", "nested.txt", "bytes"));
+    String nesting = outer(part("form-data; name=group", "multipart/mixed; boundary=inner", inner));
+
+    assertEquals(singletonList("nested.txt"), filenamesOf(nesting));
+  }
+
+  @Test
+  void reportsFilenamesEvenWhenTheBodyDegradesToARawString() {
+    // Nothing but file parts, so there is no field to report and the body stays a raw string.
+    // The filenames are then the only structured thing left to hand the WAF.
+    String body = outer(file("avatar", "cat.png", "bytes"));
+
+    assertEquals(body, parseBody(body, MULTIPART));
+    assertEquals(singletonList("cat.png"), filenamesOf(body));
+  }
+
+  @Test
+  void reportsNoFilenameWhenTheMultipartBodyIsNotParsed() {
+    String body = outer(file("avatar", "cat.png", "bytes"));
+
+    ParseContext sizeCapped = new ParseContext();
+    assertNull(parseMultipart(body, MULTIPART, 0, sizeCapped, 0));
+    assertEquals(emptyList(), sizeCapped.filenames());
+
+    ParseContext noBoundary = new ParseContext();
+    assertEquals(body, parseBody(body, "multipart/form-data", noBoundary));
+    assertEquals(emptyList(), noBoundary.filenames());
+  }
+
+  private static List<String> filenamesOf(String body) {
+    ParseContext context = new ParseContext();
+    parseBody(body, MULTIPART, context);
+    return context.filenames();
+  }
+
+  private static final String MULTIPART = "multipart/form-data; boundary=outer";
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> multipart(String... parts) {
+    return multipart(outer(parts));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> multipart(String body) {
+    Object parsed = parseBody(body, MULTIPART);
+    assertInstanceOf(Map.class, parsed);
+    return (Map<String, Object>) parsed;
+  }
+
+  /** Joins the parts with CRLF and appends the close delimiter, using the default boundary. */
+  private static String outer(String... parts) {
+    return body("outer", parts);
+  }
+
+  private static String body(String boundary, String... parts) {
+    StringBuilder body = new StringBuilder();
+    for (String part : parts) {
+      body.append("--").append(boundary).append("\r\n").append(part).append("\r\n");
+    }
+    return body.append("--").append(boundary).append("--\r\n").toString();
+  }
+
+  private static String field(String name, String value) {
+    return part("form-data; name=\"" + name + "\"", value);
+  }
+
+  private static String file(String name, String filename, String value) {
+    return part("form-data; name=\"" + name + "\"; filename=\"" + filename + "\"", value);
+  }
+
+  private static String part(String disposition, String value) {
+    return part(disposition, null, value);
+  }
+
+  private static String part(String disposition, String contentType, String value) {
+    StringBuilder part = new StringBuilder();
+    if (disposition != null) {
+      part.append("Content-Disposition: ").append(disposition).append("\r\n");
+    }
+    if (contentType != null) {
+      part.append("Content-Type: ").append(contentType).append("\r\n");
+    }
+    return part.append("\r\n").append(value).toString();
   }
 
   @SuppressWarnings("unchecked")

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
@@ -127,6 +127,46 @@ class ContentTypeBodyParserTest {
     assertEquals(singletonList(""), parsed.get("last"));
   }
 
+  @ParameterizedTest(name = "[{index}] {0} -> {1}")
+  @CsvSource(
+      delimiter = '|',
+      value = {
+        // %E9 is é in Latin-1 and an invalid sequence in UTF-8: the WAF has to see whichever one
+        // the handler will read, so the declared charset decides
+        "application/x-www-form-urlencoded; charset=iso-8859-1   | café",
+        "application/x-www-form-urlencoded; charset=ISO-8859-1   | café",
+        "application/x-www-form-urlencoded; charset=\"iso-8859-1\" | café",
+        // a parameter after the charset must not be read as part of its name
+        "application/x-www-form-urlencoded; charset=iso-8859-1; q=1 | café",
+        // absent, empty, or not a charset this JVM has: UTF-8, which cannot decode %E9
+        "application/x-www-form-urlencoded                       | caf�",
+        "application/x-www-form-urlencoded; charset=              | caf�",
+        "application/x-www-form-urlencoded; charset=utf-42        | caf�",
+        "application/x-www-form-urlencoded; charset=not a charset | caf�",
+      })
+  void decodesFormValuesWithTheDeclaredCharset(String contentType, String expected) {
+    Map<?, ?> parsed = asMap(parseBody("q=caf%E9", contentType));
+
+    assertEquals(singletonList(expected), parsed.get("q"));
+  }
+
+  @Test
+  void decodesFormNamesWithTheDeclaredCharsetToo() {
+    Map<?, ?> parsed =
+        asMap(parseBody("caf%E9=1", "application/x-www-form-urlencoded; charset=iso-8859-1"));
+
+    assertEquals(singletonList("1"), parsed.get("café"));
+  }
+
+  @Test
+  void keepsAsciiFormValuesIdenticalWhateverTheCharset() {
+    // The payloads rules actually target are ASCII, and percent-decode the same under either
+    assertEquals(
+        asMap(parseBody("q=%3Cscript%3E", URL_ENCODED)),
+        asMap(
+            parseBody("q=%3Cscript%3E", "application/x-www-form-urlencoded; charset=iso-8859-1")));
+  }
+
   @Test
   void skipsEmptyUrlEncodedPairsButKeepsEmptyNames() {
     Map<?, ?> parsed = urlEncoded("&&=orphan&&a=1&&");

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
@@ -60,6 +60,8 @@ class ContentTypeBodyParserTest {
         "{\"a\":1}          | application/xml                   | STRING",
         "{\"a\":1}          | application/octet-stream          | STRING",
         "{\"a\":1}          | garbage                           | STRING",
+        // a slashless header declares a type but no subtype, so it is not JSON-ish
+        "{\"a\":1}          | json                              | STRING",
         // known gap: a JSON-carrying type whose name says neither "json" nor "javascript" keeps
         // the raw string, which the WAF can still match string rules against
         "{\"a\":1}          | application/csp-report            | STRING",
@@ -96,7 +98,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void parsesUrlEncodedIntoAMultimap() {
-    Map<String, Object> parsed = urlEncoded("user=admin&role=root");
+    Map<?, ?> parsed = urlEncoded("user=admin&role=root");
 
     assertEquals(singletonList("admin"), parsed.get("user"));
     assertEquals(singletonList("root"), parsed.get("role"));
@@ -110,7 +112,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void decodesUrlEncodedPercentEscapesAndPluses() {
-    Map<String, Object> parsed = urlEncoded("na+me=hello+world&q=%7B%22a%22%3A1%7D");
+    Map<?, ?> parsed = urlEncoded("na+me=hello+world&q=%7B%22a%22%3A1%7D");
 
     assertEquals(singletonList("hello world"), parsed.get("na me"));
     assertEquals(singletonList("{\"a\":1}"), parsed.get("q"));
@@ -118,7 +120,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void keepsUndecodableUrlEncodedTokensAsIs() {
-    Map<String, Object> parsed = urlEncoded("a=%&%=b");
+    Map<?, ?> parsed = urlEncoded("a=%&%=b");
 
     assertEquals(singletonList("%"), parsed.get("a"));
     assertEquals(singletonList("b"), parsed.get("%"));
@@ -126,7 +128,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void treatsValuelessUrlEncodedPairsAsEmptyValues() {
-    Map<String, Object> parsed = urlEncoded("flag&other=&last");
+    Map<?, ?> parsed = urlEncoded("flag&other=&last");
 
     assertEquals(singletonList(""), parsed.get("flag"));
     assertEquals(singletonList(""), parsed.get("other"));
@@ -135,7 +137,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void skipsEmptyUrlEncodedPairsAndNames() {
-    Map<String, Object> parsed = urlEncoded("&&=orphan&&a=1&&");
+    Map<?, ?> parsed = urlEncoded("&&=orphan&&a=1&&");
 
     assertEquals(singletonList("1"), parsed.get("a"));
     assertEquals(1, parsed.size());
@@ -197,7 +199,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void parsesMultipartFieldsIntoAMap() {
-    Map<String, Object> fields = multipart(field("user", "admin"), field("role", "root"));
+    Map<?, ?> fields = multipart(field("user", "admin"), field("role", "root"));
 
     assertEquals("admin", fields.get("user"));
     assertEquals("root", fields.get("role"));
@@ -213,14 +215,14 @@ class ContentTypeBodyParserTest {
 
   @Test
   void skipsMultipartPartsWithoutAContentDisposition() {
-    Map<String, Object> fields = multipart(field("user", "admin"), part(null, "orphan"));
+    Map<?, ?> fields = multipart(field("user", "admin"), part(null, "orphan"));
 
     assertEquals(1, fields.size());
   }
 
   @Test
   void dispatchesOnEachMultipartPartsOwnContentType() {
-    Map<String, Object> fields =
+    Map<?, ?> fields =
         multipart(
             part("form-data; name=payload", "application/json", "{\"a\":1}"),
             part("form-data; name=plain", "text/plain", "12345"),
@@ -235,7 +237,7 @@ class ContentTypeBodyParserTest {
   void keepsMultipartPartsThatDeclareNoContentTypeAsRawStrings() {
     // A part with no Content-Type is text/plain per RFC 7578, section 4.4, not a body of unknown
     // type: a JSON parse would hand the WAF a Double and a Boolean no string rule can match
-    Map<String, Object> fields =
+    Map<?, ?> fields =
         multipart(field("amount", "12345"), field("flag", "true"), field("json", "{\"a\":1}"));
 
     assertEquals("12345", fields.get("amount"));
@@ -247,14 +249,14 @@ class ContentTypeBodyParserTest {
   void keepsMultipartPartsWithAnEmptyContentTypeAsRawStrings() {
     // Only the empty case is worth covering: MultipartSplitter trims header values, so a
     // whitespace-only Content-Type reaches the parser as "" and not as its original spelling
-    Map<String, Object> fields = multipart(part("form-data; name=\"amount\"", "", "12345"));
+    Map<?, ?> fields = multipart(part("form-data; name=\"amount\"", "", "12345"));
 
     assertEquals("12345", fields.get("amount"));
   }
 
   @Test
   void promotesRepeatedMultipartFieldNamesToAList() {
-    Map<String, Object> fields = multipart(field("x", "a"), field("x", "b"), field("x", "c"));
+    Map<?, ?> fields = multipart(field("x", "a"), field("x", "b"), field("x", "c"));
 
     assertEquals(asList("a", "b", "c"), fields.get("x"));
   }
@@ -262,7 +264,7 @@ class ContentTypeBodyParserTest {
   @Test
   void nestsARepeatedJsonArrayPartValueRatherThanFlatteningIt() {
     // The first value is itself a List, so appending to it would flatten two values into one
-    Map<String, Object> fields =
+    Map<?, ?> fields =
         multipart(part("form-data; name=x", "application/json", "[1,2]"), field("x", "b"));
 
     assertEquals(asList(asList(1.0, 2.0), "b"), fields.get("x"));
@@ -270,7 +272,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void doesNotTakeAFieldNameThatForgesAFilenameForAFilePart() {
-    Map<String, Object> fields = multipart(part("form-data; name=\"; filename=x\"", "payload"));
+    Map<?, ?> fields = multipart(part("form-data; name=\"; filename=x\"", "payload"));
 
     assertEquals("payload", fields.get("; filename=x"));
   }
@@ -280,7 +282,7 @@ class ContentTypeBodyParserTest {
     String inner = body("inner", field("nested", "value"), file("upload", "f.txt", "data"));
     String nesting = outer(part("form-data; name=group", "multipart/mixed; boundary=inner", inner));
 
-    Map<String, Object> fields = asMap(parseBody(nesting, MULTIPART));
+    Map<?, ?> fields = asMap(parseBody(nesting, MULTIPART));
 
     assertEquals(singletonMap("nested", "value"), fields.get("group"));
   }
@@ -289,7 +291,7 @@ class ContentTypeBodyParserTest {
   void sharesThePartAllowanceBetweenUrlEncodedParametersAndMultipartParts() {
     // Two thirds of the allowance each: the second only fails if both draw from one allowance
     String urlEncoded = urlEncodedPairs(MAX_PARTS * 2 / 3);
-    Map<String, Object> fields =
+    Map<?, ?> fields =
         multipart(
             part("form-data; name=first", URL_ENCODED, urlEncoded),
             part("form-data; name=second", URL_ENCODED, urlEncoded));
@@ -302,7 +304,7 @@ class ContentTypeBodyParserTest {
   void spendsThePartAllowanceOnlyOnPairsItReads() {
     // Half the allowance each, less their two parts: they only fit if neither is charged upfront
     String urlEncoded = urlEncodedPairs((MAX_PARTS - 2) / 2);
-    Map<String, Object> fields =
+    Map<?, ?> fields =
         multipart(
             part("form-data; name=first", URL_ENCODED, urlEncoded),
             part("form-data; name=second", URL_ENCODED, urlEncoded));
@@ -336,7 +338,7 @@ class ContentTypeBodyParserTest {
   void sharesThePartAllowanceAcrossNestingLevels() {
     // The inner body fits the allowance on its own, but the outer part it sits in has spent one
     String inner = body("inner", fieldParts(MAX_PARTS));
-    Map<String, Object> fields =
+    Map<?, ?> fields =
         multipart(part("form-data; name=group", "multipart/mixed; boundary=inner", inner));
 
     assertEquals(inner, fields.get("group"));
@@ -379,11 +381,11 @@ class ContentTypeBodyParserTest {
 
     // enough for the outer body alone, one character short of also covering the nested one
     ParseContext exhausted = new ParseContext(nested.length() + inner.length() - 1);
-    Map<String, Object> fields = asMap(parseBody(nested, MULTIPART, exhausted));
+    Map<?, ?> fields = asMap(parseBody(nested, MULTIPART, exhausted));
     assertEquals(inner, fields.get("n"));
 
     ParseContext sufficient = new ParseContext(nested.length() + inner.length());
-    Map<String, Object> parsed = asMap(parseBody(nested, MULTIPART, sufficient));
+    Map<?, ?> parsed = asMap(parseBody(nested, MULTIPART, sufficient));
     assertEquals("v", ((Map<?, ?>) parsed.get("n")).get("deep"));
   }
 
@@ -456,23 +458,22 @@ class ContentTypeBodyParserTest {
   }
 
   /** Wraps the parts in a body with the default boundary and parses it. */
-  private static Map<String, Object> multipart(String... parts) {
+  private static Map<?, ?> multipart(String... parts) {
     return multipartBody(outer(parts));
   }
 
   /** Distinct from {@link #multipart}, whose varargs would otherwise swallow a whole body. */
-  private static Map<String, Object> multipartBody(String body) {
+  private static Map<?, ?> multipartBody(String body) {
     return asMap(parseBody(body, MULTIPART));
   }
 
-  private static Map<String, Object> urlEncoded(String body) {
+  private static Map<?, ?> urlEncoded(String body) {
     return asMap(parseBody(body, URL_ENCODED));
   }
 
-  @SuppressWarnings("unchecked")
-  private static Map<String, Object> asMap(Object parsed) {
+  private static Map<?, ?> asMap(Object parsed) {
     assertInstanceOf(Map.class, parsed);
-    return (Map<String, Object>) parsed;
+    return (Map<?, ?>) parsed;
   }
 
   /** Joins the parts with CRLF and appends the close delimiter, using the default boundary. */

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
@@ -234,8 +234,7 @@ class ContentTypeBodyParserTest {
   @Test
   void keepsMultipartPartsThatDeclareNoContentTypeAsRawStrings() {
     // A part with no Content-Type is text/plain per RFC 7578, section 4.4, not a body of unknown
-    // type: a JSON parse would hand the WAF a Double, a Boolean and a Map, so the same form
-    // submitted urlencoded and as multipart would no longer match the same string rules
+    // type: a JSON parse would hand the WAF a Double and a Boolean no string rule can match
     Map<String, Object> fields =
         multipart(field("amount", "12345"), field("flag", "true"), field("json", "{\"a\":1}"));
 
@@ -262,8 +261,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void nestsARepeatedJsonArrayPartValueRatherThanFlatteningIt() {
-    // The first value is itself a List, so a repeat cannot be told from a fresh key by the stored
-    // value's type: appending to it would hand the WAF a structure that was never sent
+    // The first value is itself a List, so appending to it would flatten two values into one
     Map<String, Object> fields =
         multipart(part("form-data; name=x", "application/json", "[1,2]"), field("x", "b"));
 
@@ -289,8 +287,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void sharesThePartAllowanceBetweenUrlEncodedParametersAndMultipartParts() {
-    // Two thirds of the allowance each: the first part fits, the second cannot, which only holds if
-    // both draw from one allowance rather than from a per-part counter
+    // Two thirds of the allowance each: the second only fails if both draw from one allowance
     String urlEncoded = urlEncodedPairs(MAX_PARTS * 2 / 3);
     Map<String, Object> fields =
         multipart(
@@ -303,8 +300,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void spendsThePartAllowanceOnlyOnPairsItReads() {
-    // Half the allowance each, less the two multipart parts carrying them: together they fit
-    // exactly, which they could not if either body were charged upfront
+    // Half the allowance each, less their two parts: they only fit if neither is charged upfront
     String urlEncoded = urlEncodedPairs((MAX_PARTS - 2) / 2);
     Map<String, Object> fields =
         multipart(
@@ -330,8 +326,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void keepsMultipartBodyOverThePartAllowanceAsRawString() {
-    // One part over the allowance drops that part from every WAF address, so the whole body
-    // degrades to a raw string instead, as an over-allowance urlencoded body does
+    // One part over the allowance degrades the whole body, as an urlencoded body over it does
     String body = outer(fieldParts(MAX_PARTS + 1));
 
     assertEquals(body, parseBody(body, MULTIPART));
@@ -339,8 +334,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void sharesThePartAllowanceAcrossNestingLevels() {
-    // The inner body alone is within the allowance, but the outer part it sits in has already
-    // spent one, so it can no longer be read and degrades to a raw string on its own
+    // The inner body fits the allowance on its own, but the outer part it sits in has spent one
     String inner = body("inner", fieldParts(MAX_PARTS));
     Map<String, Object> fields =
         multipart(part("form-data; name=group", "multipart/mixed; boundary=inner", inner));
@@ -378,19 +372,8 @@ class ContentTypeBodyParserTest {
   }
 
   @Test
-  void chargesTheByteAllowanceWhateverTheContentType() {
-    // The allowance bounds reading, not multipart specifically, so a JSON body is charged too
-    String body = "{\"a\":1}";
-
-    assertInstanceOf(
-        Map.class, parseBody(body, "application/json", new ParseContext(body.length())));
-    assertEquals(body, parseBody(body, "application/json", new ParseContext(body.length() - 1)));
-  }
-
-  @Test
   void sharesTheByteAllowanceAcrossNestingLevels() {
-    // Without a shared allowance a nested body is re-measured against a fresh allowance at every
-    // level, so one crafted body costs MAX_DEPTH times its own size to scan and copy
+    // Unshared, a nested body is re-measured at every level: MAX_DEPTH times its size to copy
     String inner = body("inner", field("deep", "v"));
     String nested = outer(part("form-data; name=\"n\"", "multipart/mixed; boundary=inner", inner));
 
@@ -437,9 +420,8 @@ class ContentTypeBodyParserTest {
 
   @Test
   void reportsFilenamesEvenWhenTheBodyDegradesToARawString() {
-    // Nothing but file parts, so there is no field to report. An empty map would tell the WAF the
-    // body was empty, so the raw string is kept, and the filenames are then the only structured
-    // thing left to hand it.
+    // Nothing but file parts, so there is no field to report: an empty map would tell the WAF the
+    // body was empty, so the raw string is kept and the filenames reported alongside it
     String body = outer(file("avatar", "cat.png", "bytes"));
 
     assertEquals(body, parseBody(body, MULTIPART));

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
@@ -1,0 +1,190 @@
+package datadog.trace.lambda;
+
+import static datadog.trace.lambda.ContentTypeBodyParser.MAX_DEPTH;
+import static datadog.trace.lambda.ContentTypeBodyParser.MAX_ELEMENTS;
+import static datadog.trace.lambda.ContentTypeBodyParser.parseBody;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ContentTypeBodyParserTest {
+
+  @ParameterizedTest(name = "[{index}] {1} -> {2}")
+  @CsvSource(
+      delimiter = '|',
+      value = {
+        // content type absent or blank: best-effort JSON, as before content-type dispatch existed
+        "{\"a\":1}          |                                   | MAP",
+        "{\"a\":1}          | '   '                             | MAP",
+        "not json           |                                   | STRING",
+        // JSON, including suffixed subtypes and parameters
+        "{\"a\":1}          | application/json                  | MAP",
+        "{\"a\":1}          | application/json; charset=utf-8   | MAP",
+        "{\"a\":1}          | APPLICATION/JSON                  | MAP",
+        "{\"a\":1}          | application/vnd.api+json          | MAP",
+        "{\"a\":1           | application/json                  | STRING",
+        // JSON-ish vendor types: no +json suffix, but the payload is JSON
+        "{\"a\":1}          | application/x-amz-json-1.1        | MAP",
+        "{\"a\":1}          | application/javascript            | MAP",
+        // urlencoded
+        "a=1                | application/x-www-form-urlencoded | MAP",
+        "a=1                | APPLICATION/X-WWW-FORM-URLENCODED | MAP",
+        // multipart is not structured yet
+        "{\"a\":1}          | multipart/form-data; boundary=xy  | STRING",
+        // text/*: never structured, even when it holds JSON. A JSON parse of "12345" would yield a
+        // Double, which no string rule can match
+        "{\"a\":1}          | text/plain                        | STRING",
+        "12345              | text/plain                        | STRING",
+        "{\"a\":1}          | text/html                         | STRING",
+        // anything else
+        "{\"a\":1}          | application/xml                   | STRING",
+        "{\"a\":1}          | application/octet-stream          | STRING",
+        "{\"a\":1}          | garbage                           | STRING",
+        // known gap: a JSON-carrying type whose name says neither "json" nor "javascript" keeps
+        // the raw string, which the WAF can still match string rules against
+        "{\"a\":1}          | application/csp-report            | STRING",
+      })
+  void dispatchesOnContentType(String body, String contentType, String expectedKind) {
+    Object parsed = parseBody(body, contentType);
+
+    if ("MAP".equals(expectedKind)) {
+      assertInstanceOf(Map.class, parsed);
+    } else {
+      assertEquals(body, parsed);
+    }
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {" "})
+  void parsesJsonWhenContentTypeIsAbsent(String contentType) {
+    Object parsed = parseBody("{\"user\":\"admin\"}", contentType);
+
+    assertInstanceOf(Map.class, parsed);
+    assertEquals("admin", ((Map<?, ?>) parsed).get("user"));
+  }
+
+  @Test
+  void returnsNullForNullBody() {
+    assertNull(parseBody(null, "application/json"));
+  }
+
+  @Test
+  void keepsEmptyBodyAsEmptyString() {
+    assertEquals("", parseBody("", "application/json"));
+    assertEquals("", parseBody("", "application/x-www-form-urlencoded"));
+  }
+
+  @Test
+  void keepsRawStringOnceMaxDepthIsReached() {
+    String body = "{\"a\":1}";
+
+    assertEquals(body, ContentTypeBodyParser.dispatch(body, "application/json", MAX_DEPTH));
+    assertInstanceOf(
+        Map.class, ContentTypeBodyParser.dispatch(body, "application/json", MAX_DEPTH - 1));
+  }
+
+  @Test
+  void parsesUrlEncodedIntoAMultimap() {
+    Map<String, List<String>> parsed = urlEncoded("user=admin&role=root");
+
+    assertEquals(singletonList("admin"), parsed.get("user"));
+    assertEquals(singletonList("root"), parsed.get("role"));
+    assertEquals(2, parsed.size());
+  }
+
+  @Test
+  void groupsRepeatedUrlEncodedKeysIntoOneList() {
+    assertEquals(asList("a", "b", "c"), urlEncoded("x=a&x=b&x=c").get("x"));
+  }
+
+  @Test
+  void decodesUrlEncodedPercentEscapesAndPluses() {
+    Map<String, List<String>> parsed = urlEncoded("na+me=hello+world&q=%7B%22a%22%3A1%7D");
+
+    assertEquals(singletonList("hello world"), parsed.get("na me"));
+    assertEquals(singletonList("{\"a\":1}"), parsed.get("q"));
+  }
+
+  @Test
+  void keepsUndecodableUrlEncodedTokensAsIs() {
+    Map<String, List<String>> parsed = urlEncoded("a=%&%=b");
+
+    assertEquals(singletonList("%"), parsed.get("a"));
+    assertEquals(singletonList("b"), parsed.get("%"));
+  }
+
+  @Test
+  void treatsValuelessUrlEncodedPairsAsEmptyValues() {
+    Map<String, List<String>> parsed = urlEncoded("flag&other=&last");
+
+    assertEquals(singletonList(""), parsed.get("flag"));
+    assertEquals(singletonList(""), parsed.get("other"));
+    assertEquals(singletonList(""), parsed.get("last"));
+  }
+
+  @Test
+  void skipsEmptyUrlEncodedPairsAndNames() {
+    Map<String, List<String>> parsed = urlEncoded("&&=orphan&&a=1&&");
+
+    assertEquals(singletonList("1"), parsed.get("a"));
+    assertEquals(1, parsed.size());
+  }
+
+  @Test
+  void splitsUrlEncodedValuesAtTheFirstEqualsOnly() {
+    assertEquals(singletonList("b=c=d"), urlEncoded("a=b=c=d").get("a"));
+  }
+
+  @Test
+  void doesNotSeparateUrlEncodedPairsOnSemicolons() {
+    assertEquals(singletonList("1;b=2"), urlEncoded("a=1;b=2").get("a"));
+  }
+
+  @Test
+  void capsUrlEncodedPairsAtMaxElements() {
+    StringBuilder body = new StringBuilder();
+    for (int i = 0; i < MAX_ELEMENTS + 1; i++) {
+      body.append(i == 0 ? "" : "&").append('k').append(i).append("=v");
+    }
+
+    assertEquals(MAX_ELEMENTS, urlEncoded(body.toString()).size());
+  }
+
+  @Test
+  void stopsScanningNamelessUrlEncodedPairsAtTheCap() {
+    StringBuilder body = new StringBuilder();
+    for (int i = 0; i < MAX_ELEMENTS; i++) {
+      body.append("=v&");
+    }
+    body.append("a=1");
+    String raw = body.toString();
+
+    // Nameless pairs still do decoding work, so they exhaust the cap and the trailing parameter is
+    // never reached; nothing survives, so the raw body is kept
+    assertEquals(raw, parseBody(raw, "application/x-www-form-urlencoded"));
+  }
+
+  @Test
+  void keepsUnparseableUrlEncodedBodyAsRawString() {
+    // Nothing but separators: no parameter survives, so the raw body is kept
+    assertEquals("&&&", parseBody("&&&", "application/x-www-form-urlencoded"));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, List<String>> urlEncoded(String body) {
+    Object parsed = parseBody(body, "application/x-www-form-urlencoded");
+    assertInstanceOf(Map.class, parsed);
+    return (Map<String, List<String>>) parsed;
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
@@ -1,11 +1,8 @@
 package datadog.trace.lambda;
 
 import static datadog.trace.lambda.ContentTypeBodyParser.MAX_DEPTH;
-import static datadog.trace.lambda.ContentTypeBodyParser.MAX_ELEMENTS;
 import static datadog.trace.lambda.ContentTypeBodyParser.MAX_PARTS;
 import static datadog.trace.lambda.ContentTypeBodyParser.dispatch;
-import static datadog.trace.lambda.ContentTypeBodyParser.parseBody;
-import static datadog.trace.lambda.ContentTypeBodyParser.parseMultipart;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -20,10 +17,11 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class ContentTypeBodyParserTest {
+
+  private static final String MULTIPART = "multipart/form-data; boundary=outer";
+  private static final String URL_ENCODED = "application/x-www-form-urlencoded";
 
   @ParameterizedTest(name = "[{index}] {1} -> {2}")
   @CsvSource(
@@ -32,7 +30,10 @@ class ContentTypeBodyParserTest {
         // content type absent or blank: best-effort JSON, as before content-type dispatch existed
         "{\"a\":1}          |                                   | MAP",
         "{\"a\":1}          | '   '                             | MAP",
+        "{\"a\":1}          | ''                                | MAP",
         "not json           |                                   | STRING",
+        // a header holding nothing but parameters declares no type either
+        "{\"a\":1}          | '; charset=utf-8'                 | MAP",
         // JSON, including suffixed subtypes and parameters
         "{\"a\":1}          | application/json                  | MAP",
         "{\"a\":1}          | application/json; charset=utf-8   | MAP",
@@ -48,6 +49,8 @@ class ContentTypeBodyParserTest {
         // a multipart body whose boundary happens to contain "json" must still reach the multipart
         // parser rather than being handed to the JSON parser
         "not multipart      | multipart/x; boundary=--json      | STRING",
+        // a json-ish subtype wins over the multipart branch, whatever the type says
+        "{\"a\":1}          | multipart/json                    | MAP",
         // text/*: never structured, even when it holds JSON. A JSON parse of "12345" would yield a
         // Double, which no string rule can match
         "{\"a\":1}          | text/plain                        | STRING",
@@ -69,16 +72,6 @@ class ContentTypeBodyParserTest {
     } else {
       assertEquals(body, parsed);
     }
-  }
-
-  @ParameterizedTest
-  @NullAndEmptySource
-  @ValueSource(strings = {" "})
-  void parsesJsonWhenContentTypeIsAbsent(String contentType) {
-    Object parsed = parseBody("{\"user\":\"admin\"}", contentType);
-
-    assertInstanceOf(Map.class, parsed);
-    assertEquals("admin", ((Map<?, ?>) parsed).get("user"));
   }
 
   @Test
@@ -103,7 +96,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void parsesUrlEncodedIntoAMultimap() {
-    Map<String, List<String>> parsed = urlEncoded("user=admin&role=root");
+    Map<String, Object> parsed = urlEncoded("user=admin&role=root");
 
     assertEquals(singletonList("admin"), parsed.get("user"));
     assertEquals(singletonList("root"), parsed.get("role"));
@@ -117,7 +110,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void decodesUrlEncodedPercentEscapesAndPluses() {
-    Map<String, List<String>> parsed = urlEncoded("na+me=hello+world&q=%7B%22a%22%3A1%7D");
+    Map<String, Object> parsed = urlEncoded("na+me=hello+world&q=%7B%22a%22%3A1%7D");
 
     assertEquals(singletonList("hello world"), parsed.get("na me"));
     assertEquals(singletonList("{\"a\":1}"), parsed.get("q"));
@@ -125,7 +118,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void keepsUndecodableUrlEncodedTokensAsIs() {
-    Map<String, List<String>> parsed = urlEncoded("a=%&%=b");
+    Map<String, Object> parsed = urlEncoded("a=%&%=b");
 
     assertEquals(singletonList("%"), parsed.get("a"));
     assertEquals(singletonList("b"), parsed.get("%"));
@@ -133,7 +126,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void treatsValuelessUrlEncodedPairsAsEmptyValues() {
-    Map<String, List<String>> parsed = urlEncoded("flag&other=&last");
+    Map<String, Object> parsed = urlEncoded("flag&other=&last");
 
     assertEquals(singletonList(""), parsed.get("flag"));
     assertEquals(singletonList(""), parsed.get("other"));
@@ -142,7 +135,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void skipsEmptyUrlEncodedPairsAndNames() {
-    Map<String, List<String>> parsed = urlEncoded("&&=orphan&&a=1&&");
+    Map<String, Object> parsed = urlEncoded("&&=orphan&&a=1&&");
 
     assertEquals(singletonList("1"), parsed.get("a"));
     assertEquals(1, parsed.size());
@@ -159,19 +152,19 @@ class ContentTypeBodyParserTest {
   }
 
   @Test
-  void parsesUrlEncodedPairsUpToMaxElements() {
+  void parsesUrlEncodedPairsUpToThePartAllowance() {
     StringBuilder body = new StringBuilder();
-    for (int i = 0; i < MAX_ELEMENTS; i++) {
+    for (int i = 0; i < MAX_PARTS; i++) {
       body.append(i == 0 ? "" : "&").append('k').append(i).append("=v");
     }
 
-    assertEquals(MAX_ELEMENTS, urlEncoded(body.toString()).size());
+    assertEquals(MAX_PARTS, urlEncoded(body.toString()).size());
   }
 
   @Test
-  void keepsUrlEncodedBodyOverMaxElementsAsRawString() {
+  void keepsUrlEncodedBodyOverThePartAllowanceAsRawString() {
     StringBuilder body = new StringBuilder();
-    for (int i = 0; i < MAX_ELEMENTS; i++) {
+    for (int i = 0; i < MAX_PARTS; i++) {
       body.append('k').append(i).append("=v&");
     }
     body.append("attack=payload");
@@ -185,7 +178,7 @@ class ContentTypeBodyParserTest {
   @Test
   void countsNamelessUrlEncodedPairsTowardsTheCap() {
     StringBuilder body = new StringBuilder();
-    for (int i = 0; i < MAX_ELEMENTS; i++) {
+    for (int i = 0; i < MAX_PARTS; i++) {
       body.append("=v&");
     }
     body.append("a=1");
@@ -212,35 +205,10 @@ class ContentTypeBodyParserTest {
   }
 
   @Test
-  void skipsMultipartFileParts() {
-    Map<String, Object> fields = multipart(field("user", "admin"), file("upload", "f.txt", "data"));
-
-    assertEquals("admin", fields.get("user"));
-    assertEquals(1, fields.size());
-  }
-
-  @Test
-  void skipsMultipartPartsWithAnEmptyFilename() {
-    // An untouched file input: browsers send filename="", which is a file part all the same
-    Map<String, Object> fields = multipart(field("user", "admin"), file("upload", "", ""));
-
-    assertEquals(1, fields.size());
-  }
-
-  @Test
-  void keepsAFileOnlyMultipartBodyAsARawString() {
-    // A raw string still matches string rules; an empty map would tell the WAF the body was empty
-    String body = outer(file("upload", "f.txt", "data"));
+  void skipsMultipartPartsWithoutAName() {
+    String body = outer(part("form-data", "novalue"), part("form-data; name=", "empty"));
 
     assertEquals(body, parseBody(body, MULTIPART));
-  }
-
-  @Test
-  void skipsMultipartPartsWithoutAName() {
-    assertEquals(
-        outer(part("form-data", "novalue"), part("form-data; name=", "empty")),
-        parseBody(
-            outer(part("form-data", "novalue"), part("form-data; name=", "empty")), MULTIPART));
   }
 
   @Test
@@ -278,7 +246,9 @@ class ContentTypeBodyParserTest {
 
   @Test
   void keepsMultipartPartsWithAnEmptyContentTypeAsRawStrings() {
-    Map<String, Object> fields = multipart(outer(part("form-data; name=\"amount\"", "", "12345")));
+    // Only the empty case is worth covering: MultipartSplitter trims header values, so a
+    // whitespace-only Content-Type reaches the parser as "" and not as its original spelling
+    Map<String, Object> fields = multipart(part("form-data; name=\"amount\"", "", "12345"));
 
     assertEquals("12345", fields.get("amount"));
   }
@@ -302,53 +272,48 @@ class ContentTypeBodyParserTest {
 
   @Test
   void doesNotTakeAFieldNameThatForgesAFilenameForAFilePart() {
-    Map<String, Object> fields =
-        multipart(outer(part("form-data; name=\"; filename=x\"", "payload")));
+    Map<String, Object> fields = multipart(part("form-data; name=\"; filename=x\"", "payload"));
 
     assertEquals("payload", fields.get("; filename=x"));
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   void parsesNestedMultipartBodiesAndSkipsTheirFileParts() {
     String inner = body("inner", field("nested", "value"), file("upload", "f.txt", "data"));
     String nesting = outer(part("form-data; name=group", "multipart/mixed; boundary=inner", inner));
 
-    Map<String, Object> fields = (Map<String, Object>) parseBody(nesting, MULTIPART);
+    Map<String, Object> fields = asMap(parseBody(nesting, MULTIPART));
 
     assertEquals(singletonMap("nested", "value"), fields.get("group"));
   }
 
   @Test
-  void sharesTheElementAllowanceAcrossNestingLevels() {
+  void sharesThePartAllowanceBetweenUrlEncodedParametersAndMultipartParts() {
     // Two thirds of the allowance each: the first part fits, the second cannot, which only holds if
     // both draw from one allowance rather than from a per-part counter
-    String urlEncoded = urlEncodedPairs(MAX_ELEMENTS * 2 / 3);
+    String urlEncoded = urlEncodedPairs(MAX_PARTS * 2 / 3);
     Map<String, Object> fields =
         multipart(
-            outer(
-                part("form-data; name=first", URL_ENCODED, urlEncoded),
-                part("form-data; name=second", URL_ENCODED, urlEncoded)));
+            part("form-data; name=first", URL_ENCODED, urlEncoded),
+            part("form-data; name=second", URL_ENCODED, urlEncoded));
 
     assertInstanceOf(Map.class, fields.get("first"));
     assertEquals(urlEncoded, fields.get("second"));
   }
 
   @Test
-  void spendsTheElementAllowanceOnlyOnPairsItReads() {
-    // Just under the allowance twice over would exceed it if the whole body were charged upfront
-    String urlEncoded = urlEncodedPairs(MAX_ELEMENTS / 2);
+  void spendsThePartAllowanceOnlyOnPairsItReads() {
+    // Half the allowance each, less the two multipart parts carrying them: together they fit
+    // exactly, which they could not if either body were charged upfront
+    String urlEncoded = urlEncodedPairs((MAX_PARTS - 2) / 2);
     Map<String, Object> fields =
         multipart(
-            outer(
-                part("form-data; name=first", URL_ENCODED, urlEncoded),
-                part("form-data; name=second", URL_ENCODED, urlEncoded)));
+            part("form-data; name=first", URL_ENCODED, urlEncoded),
+            part("form-data; name=second", URL_ENCODED, urlEncoded));
 
     assertInstanceOf(Map.class, fields.get("first"));
     assertInstanceOf(Map.class, fields.get("second"));
   }
-
-  private static final String URL_ENCODED = "application/x-www-form-urlencoded";
 
   private static String urlEncodedPairs(int count) {
     StringBuilder body = new StringBuilder();
@@ -360,7 +325,7 @@ class ContentTypeBodyParserTest {
 
   @Test
   void parsesMultipartPartsUpToThePartAllowance() {
-    assertEquals(MAX_PARTS, multipart(outer(fieldParts(MAX_PARTS))).size());
+    assertEquals(MAX_PARTS, multipart(fieldParts(MAX_PARTS)).size());
   }
 
   @Test
@@ -378,7 +343,7 @@ class ContentTypeBodyParserTest {
     // spent one, so it can no longer be read and degrades to a raw string on its own
     String inner = body("inner", fieldParts(MAX_PARTS));
     Map<String, Object> fields =
-        multipart(outer(part("form-data; name=group", "multipart/mixed; boundary=inner", inner)));
+        multipart(part("form-data; name=group", "multipart/mixed; boundary=inner", inner));
 
     assertEquals(inner, fields.get("group"));
   }
@@ -389,13 +354,6 @@ class ContentTypeBodyParserTest {
       parts[i] = field("k" + i, "v");
     }
     return parts;
-  }
-
-  @Test
-  void keepsRawStringOnceMaxDepthIsReachedInAMultipartPart() {
-    String body = outer(field("user", "admin"));
-
-    assertEquals(body, dispatch(body, MULTIPART, MAX_DEPTH, new ParseContext()));
   }
 
   @Test
@@ -412,19 +370,38 @@ class ContentTypeBodyParserTest {
   }
 
   @Test
-  void keepsMultipartBodyAboveTheSizeLimitAsRawString() {
+  void keepsABodyTheByteAllowanceCannotCoverAsRawString() {
     String body = outer(field("user", "admin"));
 
-    assertInstanceOf(
-        Map.class, parseMultipart(body, MULTIPART, 0, new ParseContext(), body.length()));
-    assertNull(parseMultipart(body, MULTIPART, 0, new ParseContext(), body.length() - 1));
+    assertInstanceOf(Map.class, parseBody(body, MULTIPART, new ParseContext(body.length())));
+    assertEquals(body, parseBody(body, MULTIPART, new ParseContext(body.length() - 1)));
   }
 
   @Test
-  void disablesMultipartParsingWhenTheSizeLimitIsZero() {
-    String body = outer(field("user", "admin"));
+  void chargesTheByteAllowanceWhateverTheContentType() {
+    // The allowance bounds reading, not multipart specifically, so a JSON body is charged too
+    String body = "{\"a\":1}";
 
-    assertNull(parseMultipart(body, MULTIPART, 0, new ParseContext(), 0));
+    assertInstanceOf(
+        Map.class, parseBody(body, "application/json", new ParseContext(body.length())));
+    assertEquals(body, parseBody(body, "application/json", new ParseContext(body.length() - 1)));
+  }
+
+  @Test
+  void sharesTheByteAllowanceAcrossNestingLevels() {
+    // Without a shared allowance a nested body is re-measured against a fresh allowance at every
+    // level, so one crafted body costs MAX_DEPTH times its own size to scan and copy
+    String inner = body("inner", field("deep", "v"));
+    String nested = outer(part("form-data; name=\"n\"", "multipart/mixed; boundary=inner", inner));
+
+    // enough for the outer body alone, one character short of also covering the nested one
+    ParseContext exhausted = new ParseContext(nested.length() + inner.length() - 1);
+    Map<String, Object> fields = asMap(parseBody(nested, MULTIPART, exhausted));
+    assertEquals(inner, fields.get("n"));
+
+    ParseContext sufficient = new ParseContext(nested.length() + inner.length());
+    Map<String, Object> parsed = asMap(parseBody(nested, MULTIPART, sufficient));
+    assertEquals("v", ((Map<?, ?>) parsed.get("n")).get("deep"));
   }
 
   @Test
@@ -437,7 +414,7 @@ class ContentTypeBodyParserTest {
 
     assertEquals(asList("cat.png", "report.pdf"), filenamesOf(body));
     // The file parts are not fields, so only the field survives into the body map
-    assertEquals(singletonMap("user", "admin"), multipart(body));
+    assertEquals(singletonMap("user", "admin"), multipartBody(body));
   }
 
   @Test
@@ -447,7 +424,7 @@ class ContentTypeBodyParserTest {
     String body = outer(file("avatar", "", "bytes"), field("user", "admin"));
 
     assertEquals(emptyList(), filenamesOf(body));
-    assertEquals(singletonMap("user", "admin"), multipart(body));
+    assertEquals(singletonMap("user", "admin"), multipartBody(body));
   }
 
   @Test
@@ -460,8 +437,9 @@ class ContentTypeBodyParserTest {
 
   @Test
   void reportsFilenamesEvenWhenTheBodyDegradesToARawString() {
-    // Nothing but file parts, so there is no field to report and the body stays a raw string.
-    // The filenames are then the only structured thing left to hand the WAF.
+    // Nothing but file parts, so there is no field to report. An empty map would tell the WAF the
+    // body was empty, so the raw string is kept, and the filenames are then the only structured
+    // thing left to hand it.
     String body = outer(file("avatar", "cat.png", "bytes"));
 
     assertEquals(body, parseBody(body, MULTIPART));
@@ -472,8 +450,8 @@ class ContentTypeBodyParserTest {
   void reportsNoFilenameWhenTheMultipartBodyIsNotParsed() {
     String body = outer(file("avatar", "cat.png", "bytes"));
 
-    ParseContext sizeCapped = new ParseContext();
-    assertNull(parseMultipart(body, MULTIPART, 0, sizeCapped, 0));
+    ParseContext sizeCapped = new ParseContext(body.length() - 1);
+    assertEquals(body, parseBody(body, MULTIPART, sizeCapped));
     assertEquals(emptyList(), sizeCapped.filenames());
 
     ParseContext noBoundary = new ParseContext();
@@ -487,16 +465,30 @@ class ContentTypeBodyParserTest {
     return context.filenames();
   }
 
-  private static final String MULTIPART = "multipart/form-data; boundary=outer";
+  private static Object parseBody(String body, String contentType) {
+    return parseBody(body, contentType, new ParseContext());
+  }
 
-  @SuppressWarnings("unchecked")
+  private static Object parseBody(String body, String contentType, ParseContext context) {
+    return ContentTypeBodyParser.parseBody(body, contentType, context);
+  }
+
+  /** Wraps the parts in a body with the default boundary and parses it. */
   private static Map<String, Object> multipart(String... parts) {
-    return multipart(outer(parts));
+    return multipartBody(outer(parts));
+  }
+
+  /** Distinct from {@link #multipart}, whose varargs would otherwise swallow a whole body. */
+  private static Map<String, Object> multipartBody(String body) {
+    return asMap(parseBody(body, MULTIPART));
+  }
+
+  private static Map<String, Object> urlEncoded(String body) {
+    return asMap(parseBody(body, URL_ENCODED));
   }
 
   @SuppressWarnings("unchecked")
-  private static Map<String, Object> multipart(String body) {
-    Object parsed = parseBody(body, MULTIPART);
+  private static Map<String, Object> asMap(Object parsed) {
     assertInstanceOf(Map.class, parsed);
     return (Map<String, Object>) parsed;
   }
@@ -535,12 +527,5 @@ class ContentTypeBodyParserTest {
       part.append("Content-Type: ").append(contentType).append("\r\n");
     }
     return part.append("\r\n").append(value).toString();
-  }
-
-  @SuppressWarnings("unchecked")
-  private static Map<String, List<String>> urlEncoded(String body) {
-    Object parsed = parseBody(body, "application/x-www-form-urlencoded");
-    assertInstanceOf(Map.class, parsed);
-    return (Map<String, List<String>>) parsed;
   }
 }

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
@@ -264,6 +264,26 @@ class ContentTypeBodyParserTest {
   }
 
   @Test
+  void keepsMultipartPartsThatDeclareNoContentTypeAsRawStrings() {
+    // A part with no Content-Type is text/plain per RFC 7578, section 4.4, not a body of unknown
+    // type: a JSON parse would hand the WAF a Double, a Boolean and a Map, so the same form
+    // submitted urlencoded and as multipart would no longer match the same string rules
+    Map<String, Object> fields =
+        multipart(field("amount", "12345"), field("flag", "true"), field("json", "{\"a\":1}"));
+
+    assertEquals("12345", fields.get("amount"));
+    assertEquals("true", fields.get("flag"));
+    assertEquals("{\"a\":1}", fields.get("json"));
+  }
+
+  @Test
+  void keepsMultipartPartsWithAnEmptyContentTypeAsRawStrings() {
+    Map<String, Object> fields = multipart(outer(part("form-data; name=\"amount\"", "", "12345")));
+
+    assertEquals("12345", fields.get("amount"));
+  }
+
+  @Test
   void promotesRepeatedMultipartFieldNamesToAList() {
     Map<String, Object> fields = multipart(field("x", "a"), field("x", "b"), field("x", "c"));
 

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
@@ -128,11 +128,13 @@ class ContentTypeBodyParserTest {
   }
 
   @Test
-  void skipsEmptyUrlEncodedPairsAndNames() {
+  void skipsEmptyUrlEncodedPairsButKeepsEmptyNames() {
     Map<?, ?> parsed = urlEncoded("&&=orphan&&a=1&&");
 
     assertEquals(singletonList("1"), parsed.get("a"));
-    assertEquals(1, parsed.size());
+    // A pair with no name still carries a value the handler decodes, so the WAF must see it
+    assertEquals(singletonList("orphan"), parsed.get(""));
+    assertEquals(2, parsed.size());
   }
 
   @Test
@@ -176,9 +178,18 @@ class ContentTypeBodyParserTest {
 
   @Test
   void skipsMultipartPartsWithoutAName() {
-    String body = outer(part("form-data", "novalue"), part("form-data; name=", "empty"));
+    // No name parameter at all, in either part: nothing is a field, so the raw string is kept
+    String body = outer(part("form-data", "novalue"), part("form-data; charset=utf-8", "other"));
 
     assertEquals(body, parseBody(body, MULTIPART));
+  }
+
+  @Test
+  void treatsABareNameParameterAsAnEmptyName() {
+    // "name=" is present but empty, which the handler decodes as a field named ""
+    Map<?, ?> parsed = multipart(part("form-data; name=", "payload"));
+
+    assertEquals(singletonMap("", "payload"), parsed);
   }
 
   @Test
@@ -351,6 +362,19 @@ class ContentTypeBodyParserTest {
     assertEquals(asList("cat.png", "report.pdf"), filenamesOf(body));
     // The file parts are not fields, so only the field survives into the body map
     assertEquals(singletonMap("user", "admin"), multipartBody(body));
+  }
+
+  @Test
+  void keepsAMultipartFieldWithAnEmptyName() {
+    // The handler decodes this part like any other, so dropping it would hide its value from the
+    // WAF. Only a part with no name parameter at all is not a field.
+    String body = outer(field("", "payload"), part("form-data", "unnamed"), field("a", "1"));
+
+    Map<?, ?> parsed = multipartBody(body);
+
+    assertEquals("payload", parsed.get(""));
+    assertEquals("1", parsed.get("a"));
+    assertEquals(2, parsed.size());
   }
 
   @Test

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/ContentTypeBodyParserTest.java
@@ -138,11 +138,17 @@ class ContentTypeBodyParserTest {
         "application/x-www-form-urlencoded; charset=\"iso-8859-1\" | café",
         // a parameter after the charset must not be read as part of its name
         "application/x-www-form-urlencoded; charset=iso-8859-1; q=1 | café",
+        // RFC 7230 optional whitespace around the "="
+        "application/x-www-form-urlencoded; charset =iso-8859-1  | café",
         // absent, empty, or not a charset this JVM has: UTF-8, which cannot decode %E9
         "application/x-www-form-urlencoded                       | caf�",
         "application/x-www-form-urlencoded; charset=              | caf�",
         "application/x-www-form-urlencoded; charset=utf-42        | caf�",
         "application/x-www-form-urlencoded; charset=not a charset | caf�",
+        // a parameter that merely ends in "charset" is not one
+        "application/x-www-form-urlencoded; xcharset=iso-8859-1   | caf�",
+        // nor is a "charset=" that only occurs inside another parameter's quoted value
+        "application/x-www-form-urlencoded; q=\"; charset=iso-8859-1\" | caf�",
       })
   void decodesFormValuesWithTheDeclaredCharset(String contentType, String expected) {
     Map<?, ?> parsed = asMap(parseBody("q=caf%E9", contentType));

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
@@ -701,6 +701,57 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  void parsesUrlEncodedBodyIntoAMultimap() {
+    String eventJson =
+        "{"
+            + "\"body\": \"user=admin&role=root\","
+            + "\"headers\": {\"Content-Type\": \"application/x-www-form-urlencoded\"},"
+            + "\"requestContext\": {\"httpMethod\": \"POST\"}"
+            + "}";
+    ByteArrayInputStream event = createInputStream(eventJson);
+
+    Object[] capturedBody = {null};
+
+    setupMockCallbacks(new Callbacks().onBody(body -> capturedBody[0] = body));
+
+    AgentSpanContext result = LambdaAppSecHandler.processRequestStart(event);
+
+    assertNotNull(result);
+    assertInstanceOf(Map.class, capturedBody[0]);
+    Map<String, List<String>> parameters = (Map<String, List<String>>) capturedBody[0];
+    assertEquals(Arrays.asList("admin"), parameters.get("user"));
+    assertEquals(Arrays.asList("root"), parameters.get("role"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void appliesContentTypeDispatchToBase64DecodedBodies() {
+    String base64Body =
+        Base64.getEncoder().encodeToString("user=admin".getBytes(StandardCharsets.UTF_8));
+    String eventJson =
+        "{"
+            + "\"body\": \""
+            + base64Body
+            + "\","
+            + "\"isBase64Encoded\": true,"
+            + "\"headers\": {\"Content-Type\": \"application/x-www-form-urlencoded\"},"
+            + "\"requestContext\": {\"httpMethod\": \"POST\"}"
+            + "}";
+    ByteArrayInputStream event = createInputStream(eventJson);
+
+    Object[] capturedBody = {null};
+
+    setupMockCallbacks(new Callbacks().onBody(body -> capturedBody[0] = body));
+
+    AgentSpanContext result = LambdaAppSecHandler.processRequestStart(event);
+
+    assertNotNull(result);
+    assertInstanceOf(Map.class, capturedBody[0]);
+    assertEquals(Arrays.asList("admin"), ((Map<String, List<String>>) capturedBody[0]).get("user"));
+  }
+
+  @Test
   void handlesPathWithQueryStringCorrectly() {
     String eventJson =
         "{"

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
@@ -3,6 +3,7 @@ package datadog.trace.lambda;
 import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.lambda.LambdaEventParser.detectTriggerType;
 import static datadog.trace.lambda.LambdaEventParser.parseResponse;
+import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -47,6 +48,7 @@ import datadog.trace.bootstrap.instrumentation.api.TagContext;
 import datadog.trace.bootstrap.instrumentation.api.Tags;
 import datadog.trace.bootstrap.instrumentation.api.URIDataAdapter;
 import datadog.trace.core.DDCoreJavaSpecification;
+import datadog.trace.lambda.LambdaEventParser.LambdaResponseData;
 import datadog.trace.lambda.LambdaEventParser.LambdaTriggerType;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -69,6 +71,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
@@ -2185,6 +2189,30 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   @Test
   void extractResponseDataReturnsNullForEmptyString() {
     assertNull(parseResponse(""));
+  }
+
+  @ParameterizedTest(name = "[{index}] content-type {0}")
+  @ValueSource(strings = {"", "   ", "application/json"})
+  void parsesAResponseBodyAsJsonWhenTheContentTypeIsBlankOrJson(String contentType) {
+    // A blank content type says nothing about the body, so it gets the same best-effort JSON parse
+    // as an absent one, matching the request path.
+    LambdaResponseData response =
+        parseResponse(
+            "{\"statusCode\": 200, \"headers\": {\"content-type\": \""
+                + contentType
+                + "\"}, \"body\": \"{\\\"a\\\":1}\"}");
+    assertNotNull(response);
+    assertEquals(singletonMap("a", 1.0), response.body);
+  }
+
+  @Test
+  void keepsAResponseBodyRawWhenTheContentTypeIsNotJson() {
+    LambdaResponseData response =
+        parseResponse(
+            "{\"statusCode\": 200, \"headers\": {\"content-type\": \"text/plain\"},"
+                + " \"body\": \"{\\\"a\\\":1}\"}");
+    assertNotNull(response);
+    assertEquals("{\"a\":1}", response.body);
   }
 
   // ============================================================================

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
@@ -726,6 +726,109 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   @SuppressWarnings("unchecked")
+  void parsesMultipartBodyIntoItsFields() {
+    String eventJson =
+        "{"
+            + "\"body\": \"--xy\\r\\nContent-Disposition: form-data; name=\\\"user\\\"\\r\\n\\r\\nadmin"
+            + "\\r\\n--xy\\r\\nContent-Disposition: form-data; name=\\\"role\\\"\\r\\n\\r\\nroot"
+            + "\\r\\n--xy--\","
+            + "\"headers\": {\"Content-Type\": \"multipart/form-data; boundary=xy\"},"
+            + "\"requestContext\": {\"httpMethod\": \"POST\"}"
+            + "}";
+    ByteArrayInputStream event = createInputStream(eventJson);
+
+    Object[] capturedBody = {null};
+
+    setupMockCallbacks(new Callbacks().onBody(body -> capturedBody[0] = body));
+
+    AgentSpanContext result = LambdaAppSecHandler.processRequestStart(event);
+
+    assertNotNull(result);
+    assertInstanceOf(Map.class, capturedBody[0]);
+    Map<String, Object> fields = (Map<String, Object>) capturedBody[0];
+    assertEquals("admin", fields.get("user"));
+    assertEquals("root", fields.get("role"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void reportsMultipartFilenamesToTheWaf() {
+    String eventJson =
+        "{"
+            + "\"body\": \"--xy\\r\\nContent-Disposition: form-data; name=\\\"user\\\"\\r\\n\\r\\nadmin"
+            + "\\r\\n--xy\\r\\nContent-Disposition: form-data; name=\\\"avatar\\\";"
+            + " filename=\\\"cat.png\\\"\\r\\n\\r\\nbytes"
+            + "\\r\\n--xy--\","
+            + "\"headers\": {\"Content-Type\": \"multipart/form-data; boundary=xy\"},"
+            + "\"requestContext\": {\"httpMethod\": \"POST\"}"
+            + "}";
+    ByteArrayInputStream event = createInputStream(eventJson);
+
+    Object[] capturedBody = {null};
+    Object[] capturedFilenames = {null};
+
+    setupMockCallbacks(
+        new Callbacks()
+            .onBody(body -> capturedBody[0] = body)
+            .onFilenames(filenames -> capturedFilenames[0] = filenames));
+
+    AgentSpanContext result = LambdaAppSecHandler.processRequestStart(event);
+
+    assertNotNull(result);
+    assertEquals(Arrays.asList("cat.png"), capturedFilenames[0]);
+    // The file part is reported by name only: it is not a field, and its content is left out
+    Map<String, Object> fields = (Map<String, Object>) capturedBody[0];
+    assertEquals("admin", fields.get("user"));
+    assertNull(fields.get("avatar"));
+  }
+
+  @Test
+  void doesNotReportFilenamesForAMultipartBodyWithoutFileParts() {
+    String eventJson =
+        "{"
+            + "\"body\": \"--xy\\r\\nContent-Disposition: form-data; name=\\\"user\\\"\\r\\n\\r\\nadmin"
+            + "\\r\\n--xy--\","
+            + "\"headers\": {\"Content-Type\": \"multipart/form-data; boundary=xy\"},"
+            + "\"requestContext\": {\"httpMethod\": \"POST\"}"
+            + "}";
+    ByteArrayInputStream event = createInputStream(eventJson);
+
+    Object[] capturedFilenames = {null};
+
+    setupMockCallbacks(new Callbacks().onFilenames(filenames -> capturedFilenames[0] = filenames));
+
+    AgentSpanContext result = LambdaAppSecHandler.processRequestStart(event);
+
+    assertNotNull(result);
+    assertNull(capturedFilenames[0]);
+  }
+
+  @Test
+  void keepsMultipartBodyWithoutBoundaryAsRawString() {
+    String body =
+        "--xy\\r\\nContent-Disposition: form-data; name=user\\r\\n\\r\\nadmin\\r\\n--xy--";
+    String eventJson =
+        "{"
+            + "\"body\": \""
+            + body
+            + "\","
+            + "\"headers\": {\"Content-Type\": \"multipart/form-data\"},"
+            + "\"requestContext\": {\"httpMethod\": \"POST\"}"
+            + "}";
+    ByteArrayInputStream event = createInputStream(eventJson);
+
+    Object[] capturedBody = {null};
+
+    setupMockCallbacks(new Callbacks().onBody(b -> capturedBody[0] = b));
+
+    AgentSpanContext result = LambdaAppSecHandler.processRequestStart(event);
+
+    assertNotNull(result);
+    assertEquals(body.replace("\\r\\n", "\r\n"), capturedBody[0]);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
   void appliesContentTypeDispatchToBase64DecodedBodies() {
     String base64Body =
         Base64.getEncoder().encodeToString("user=admin".getBytes(StandardCharsets.UTF_8));
@@ -2433,6 +2536,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
     BiConsumer<String, Integer> onSocketAddress;
     Consumer<Map<String, Object>> onPathParams;
     Consumer<Object> onBody;
+    Consumer<List<String>> onFilenames;
 
     Callbacks onMethodUri(BiConsumer<String, URIDataAdapter> cb) {
       this.onMethodUri = cb;
@@ -2456,6 +2560,11 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
     Callbacks onBody(Consumer<Object> cb) {
       this.onBody = cb;
+      return this;
+    }
+
+    Callbacks onFilenames(Consumer<List<String>> cb) {
+      this.onFilenames = cb;
       return this;
     }
   }
@@ -2534,6 +2643,19 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
           .apply(any(), any());
     }
 
+    BiFunction<RequestContext, List<String>, Flow<Void>> filenamesCallback = null;
+    if (callbacks.onFilenames != null) {
+      filenamesCallback = mock(BiFunction.class);
+      Consumer<List<String>> capture = callbacks.onFilenames;
+      doAnswer(
+              inv -> {
+                capture.accept(inv.getArgument(1));
+                return Flow.ResultFlow.empty();
+              })
+          .when(filenamesCallback)
+          .apply(any(), any());
+    }
+
     CallbackProvider mockCallbackProvider = mock(CallbackProvider.class);
     when(mockCallbackProvider.getCallback(EVENTS.requestStarted()))
         .thenReturn(requestStartedCallback);
@@ -2547,6 +2669,8 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
     when(mockCallbackProvider.getCallback(EVENTS.requestPathParams()))
         .thenReturn(pathParamsCallback);
     when(mockCallbackProvider.getCallback(EVENTS.requestBodyProcessed())).thenReturn(bodyCallback);
+    when(mockCallbackProvider.getCallback(EVENTS.requestFilesFilenames()))
+        .thenReturn(filenamesCallback);
 
     AgentTracer.TracerAPI mockTracer = mock(AgentTracer.TracerAPI.class);
     when(mockTracer.getCallbackProvider(RequestContextSlot.APPSEC))

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
@@ -706,56 +706,6 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
   @Test
   @SuppressWarnings("unchecked")
-  void parsesUrlEncodedBodyIntoAMultimap() {
-    String eventJson =
-        "{"
-            + "\"body\": \"user=admin&role=root\","
-            + "\"headers\": {\"Content-Type\": \"application/x-www-form-urlencoded\"},"
-            + "\"requestContext\": {\"httpMethod\": \"POST\"}"
-            + "}";
-    ByteArrayInputStream event = createInputStream(eventJson);
-
-    Object[] capturedBody = {null};
-
-    setupMockCallbacks(new Callbacks().onBody(body -> capturedBody[0] = body));
-
-    AgentSpanContext result = LambdaAppSecHandler.processRequestStart(event);
-
-    assertNotNull(result);
-    assertInstanceOf(Map.class, capturedBody[0]);
-    Map<String, List<String>> parameters = (Map<String, List<String>>) capturedBody[0];
-    assertEquals(Arrays.asList("admin"), parameters.get("user"));
-    assertEquals(Arrays.asList("root"), parameters.get("role"));
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  void parsesMultipartBodyIntoItsFields() {
-    String eventJson =
-        "{"
-            + "\"body\": \"--xy\\r\\nContent-Disposition: form-data; name=\\\"user\\\"\\r\\n\\r\\nadmin"
-            + "\\r\\n--xy\\r\\nContent-Disposition: form-data; name=\\\"role\\\"\\r\\n\\r\\nroot"
-            + "\\r\\n--xy--\","
-            + "\"headers\": {\"Content-Type\": \"multipart/form-data; boundary=xy\"},"
-            + "\"requestContext\": {\"httpMethod\": \"POST\"}"
-            + "}";
-    ByteArrayInputStream event = createInputStream(eventJson);
-
-    Object[] capturedBody = {null};
-
-    setupMockCallbacks(new Callbacks().onBody(body -> capturedBody[0] = body));
-
-    AgentSpanContext result = LambdaAppSecHandler.processRequestStart(event);
-
-    assertNotNull(result);
-    assertInstanceOf(Map.class, capturedBody[0]);
-    Map<String, Object> fields = (Map<String, Object>) capturedBody[0];
-    assertEquals("admin", fields.get("user"));
-    assertEquals("root", fields.get("role"));
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
   void reportsMultipartFilenamesToTheWaf() {
     String eventJson =
         "{"
@@ -805,30 +755,6 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
 
     assertNotNull(result);
     assertNull(capturedFilenames[0]);
-  }
-
-  @Test
-  void keepsMultipartBodyWithoutBoundaryAsRawString() {
-    String body =
-        "--xy\\r\\nContent-Disposition: form-data; name=user\\r\\n\\r\\nadmin\\r\\n--xy--";
-    String eventJson =
-        "{"
-            + "\"body\": \""
-            + body
-            + "\","
-            + "\"headers\": {\"Content-Type\": \"multipart/form-data\"},"
-            + "\"requestContext\": {\"httpMethod\": \"POST\"}"
-            + "}";
-    ByteArrayInputStream event = createInputStream(eventJson);
-
-    Object[] capturedBody = {null};
-
-    setupMockCallbacks(new Callbacks().onBody(b -> capturedBody[0] = b));
-
-    AgentSpanContext result = LambdaAppSecHandler.processRequestStart(event);
-
-    assertNotNull(result);
-    assertEquals(body.replace("\\r\\n", "\r\n"), capturedBody[0]);
   }
 
   @Test

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
@@ -2118,7 +2118,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   }
 
   @ParameterizedTest(name = "[{index}] content-type {0}")
-  @ValueSource(strings = {"", "   ", "application/json"})
+  @ValueSource(strings = {"", "application/json"})
   void parsesAResponseBodyAsJsonWhenTheContentTypeIsBlankOrJson(String contentType) {
     // A blank content type says nothing about the body, so it gets the same best-effort JSON parse
     // as an absent one, matching the request path.

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
@@ -3,6 +3,7 @@ package datadog.trace.lambda;
 import static datadog.trace.api.gateway.Events.EVENTS;
 import static datadog.trace.lambda.LambdaEventParser.detectTriggerType;
 import static datadog.trace.lambda.LambdaEventParser.parseResponse;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -480,6 +481,77 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
     assertEquals("DELETE", capturedMethod[0]);
     assertEquals("/alb/test", capturedPath[0]);
     assertEquals("203.0.113.42", capturedSourceIp[0]);
+  }
+
+  @Test
+  void mergesApiGatewayV1MultiValueHeadersOverSingleValueOnes() {
+    // A REST proxy event carries both maps; "accept" is repeated, and the single-value map keeps
+    // only one of its values, so the merged reading is the one the WAF must see
+    String eventJson =
+        "{"
+            + "\"path\": \"/test\","
+            + "\"httpMethod\": \"GET\","
+            + "\"headers\": {\"Accept\": \"application/json\", \"X-Only-Single\": \"kept\"},"
+            + "\"multiValueHeaders\": {\"Accept\": [\"text/html\", \"application/json\"]},"
+            + "\"requestContext\": {\"httpMethod\": \"GET\", \"requestId\": \"r1\"}"
+            + "}";
+    ByteArrayInputStream event = createInputStream(eventJson);
+
+    Map<String, String> capturedHeaders = new HashMap<>();
+
+    setupMockCallbacks(new Callbacks().onHeader(capturedHeaders::put));
+
+    AgentSpanContext result = LambdaAppSecHandler.processRequestStart(event);
+
+    assertNotNull(result);
+    assertEquals("text/html, application/json", capturedHeaders.get("accept"));
+    // A header only the single-value map holds survives the merge
+    assertEquals("kept", capturedHeaders.get("x-only-single"));
+  }
+
+  @Test
+  void keepsApiGatewayV1SingleValueHeadersWhenThereAreNoMultiValueOnes() {
+    String eventJson =
+        "{"
+            + "\"path\": \"/test\","
+            + "\"httpMethod\": \"GET\","
+            + "\"headers\": {\"Accept\": \"application/json\"},"
+            + "\"requestContext\": {\"httpMethod\": \"GET\", \"requestId\": \"r1\"}"
+            + "}";
+    ByteArrayInputStream event = createInputStream(eventJson);
+
+    Map<String, String> capturedHeaders = new HashMap<>();
+
+    setupMockCallbacks(new Callbacks().onHeader(capturedHeaders::put));
+
+    AgentSpanContext result = LambdaAppSecHandler.processRequestStart(event);
+
+    assertNotNull(result);
+    assertEquals("application/json", capturedHeaders.get("accept"));
+  }
+
+  @Test
+  void dispatchesAnApiGatewayV1BodyOnAContentTypeOnlyInMultiValueHeaders() {
+    String eventJson =
+        "{"
+            + "\"path\": \"/test\","
+            + "\"httpMethod\": \"POST\","
+            + "\"headers\": {},"
+            + "\"multiValueHeaders\": {\"Content-Type\": [\"application/x-www-form-urlencoded\"]},"
+            + "\"body\": \"name=John\","
+            + "\"requestContext\": {\"httpMethod\": \"POST\", \"requestId\": \"r1\"}"
+            + "}";
+    ByteArrayInputStream event = createInputStream(eventJson);
+
+    Object[] capturedBody = {null};
+
+    setupMockCallbacks(new Callbacks().onBody(body -> capturedBody[0] = body));
+
+    AgentSpanContext result = LambdaAppSecHandler.processRequestStart(event);
+
+    assertNotNull(result);
+    assertInstanceOf(Map.class, capturedBody[0]);
+    assertEquals(singletonList("John"), ((Map<?, ?>) capturedBody[0]).get("name"));
   }
 
   @Test
@@ -2004,7 +2076,7 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   }
 
   @Test
-  void processResponseDataSkipsMultiValueHeadersEntryWithNonListValue() {
+  void processResponseDataKeepsMultiValueHeadersEntryWithNonListValue() {
     LambdaAppSecHandler.setCurrentTriggerType(LambdaTriggerType.API_GATEWAY_V1_REST);
     String json =
         "{\"statusCode\": 200, \"headers\": {\"content-type\": \"text/html\"}, \"multiValueHeaders\": {\"x-scalar\": \"not-a-list\", \"x-valid\": [\"v1\", \"v2\"]}}";
@@ -2014,7 +2086,8 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
     LambdaAppSecHandler.processResponseData(span, result);
     assertEquals("text/html", capturedHeaders.get("content-type"));
     assertEquals("v1, v2", capturedHeaders.get("x-valid"));
-    assertFalse(capturedHeaders.containsKey("x-scalar"));
+    // Not a shape AWS sends, but the runtime would still deliver the header, so it is reported
+    assertEquals("not-a-list", capturedHeaders.get("x-scalar"));
   }
 
   @Test

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/LambdaAppSecHandlerTest.java
@@ -510,6 +510,31 @@ class LambdaAppSecHandlerTest extends DDCoreJavaSpecification {
   }
 
   @Test
+  void joinsRepeatedCookieHeadersWithASemicolon() {
+    // HTTP/2 lets a client split Cookie across field lines, so a REST event may hold several. A
+    // cookie value may itself hold a comma, so joining with ", " would swallow the second cookie's
+    // name into the first one's value and hide it from the cookie rules.
+    String eventJson =
+        "{"
+            + "\"path\": \"/test\","
+            + "\"httpMethod\": \"GET\","
+            + "\"headers\": {\"Cookie\": \"sess=xyz\"},"
+            + "\"multiValueHeaders\": {\"Cookie\": [\"sess=xyz\", \"tracking=' OR 1=1 --\"]},"
+            + "\"requestContext\": {\"httpMethod\": \"GET\", \"requestId\": \"r1\"}"
+            + "}";
+    ByteArrayInputStream event = createInputStream(eventJson);
+
+    Map<String, String> capturedHeaders = new HashMap<>();
+
+    setupMockCallbacks(new Callbacks().onHeader(capturedHeaders::put));
+
+    AgentSpanContext result = LambdaAppSecHandler.processRequestStart(event);
+
+    assertNotNull(result);
+    assertEquals("sess=xyz; tracking=' OR 1=1 --", capturedHeaders.get("cookie"));
+  }
+
+  @Test
   void keepsApiGatewayV1SingleValueHeadersWhenThereAreNoMultiValueOnes() {
     String eventJson =
         "{"

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/MultipartSplitterTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/MultipartSplitterTest.java
@@ -1,0 +1,233 @@
+package datadog.trace.lambda;
+
+import static datadog.trace.lambda.MultipartSplitter.extractBoundary;
+import static datadog.trace.lambda.MultipartSplitter.parameter;
+import static datadog.trace.lambda.MultipartSplitter.split;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.lambda.MultipartSplitter.Part;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class MultipartSplitterTest {
+
+  private static final int NO_PART_BUDGET_LIMIT = 256;
+
+  @ParameterizedTest(name = "[{index}] {0} -> {1}")
+  @CsvSource(
+      delimiter = '|',
+      nullValues = "NULL",
+      value = {
+        // case is preserved: the boundary is matched byte-for-byte against the body
+        "multipart/form-data; boundary=AbC123        | AbC123",
+        // the parameter name is not
+        "multipart/form-data; BOUNDARY=xy            | xy",
+        // quoted values may hold separators
+        "multipart/form-data; boundary=\"a;b c\"     | a;b c",
+        // position among the other parameters does not matter
+        "multipart/form-data; boundary=xy; charset=x | xy",
+        "multipart/form-data; charset=x; boundary=xy | xy",
+        // a parameter that merely ends in "boundary" is not one
+        "multipart/form-data; xboundary=xy           | NULL",
+        "multipart/form-data                         | NULL",
+        "multipart/form-data; boundary=              | NULL",
+        "NULL                                        | NULL",
+      })
+  void extractsTheBoundary(String contentType, String expected) {
+    assertEquals(expected, extractBoundary(contentType));
+  }
+
+  @Test
+  void rejectsABoundaryOverSeventyCharacters() {
+    String maximum = repeat('a', 70);
+
+    assertEquals(maximum, extractBoundary("multipart/form-data; boundary=" + maximum));
+    assertNull(extractBoundary("multipart/form-data; boundary=" + maximum + "a"));
+  }
+
+  @ParameterizedTest(name = "[{index}] {1} of {0} -> {2}")
+  @CsvSource(
+      delimiter = '|',
+      nullValues = "NULL",
+      value = {
+        "form-data; name=user               | name     | user",
+        "form-data; name=\"user\"           | name     | user",
+        "form-data; name=\"a;b\"            | name     | a;b",
+        "form-data; NAME=user               | name     | user",
+        "form-data; name=user; charset=utf-8| name     | user",
+        // "filename" must not answer a lookup for "name": the match has to start at a parameter
+        "form-data; filename=\"f\"; name=u  | name     | u",
+        // present but empty, which is what browsers send for an untouched file input
+        "form-data; filename=\"\"           | filename | ''",
+        "form-data; filename=               | filename | ''",
+        "form-data; name=user               | filename | NULL",
+        "NULL                               | name     | NULL",
+        // a quoted value cannot forge a parameter boundary: the quoted span is skipped whole, so
+        // this field is not mistaken for a file part and dropped
+        "form-data; name=\"; filename=x\"   | filename | NULL",
+        "form-data; name=\"; filename=x\"   | name     | '; filename=x'",
+        // and the same aliasing the other way round does not rename the field
+        "form-data; filename=\"; name=y\"   | name     | NULL",
+        // RFC 7230 optional whitespace is tolerated on both sides of the "="
+        "form-data; name =user             | name     | user",
+        "form-data; name= user             | name     | user",
+        "form-data; name = \"a b\"          | name     | a b",
+        // a bare parameter name is not a parameter
+        "form-data; name                    | name     | NULL",
+      })
+  void readsParameters(String headerValue, String paramName, String expected) {
+    assertEquals(expected, parameter(headerValue, paramName));
+  }
+
+  @Test
+  void unescapesQuotedParameterValues() {
+    assertEquals("a\"b", parameter("form-data; name=\"a\\\"b\"", "name"));
+  }
+
+  @Test
+  void toleratesTabsAroundTheParameterEquals() {
+    assertEquals("user", parameter("form-data;\tname\t=\tuser", "name"));
+  }
+
+  @Test
+  void keepsWhatWasReadOfAnUnterminatedQuotedValue() {
+    assertEquals("abc", parameter("form-data; name=\"abc", "name"));
+    assertEquals("a\"", parameter("form-data; name=\"a\\\"", "name"));
+  }
+
+  @ParameterizedTest(name = "[{index}] {0} -> {2} part(s)")
+  @CsvSource(
+      delimiter = '|',
+      value = {
+        "happy path                | --x@A: b@@v@--x--          | 1",
+        "two parts                 | --x@@a@--x@@b@--x--        | 2",
+        "preamble is discarded     | junk@--x@@v@--x--          | 1",
+        "epilogue is discarded     | --x@@v@--x--@junk          | 1",
+        // a truncated body still yields its last part
+        "truncated last delimiter  | --x@A: b@@v                | 1",
+        "truncated in the headers  | --x@A: b                   | 0",
+        "no line break at all      | --x                        | 0",
+        "close delimiter only      | --x--                      | 0",
+        "empty part content        | --x@A: b@@                 | 1",
+        "part without headers      | --x@@v@--x--               | 1",
+        "unrelated delimiter       | --y@@v@--y--               | 0",
+      })
+  void splitsBodies(String name, String template, int expectedParts) {
+    assertEquals(
+        expectedParts, split(template.replace("@", "\r\n"), "x", NO_PART_BUDGET_LIMIT).size());
+  }
+
+  @Test
+  void toleratesBareLineFeeds() {
+    String body = "--x\nContent-Disposition: form-data; name=a\n\nvalue\n--x--\n";
+
+    List<Part> parts = split(body, "x", NO_PART_BUDGET_LIMIT);
+
+    assertEquals(1, parts.size());
+    assertEquals("value", content(body, parts.get(0)));
+  }
+
+  @Test
+  void stopsAtThePartBudget() {
+    String body = ("--x\r\n\r\na\r\n--x\r\n\r\nb\r\n--x\r\n\r\nc\r\n--x--");
+
+    assertEquals(2, split(body, "x", 2).size());
+    assertEquals(0, split(body, "x", 0).size());
+  }
+
+  @Test
+  void delimitsContentExactly() {
+    // Dashes, line breaks, a replacement character and a multi-byte character all inside the
+    // content:
+    // the reported range must not be thrown off by a near-miss on the line-feed anchor
+    String content = "--not-a-boundary\r\n-x\nlast�é";
+    String body =
+        "--x\r\nContent-Disposition: form-data; name=a\r\n\r\n" + content + "\r\n--x--\r\n";
+
+    List<Part> parts = split(body, "x", NO_PART_BUDGET_LIMIT);
+
+    assertEquals(1, parts.size());
+    assertEquals(content, content(body, parts.get(0)));
+    assertEquals("form-data; name=a", parts.get(0).header("content-disposition"));
+  }
+
+  @Test
+  void confinesAPartWhoseHeadersRunIntoTheNextDelimiter() {
+    // The first part's headers are not followed by a blank line. Reading past the delimiter would
+    // merge the following part's headers into this one, so a well-formed field part would be
+    // reported as the malformed part's own — and skipped entirely if it carried a filename.
+    String body =
+        "--x\r\nX-First: 1\r\n"
+            + "--x\r\nContent-Disposition: form-data; name=\"b\"\r\n\r\nsecond\r\n--x--";
+
+    List<Part> parts = split(body, "x", NO_PART_BUDGET_LIMIT);
+
+    assertEquals(1, parts.size());
+    assertNull(parts.get(0).header("x-first"));
+    assertEquals("form-data; name=\"b\"", parts.get(0).header("content-disposition"));
+    assertEquals("second", content(body, parts.get(0)));
+  }
+
+  @Test
+  void lowercasesHeaderNamesAndTrimsValues() {
+    String body = "--x\r\nCONTENT-Disposition:  form-data; name=a \r\nX:\r\n\r\nv\r\n--x--";
+
+    Part part = split(body, "x", NO_PART_BUDGET_LIMIT).get(0);
+
+    assertEquals("form-data; name=a", part.header("content-disposition"));
+    assertEquals("", part.header("x"));
+    assertNull(part.header("absent"));
+  }
+
+  @Test
+  @Timeout(value = 10, unit = SECONDS)
+  void returnsPromptlyOnAnAdversarialBoundary() {
+    // Dashes are legal boundary characters, so a scan seeded on '-' would be quadratic here.
+    // Anchored
+    // on the mandatory line feed, of which this body has none, the scan is linear.
+    String boundary = repeat('-', 69) + "X";
+    String body = repeat('-', 1_000_000);
+
+    assertTrue(split(body, boundary, NO_PART_BUDGET_LIMIT).isEmpty());
+  }
+
+  @Test
+  @Timeout(value = 30, unit = SECONDS)
+  void neverThrowsOnAMutatedBody() {
+    String body =
+        "preamble\r\n--x\r\nContent-Disposition: form-data; name=\"a\"\r\n"
+            + "Content-Type: application/json\r\n\r\n{\"k\":1}\r\n"
+            + "--x\r\nContent-Disposition: form-data; name=b; filename=\"f\"\r\n\r\nfile\r\n"
+            + "--x--\r\nepilogue";
+    // Fixed positions rather than a random seed, so a failure is reproducible
+    char[] substitutes = {'-', '\r', '\n', ':', ';', '"', '\\', '=', '\0', '�'};
+
+    for (int i = 0; i <= body.length(); i++) {
+      split(body.substring(0, i), "x", NO_PART_BUDGET_LIMIT);
+      for (char substitute : substitutes) {
+        if (i < body.length()) {
+          split(
+              body.substring(0, i) + substitute + body.substring(i + 1), "x", NO_PART_BUDGET_LIMIT);
+        }
+      }
+    }
+  }
+
+  private static String content(String body, Part part) {
+    return body.substring(part.contentStart, part.contentEnd);
+  }
+
+  private static String repeat(char c, int count) {
+    StringBuilder builder = new StringBuilder(count);
+    for (int i = 0; i < count; i++) {
+      builder.append(c);
+    }
+    return builder.toString();
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/MultipartSplitterTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/MultipartSplitterTest.java
@@ -160,21 +160,14 @@ class MultipartSplitterTest {
   }
 
   @Test
-  void confinesAPartWhoseHeadersRunIntoTheNextDelimiter() {
-    // The first part's headers are not followed by a blank line. Reading past the delimiter would
-    // merge the following part's headers into this one, so a well-formed field part would be
-    // reported as the malformed part's own — and skipped entirely if it carried a filename.
+  void reportsNothingForAPartWhoseHeadersRunIntoTheNextDelimiter() {
+    // The first part's headers are not followed by a blank line, which no conforming parser
+    // accepts. Reporting the second part alone would show the WAF less than the app receives.
     String body =
         "--x\r\nX-First: 1\r\n"
             + "--x\r\nContent-Disposition: form-data; name=\"b\"\r\n\r\nsecond\r\n--x--";
 
-    List<Part> parts = split(body, "x", NO_PART_BUDGET_LIMIT);
-
-    // The surviving part is the second one: had the two merged, its content would have swallowed
-    // the delimiter between them.
-    assertEquals(1, parts.size());
-    assertEquals("form-data; name=\"b\"", parts.get(0).contentDisposition);
-    assertEquals("second", content(body, parts.get(0)));
+    assertTrue(split(body, "x", NO_PART_BUDGET_LIMIT).isEmpty());
   }
 
   @Test

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/MultipartSplitterTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/MultipartSplitterTest.java
@@ -32,7 +32,6 @@ class MultipartSplitterTest {
         "multipart/form-data; boundary=\"a;b c\"     | a;b c",
         // position among the other parameters does not matter
         "multipart/form-data; boundary=xy; charset=x | xy",
-        "multipart/form-data; charset=x; boundary=xy | xy",
         // a parameter that merely ends in "boundary" is not one
         "multipart/form-data; xboundary=xy           | NULL",
         "multipart/form-data                         | NULL",
@@ -76,8 +75,6 @@ class MultipartSplitterTest {
         "form-data; filename=\"; name=y\"   | name     | NULL",
         // RFC 7230 optional whitespace is tolerated on both sides of the "="
         "form-data; name =user             | name     | user",
-        "form-data; name= user             | name     | user",
-        "form-data; name = \"a b\"          | name     | a b",
         // a bare parameter name is not a parameter
         "form-data; name                    | name     | NULL",
       })
@@ -174,41 +171,16 @@ class MultipartSplitterTest {
   void matchesHeaderNamesCaseInsensitivelyAndTrimsValues() {
     String body =
         "--x\r\nCONTENT-Disposition:  form-data; name=a \r\n"
-            + "content-type \t:\ttext/plain \r\n\r\nv\r\n--x--";
-
-    Part part = split(body, "x", NO_PART_BUDGET_LIMIT).get(0);
-
-    assertEquals("form-data; name=a", part.contentDisposition);
-    assertEquals("text/plain", part.contentType);
-  }
-
-  @Test
-  void reportsNoValueForAHeaderThatIsPresentButEmpty() {
-    String body = "--x\r\nContent-Type:\r\n\r\nv\r\n--x--";
-
-    Part part = split(body, "x", NO_PART_BUDGET_LIMIT).get(0);
-
-    assertEquals("", part.contentType);
-    assertNull(part.contentDisposition);
-  }
-
-  @Test
-  @Timeout(value = 10, unit = SECONDS)
-  void dropsHeadersItDoesNotReadWhateverTheirNumber() {
-    // Only Content-Disposition and Content-Type are kept, so a part may declare arbitrarily many
-    // others without any of them being retained.
-    StringBuilder headers = new StringBuilder();
-    for (int i = 0; i < 100_000; i++) {
-      headers.append("X-Filler-").append(i).append(": ").append(i).append("\r\n");
-    }
-    String body = "--x\r\n" + headers + "Content-Disposition: form-data; name=a\r\n\r\nv\r\n--x--";
+            + "content-type \t:\ttext/plain \r\n\r\nv\r\n"
+            + "--x\r\nContent-Type:\r\n\r\nv\r\n--x--";
 
     List<Part> parts = split(body, "x", NO_PART_BUDGET_LIMIT);
 
-    assertEquals(1, parts.size());
     assertEquals("form-data; name=a", parts.get(0).contentDisposition);
-    assertNull(parts.get(0).contentType);
-    assertEquals("v", content(body, parts.get(0)));
+    assertEquals("text/plain", parts.get(0).contentType);
+    // A header present but empty is reported as "", distinct from the null of an absent one
+    assertEquals("", parts.get(1).contentType);
+    assertNull(parts.get(1).contentDisposition);
   }
 
   @Test

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/MultipartSplitterTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/MultipartSplitterTest.java
@@ -117,6 +117,8 @@ class MultipartSplitterTest {
         "empty part content        | --x@A: b@@                 | 1",
         "part without headers      | --x@@v@--x--               | 1",
         "unrelated delimiter       | --y@@v@--y--               | 0",
+        // RFC 2046 transport padding between the delimiter and its line break
+        "padded delimiter          | --x  @@v@--x--             | 1",
       })
   void splitsBodies(String name, String template, int expectedParts) {
     assertEquals(
@@ -144,8 +146,9 @@ class MultipartSplitterTest {
   @Test
   void delimitsContentExactly() {
     // Dashes, line breaks, a replacement character and a multi-byte character all inside the
-    // content: the reported range must not be thrown off by a near-miss on the line-feed anchor
-    String content = "--not-a-boundary\r\n-x\nlast�é";
+    // content, plus a line that starts with the delimiter without being one: the reported range
+    // must not be thrown off by a near miss on the line-feed anchor or on the delimiter itself
+    String content = "--not-a-boundary\r\n--x-not-a-boundary\r\n-x\nlast�é";
     String body =
         "--x\r\nContent-Disposition: form-data; name=a\r\n\r\n" + content + "\r\n--x--\r\n";
 

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/MultipartSplitterTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/MultipartSplitterTest.java
@@ -109,6 +109,9 @@ class MultipartSplitterTest {
         // a truncated body still yields its last part
         "truncated last delimiter  | --x@A: b@@v                | 1",
         "truncated in the headers  | --x@A: b                   | 0",
+        // A part truncated inside its headers voids the parts before it too: its own headers are
+        // content the WAF would otherwise never see
+        "truncated after a part    | --x@@v@--x@A: b            | 0",
         "no line break at all      | --x                        | 0",
         "close delimiter only      | --x--                      | 0",
         "empty part content        | --x@A: b@@                 | 1",
@@ -143,9 +146,10 @@ class MultipartSplitterTest {
   @Test
   void delimitsContentExactly() {
     // Dashes, line breaks, a replacement character and a multi-byte character all inside the
-    // content, plus a line that starts with the delimiter without being one: the reported range
-    // must not be thrown off by a near miss on the line-feed anchor or on the delimiter itself
-    String content = "--not-a-boundary\r\n--x-not-a-boundary\r\n-x\nlast�é";
+    // content, plus lines that start with the part and close delimiters without being either: the
+    // reported range must not be thrown off by a near miss on the line-feed anchor, on the
+    // delimiter itself, or on its trailing dashes
+    String content = "--not-a-boundary\r\n--x-not-a-boundary\r\n--x--not-a-close\r\n-x\nlast�é";
     String body =
         "--x\r\nContent-Disposition: form-data; name=a\r\n\r\n" + content + "\r\n--x--\r\n";
 

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/MultipartSplitterTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/MultipartSplitterTest.java
@@ -144,8 +144,7 @@ class MultipartSplitterTest {
   @Test
   void delimitsContentExactly() {
     // Dashes, line breaks, a replacement character and a multi-byte character all inside the
-    // content:
-    // the reported range must not be thrown off by a near-miss on the line-feed anchor
+    // content: the reported range must not be thrown off by a near-miss on the line-feed anchor
     String content = "--not-a-boundary\r\n-x\nlast�é";
     String body =
         "--x\r\nContent-Disposition: form-data; name=a\r\n\r\n" + content + "\r\n--x--\r\n";
@@ -154,7 +153,7 @@ class MultipartSplitterTest {
 
     assertEquals(1, parts.size());
     assertEquals(content, content(body, parts.get(0)));
-    assertEquals("form-data; name=a", parts.get(0).header("content-disposition"));
+    assertEquals("form-data; name=a", parts.get(0).contentDisposition);
   }
 
   @Test
@@ -168,29 +167,59 @@ class MultipartSplitterTest {
 
     List<Part> parts = split(body, "x", NO_PART_BUDGET_LIMIT);
 
+    // The surviving part is the second one: had the two merged, its content would have swallowed
+    // the delimiter between them.
     assertEquals(1, parts.size());
-    assertNull(parts.get(0).header("x-first"));
-    assertEquals("form-data; name=\"b\"", parts.get(0).header("content-disposition"));
+    assertEquals("form-data; name=\"b\"", parts.get(0).contentDisposition);
     assertEquals("second", content(body, parts.get(0)));
   }
 
   @Test
-  void lowercasesHeaderNamesAndTrimsValues() {
-    String body = "--x\r\nCONTENT-Disposition:  form-data; name=a \r\nX:\r\n\r\nv\r\n--x--";
+  void matchesHeaderNamesCaseInsensitivelyAndTrimsValues() {
+    String body =
+        "--x\r\nCONTENT-Disposition:  form-data; name=a \r\n"
+            + "content-type \t:\ttext/plain \r\n\r\nv\r\n--x--";
 
     Part part = split(body, "x", NO_PART_BUDGET_LIMIT).get(0);
 
-    assertEquals("form-data; name=a", part.header("content-disposition"));
-    assertEquals("", part.header("x"));
-    assertNull(part.header("absent"));
+    assertEquals("form-data; name=a", part.contentDisposition);
+    assertEquals("text/plain", part.contentType);
+  }
+
+  @Test
+  void reportsNoValueForAHeaderThatIsPresentButEmpty() {
+    String body = "--x\r\nContent-Type:\r\n\r\nv\r\n--x--";
+
+    Part part = split(body, "x", NO_PART_BUDGET_LIMIT).get(0);
+
+    assertEquals("", part.contentType);
+    assertNull(part.contentDisposition);
+  }
+
+  @Test
+  @Timeout(value = 10, unit = SECONDS)
+  void dropsHeadersItDoesNotReadWhateverTheirNumber() {
+    // Only Content-Disposition and Content-Type are kept, so a part may declare arbitrarily many
+    // others without any of them being retained.
+    StringBuilder headers = new StringBuilder();
+    for (int i = 0; i < 100_000; i++) {
+      headers.append("X-Filler-").append(i).append(": ").append(i).append("\r\n");
+    }
+    String body = "--x\r\n" + headers + "Content-Disposition: form-data; name=a\r\n\r\nv\r\n--x--";
+
+    List<Part> parts = split(body, "x", NO_PART_BUDGET_LIMIT);
+
+    assertEquals(1, parts.size());
+    assertEquals("form-data; name=a", parts.get(0).contentDisposition);
+    assertNull(parts.get(0).contentType);
+    assertEquals("v", content(body, parts.get(0)));
   }
 
   @Test
   @Timeout(value = 10, unit = SECONDS)
   void returnsPromptlyOnAnAdversarialBoundary() {
     // Dashes are legal boundary characters, so a scan seeded on '-' would be quadratic here.
-    // Anchored
-    // on the mandatory line feed, of which this body has none, the scan is linear.
+    // Anchored on the mandatory line feed, of which this body has none, the scan is linear.
     String boundary = repeat('-', 69) + "X";
     String body = repeat('-', 1_000_000);
 

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/MultipartSplitterTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/MultipartSplitterTest.java
@@ -105,7 +105,13 @@ class MultipartSplitterTest {
         "happy path                | --x@A: b@@v@--x--          | 1",
         "two parts                 | --x@@a@--x@@b@--x--        | 2",
         "preamble is discarded     | junk@--x@@v@--x--          | 1",
+        // The preamble is discarded even when a line in it looks like a delimiter: RFC 2046
+        // requires it to be ignored, so the fields after it are the ones the app receives
+        "preamble looks like one   | --x--not-a-close@--x@@v@--x-- | 1",
         "epilogue is discarded     | --x@@v@--x--@junk          | 1",
+        // A delimiter at the very start of a part's content has no line break of its own, so it
+        // reads as content, not as a delimiter — and the part that follows is absorbed with it
+        "delimiter at content start| --x@@--x@@v@--x--         | 1",
         // a truncated body still yields its last part
         "truncated last delimiter  | --x@A: b@@v                | 1",
         "truncated in the headers  | --x@A: b                   | 0",
@@ -133,6 +139,33 @@ class MultipartSplitterTest {
 
     assertEquals(1, parts.size());
     assertEquals("value", content(body, parts.get(0)));
+  }
+
+  @Test
+  void readsADelimiterAtAContentStartAsContent() {
+    // The close delimiter here shares the line break that terminated the headers, so it has none of
+    // its own. Commons FileUpload reads it as the field's content and so must we: reporting an
+    // empty field would hide the payload behind it from the WAF.
+    String body =
+        "--x\r\nContent-Disposition: form-data; name=a\r\n\r\n--x--\r\n' OR 1=1 --\r\n--x--";
+
+    List<Part> parts = split(body, "x", NO_PART_BUDGET_LIMIT);
+
+    assertEquals(1, parts.size());
+    assertEquals("--x--\r\n' OR 1=1 --", content(body, parts.get(0)));
+  }
+
+  @Test
+  void readsADelimiterWithItsOwnLineBreakAsADelimiter() {
+    // One line break more than the body above, which is enough to make the delimiter unambiguous:
+    // every parser reads the field as empty and the rest as the epilogue.
+    String body =
+        "--x\r\nContent-Disposition: form-data; name=a\r\n\r\n\r\n--x--\r\n' OR 1=1 --\r\n--x--";
+
+    List<Part> parts = split(body, "x", NO_PART_BUDGET_LIMIT);
+
+    assertEquals(1, parts.size());
+    assertEquals("", content(body, parts.get(0)));
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do

Dispatches Lambda AppSec request bodies on their declared `Content-Type` instead of handing every body to a JSON parser:

| Declared type | Reported to the WAF as |
|---|---|
| JSON-ish (`application/json`, any `+json` suffix, `application/x-amz-json-1.1`, `application/javascript`) or no usable type at all | best-effort JSON parse |
| `application/x-www-form-urlencoded` | multimap, the same shape already used for query parameters |
| `multipart/*` | form fields, each part dispatched on its own `Content-Type`; file parts contribute their filename, not their content |
| `text/*` and everything else | raw string |

A body is never dropped. Any type we cannot structure, and any parse failure, degrades to the raw string, which the WAF can still match string rules against. In particular a `text/plain` body of `12345` must reach the WAF as a `String` and not as the `Double` a JSON parse would produce.

The same rule decides what happens to a malformed multipart body. A part whose headers run into the next delimiter is not reported part-by-part: no conforming parser accepts such a body — Commons FileUpload and Netty both reject it outright — so reporting the parts that happen to survive would show the WAF less than the application receives. The whole body degrades to the raw string instead.

Parsing is bounded by three allowances, shared across nesting levels rather than re-satisfied at each one: 1 MiB of characters read, 256 parts or parameters, and 20 levels of nesting. The depth and part limits mirror the WAF's own (`WAFModule.MAX_DEPTH` / `MAX_ELEMENTS`) — structure beyond them is discarded by `ObjectIntrospection` before the WAF sees it, so producing it would be wasted work. Exceeding an allowance degrades the body to a raw string rather than truncating it, since a truncated map would hide the dropped parameter from every rule.

**Behavior changes worth a reviewer's eye.** The JSON-ish decision is now made in one place, `ContentTypeBodyParser.isJsonOrUntyped`, which the response path in `LambdaEventParser` shares with the request path. It matches on the subtype alone, where the response path previously looked for `json` or `javascript` anywhere in the raw header. Three consequences:

- A `Content-Type` holding nothing but parameters — `; charset=utf-8` — counts as declaring no type, and so gets the same best-effort JSON parse an absent header gets. Pinned by a case in `dispatchesOnContentType`.
- A **response** body with a blank `content-type` now gets that best-effort JSON parse too. Previously only an absent header did, since `""` does not contain `json`.
- A **response** body whose type carries the word in a *parameter* — `multipart/form-data; boundary=--json` — no longer reaches the JSON parser. This is why the gate matches on the subtype only: a client-chosen boundary must not decide how the body is read.

# Motivation

Peer tracers already structure urlencoded and multipart Lambda bodies. Without it, a form-encoded or multipart request reaching a Lambda is visible to the WAF only as one opaque string, so any rule addressing `server.request.body` by key cannot match — the same request routed through a non-Lambda entrypoint would be inspected properly.

# Additional Notes

`MultipartSplitter` no longer collects a `HashMap` of every header per part. Only `Content-Disposition` and `Content-Type` are ever read, so the others are matched and dropped as the scan passes them: a body that is nothing but header lines would otherwise allocate a map entry per line, which is why the change is here at all. The naive version of the fix — matching header names inline with a case-insensitive `regionMatches` — measured slower on well-formed many-part forms, so the canonical spelling is tried with a case-sensitive compare first and the matching lives in its own small method rather than inlined into `split`.

Two known flaky failures were seen in `dd-trace-core` while validating, both unrelated to this diff and both passing on re-run in isolation: `PendingTraceBufferTest.testingTracerFlareDumpWithMultipleTraces` and `DDAgentWriterCombinedTest.statsdCommFailure`. Neither is annotated `@Flaky`.

File parts populate `server.request.body.filenames`, which comes almost free once the parts are split. The other two file addresses are left empty on purpose: the Lambda event delivers the body as one UTF-8-decoded string, so a file's bytes are already corrupted by the time we see them, and `files_content` would report that damage as if it were the upload. `files_field_names` waits with it.

The repeated callback-registration boilerplate in `LambdaAppSecHandler` is left for its own change.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

🤖 Generated with [Claude Code](https://claude.com/claude-code)


