### PR TITLE
Fall back to global trace config when a span's own config is null

### DIFF
--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -163,7 +163,8 @@ public class AgentTracer {
   }
 
   public static TraceConfig traceConfig(final AgentSpan span) {
-    return null != span ? span.traceConfig() : traceConfig();
+    final TraceConfig config = span == null ? null : span.traceConfig();
+    return config == null ? traceConfig() : config;
   }
 
   public static TraceConfig traceConfig() {

--- a/internal-api/src/test/java/datadog/trace/bootstrap/instrumentation/api/AgentTracerTest.java
+++ b/internal-api/src/test/java/datadog/trace/bootstrap/instrumentation/api/AgentTracerTest.java
@@ -1,0 +1,46 @@
+package datadog.trace.bootstrap.instrumentation.api;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import datadog.trace.api.TraceConfig;
+import org.junit.jupiter.api.Test;
+
+class AgentTracerTest {
+
+  @Test
+  void traceConfigOfNullSpanFallsBackToGlobalConfig() {
+    assertSame(AgentTracer.traceConfig(), AgentTracer.traceConfig((AgentSpan) null));
+  }
+
+  @Test
+  void traceConfigOfSpanWithOwnConfigReturnsThatConfig() {
+    TraceConfig ownConfig = mock(TraceConfig.class);
+    AgentSpan span = mock(AgentSpan.class);
+    when(span.traceConfig()).thenReturn(ownConfig);
+
+    assertSame(ownConfig, AgentTracer.traceConfig(span));
+  }
+
+  // Regression test: a span wrapping only an extracted remote context (e.g. built via
+  // AgentSpan.fromSpanContext for a propagated-but-not-yet-local trace) reports a null
+  // TraceConfig. Callers such as LogbackLoggerInstrumentation$CallAppendersAdvice do
+  // `traceConfig(span).isLogsInjectionEnabled()` without a further null check, so
+  // traceConfig(AgentSpan) must never return null for a non-null span.
+  @Test
+  void traceConfigOfExtractedSpanFallsBackToGlobalConfigInsteadOfNull() {
+    AgentSpan extractedSpan = AgentSpan.fromSpanContext(new TagContext());
+
+    assertNull(
+        extractedSpan.traceConfig(),
+        "test setup: expected the extracted span itself to report a null config");
+
+    TraceConfig config = AgentTracer.traceConfig(extractedSpan);
+
+    assertNotNull(config);
+    assertSame(AgentTracer.traceConfig(), config);
+  }
+}


### PR DESCRIPTION
# What Does This Do

`AgentTracer.traceConfig(AgentSpan)` returned `null` whenever the given span itself reported a `null` `TraceConfig` (e.g. an `ExtractedSpan`, which wraps only a remote/propagated context and has no local trace config). It now falls back to the global trace config in that case, the same fallback the method already used when the span itself was `null`.

Added `AgentTracerTest` covering: a `null` span, a span with its own config, and the regression case (an extracted span whose own `traceConfig()` is `null`).

# Motivation

Several logging instrumentations call `traceConfig(span).isLogsInjectionEnabled()` after only null-checking `span` (not the returned `TraceConfig`), e.g. `LogbackLoggerInstrumentation$CallAppendersAdvice`:

```java
if (span != null && traceConfig(span).isLogsInjectionEnabled()) {
```

When the active span is an `ExtractedSpan`, `traceConfig(span)` returned `null`, causing a `NullPointerException`. It's swallowed by the tracer's own advice-exception handler so it never breaks the instrumented app, but it shows up as a spurious error-tracking issue, misattributed to whatever code happens to be on the calling thread at the time (in the case that prompted this fix, an rxjava2 observer chain, since `Logger.callAppenders` was invoked synchronously from deep inside it).

The same unguarded pattern is duplicated across five logging integrations (logback, log4j1, log4j2, jboss-logmanager, tinylog), so fixing it at the shared source (`AgentTracer.traceConfig`) covers all of them at once instead of patching each call site.

# Additional Notes

Investigated via a Datadog Error Tracking issue whose stack trace pointed at `datadog.trace.instrumentation.rxjava2.TracingSingleObserver.onSuccess` — that attribution was a red herring; root-cause writeup posted as a comment on the issue.

# Contributor Checklist

- [x] Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Avoid using `close`, `fix`, or any linking keywords when referencing an issue
- [x] Update the CODEOWNERS file on source file addition, migration, or deletion (n/a — no files added/moved)
- [x] Update public documentation with any new configuration flags or behaviors (n/a — no config/behavior change)
- [ ] Once approved, use merge queue to merge the PR

Jira ticket: [none]