### PR TITLE
Guard Tomcat CoyoteAdapter advice against null-scope NPE (quick fix)

### DIFF
--- a/dd-java-agent/instrumentation/tomcat/tomcat-5.5/build.gradle
+++ b/dd-java-agent/instrumentation/tomcat/tomcat-5.5/build.gradle
@@ -113,6 +113,7 @@ dependencies {
   testRuntimeOnly project(':dd-java-agent:instrumentation:websocket:jakarta-websocket-2.0')
 
   testImplementation testFixtures(project(':dd-java-agent:instrumentation:servlet:jakarta-servlet-5.0'))
+  testImplementation libs.bundles.junit5
 
   tomcat9TestImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.+'
   tomcat9TestImplementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.+'

--- a/dd-java-agent/instrumentation/tomcat/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatServerInstrumentation.java
+++ b/dd-java-agent/instrumentation/tomcat/tomcat-5.5/src/main/java/datadog/trace/instrumentation/tomcat/TomcatServerInstrumentation.java
@@ -133,7 +133,12 @@ public final class TomcatServerInstrumentation extends InstrumenterModule.Tracin
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void closeScope(@Advice.Local("parentScope") ContextScope scope) {
-      scope.close();
+      // scope can be null if extractParent() above threw before assigning it (the throwable is
+      // swallowed by suppress = Throwable.class), which would otherwise NPE here and mask the
+      // real failure.
+      if (scope != null) {
+        scope.close();
+      }
     }
   }
 
@@ -167,7 +172,12 @@ public final class TomcatServerInstrumentation extends InstrumenterModule.Tracin
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void closeScope(@Advice.Local("serverScope") ContextScope serverScope) {
-      serverScope.close();
+      // serverScope can be null if onService() above threw before assigning it (the throwable is
+      // swallowed by suppress = Throwable.class), which would otherwise NPE here and mask the
+      // real failure.
+      if (serverScope != null) {
+        serverScope.close();
+      }
     }
 
     private void muzzleCheck(CoyoteAdapter adapter, Request request, Response response)

--- a/dd-java-agent/instrumentation/tomcat/tomcat-5.5/src/test/java/datadog/trace/instrumentation/tomcat/TomcatServerInstrumentationTest.java
+++ b/dd-java-agent/instrumentation/tomcat/tomcat-5.5/src/test/java/datadog/trace/instrumentation/tomcat/TomcatServerInstrumentationTest.java
@@ -1,0 +1,49 @@
+package datadog.trace.instrumentation.tomcat;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.context.Context;
+import datadog.context.ContextScope;
+import org.junit.jupiter.api.Test;
+
+class TomcatServerInstrumentationTest {
+
+  private static final class RecordingScope implements ContextScope {
+    private boolean closed;
+
+    @Override
+    public Context context() {
+      return null;
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+    }
+  }
+
+  @Test
+  void contextTrackingAdviceCloseScopeToleratesNullScope() {
+    assertDoesNotThrow(() -> TomcatServerInstrumentation.ContextTrackingAdvice.closeScope(null));
+  }
+
+  @Test
+  void contextTrackingAdviceCloseScopeClosesNonNullScope() {
+    RecordingScope scope = new RecordingScope();
+    TomcatServerInstrumentation.ContextTrackingAdvice.closeScope(scope);
+    assertTrue(scope.closed);
+  }
+
+  @Test
+  void serviceAdviceCloseScopeToleratesNullScope() {
+    assertDoesNotThrow(() -> TomcatServerInstrumentation.ServiceAdvice.closeScope(null));
+  }
+
+  @Test
+  void serviceAdviceCloseScopeClosesNonNullScope() {
+    RecordingScope scope = new RecordingScope();
+    TomcatServerInstrumentation.ServiceAdvice.closeScope(scope);
+    assertTrue(scope.closed);
+  }
+}


### PR DESCRIPTION
# What Does This Do

Guards the Tomcat `CoyoteAdapter` server advice against a null-scope `NullPointerException` that can occur if the paired enter-advice fails before assigning its `@Advice.Local` `ContextScope`.

`TomcatServerInstrumentation.ContextTrackingAdvice.closeScope` and `TomcatServerInstrumentation.ServiceAdvice.closeScope` both called `.close()` unconditionally on an `@Advice.Local` `ContextScope`. Both are guarded with `if (scope != null)` now.

# Motivation

Error Tracking issue: https://app.datadoghq.com/error-tracking/issue/5ce30218-b43b-11f0-ac08-da7ad0900002

```
java.lang.NullPointerException
  at (redacted: 6 frames)
  at java.base/java.lang.VirtualThread.run(VirtualThread.java:460)
```
Logged via the agent's own suppressed-exception mechanism as:
```
Failed to handle exception in instrumentation for org.apache.catalina.connector.CoyoteAdapter
```

`ContextTrackingAdvice.extractParent` and `ServiceAdvice.onService` are both `@Advice.OnMethodEnter(suppress = Throwable.class)`. If either throws before assigning its `@Advice.Local` `ContextScope` (e.g. `DECORATE.extract(req)`, `DECORATE.startSpan(...)`, or a request-attribute call throwing inside an app's custom `Request`/attribute wrapper), the exception is silently swallowed by ByteBuddy's suppression bytecode. `CoyoteAdapter.service()` then proceeds normally, and the paired `@Advice.OnMethodExit` `closeScope` unconditionally calls `.close()` on the still-null local — a second NPE that is *also* swallowed and logged, fully masking the original failure. Because both exceptions are handled by generated advice bytecode rather than real application frames, the visible stack trace is almost entirely redacted, which is why this surfaces as a bare `VirtualThread.run` frame with no other context.

A related but narrower instance of this same failure mode (`parentContext == null` specifically) was already fixed in #11968 (`rootContext()` fallback), but the underlying structural issue — `closeScope` not tolerating a null local — was never addressed, so any other exception in the enter-advice reproduces the same NPE.

# Additional Notes

Added a direct JUnit 5 unit test (`TomcatServerInstrumentationTest`) calling the two `closeScope` advice methods with `null` and with a real `ContextScope`, since both are plain public static methods and `ContextScope` is an interface — no bytecode instrumentation harness or mocking framework needed.

# Contributor Checklist

- [x] Add an entry in `docs/release_notes.md` if this change affects the user-facing functionality. — N/A, internal fix.
- [x] Verify code coverage of new lines
- [x] Confirm this change does not add flakiness in tests

Jira ticket: [PROJ-IDENT]
