### PR TITLE
Add null-safe ContextScope.close(scope) helper (quick fix)

### DIFF
--- a/components/context/src/main/java/datadog/context/ContextScope.java
+++ b/components/context/src/main/java/datadog/context/ContextScope.java
@@ -8,4 +8,19 @@ public interface ContextScope extends AutoCloseable {
   /** Detaches the context from the execution unit. */
   @Override
   void close();
+
+  /**
+   * Closes the given scope, tolerating a {@code null} scope.
+   *
+   * <p>Useful in advice that attaches a scope on enter and closes it on exit: if the enter advice
+   * throws before assigning the scope, the exit advice would otherwise NPE on a null scope, masking
+   * the original failure.
+   *
+   * @param scope the scope to close; can be {@code null}.
+   */
+  static void close(ContextScope scope) {
+    if (scope != null) {
+      scope.close();
+    }
+  }
 }

--- a/components/context/src/test/java/datadog/context/ContextScopeTest.java
+++ b/components/context/src/test/java/datadog/context/ContextScopeTest.java
@@ -1,0 +1,35 @@
+package datadog.context;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class ContextScopeTest {
+
+  private static final class RecordingScope implements ContextScope {
+    private boolean closed;
+
+    @Override
+    public Context context() {
+      return null;
+    }
+
+    @Override
+    public void close() {
+      closed = true;
+    }
+  }
+
+  @Test
+  void staticCloseToleratesNullScope() {
+    assertDoesNotThrow(() -> ContextScope.close(null));
+  }
+
+  @Test
+  void staticCloseClosesNonNullScope() {
+    RecordingScope scope = new RecordingScope();
+    ContextScope.close(scope);
+    assertTrue(scope.closed);
+  }
+}


### PR DESCRIPTION
# What Does This Do

Adds a static, null-safe `ContextScope.close(ContextScope scope)` helper that no-ops on `null` instead of throwing.

# Motivation

While fixing #12375 (a `NullPointerException` in Tomcat's `CoyoteAdapter` advice), I found the underlying shape of that bug is a widespread, copy-pasted pattern across instrumentation advice:

- An `@Advice.OnMethodEnter(suppress = Throwable.class)` method attaches a `ContextScope` (or the older `AgentScope`) and assigns it to an `@Advice.Local`/`@Advice.Enter` variable, but the attach happens after other code that can throw (a decorator call, a request-attribute lookup, etc).
- If that enter-advice throws, the exception is silently swallowed by ByteBuddy's suppression bytecode, the instrumented method proceeds to run normally, and the local is left `null`.
- The paired `@Advice.OnMethodExit` then calls `.close()` on that (still-null) local unconditionally, producing a *second*, masking `NullPointerException` that's also swallowed and logged, hiding the real root cause entirely.

A repo-wide search turned up **40+ advice classes across 25+ instrumented libraries** with this exact unguarded shape — including all 5 Jetty server versions, Spring MVC's `RenderAdvice`, Spring WebFlux's `DispatcherHandlerAdvice`, and the generic `@Trace`/OpenTelemetry `@WithSpan` annotation advice used across user-code method tracing. Some advice classes already null-check correctly (Undertow, Servlet, gRPC, Play, Liberty, and — inconsistently — some sibling advice classes in the very same files as the unguarded ones), so this isn't a case of the pattern being unknown, just inconsistently applied.

# Additional Notes

This PR only adds the shared helper, as a starting point for discussion — it does **not** sweep the 40+ call sites yet. That's intentionally left for follow-up PRs (either a phased sweep, or converting sites opportunistically as they're touched) pending team input on the right rollout approach.

`ContextScope` lives in `components/context`, a low-level module shared across the whole tracer, so this fix (and any future call-site conversions) benefits every instrumentation, not just one.

# Contributor Checklist

- [x] Add an entry in `docs/release_notes.md` if this change affects the user-facing functionality. — N/A, internal helper, not yet adopted anywhere.
- [x] Verify code coverage of new lines
- [x] Confirm this change does not add flakiness in tests

Jira ticket: [PROJ-IDENT]
