### PR TITLE
Support using GlobalObjectStore for non-field-injected contexts

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStore.java
@@ -1,5 +1,7 @@
 package datadog.trace.bootstrap;
 
+import java.util.function.Function;
+
 /**
  * {@link ContextStore} that attempts to store context in its keys by using bytecode-injected
  * fields. Delegates to a lazy {@link WeakMap} for keys that don't have a field for this store.
@@ -50,7 +52,7 @@ public final class FieldBackedContextStore implements ContextStore<Object, Objec
   }
 
   @Override
-  public Object getOrCompute(Object key, KeyAwareFactory<? super Object, Object> contextFactory) {
+  public Object getOrCompute(Object key, Function<? super Object, Object> contextFactory) {
     if (key instanceof FieldBackedContextAccessor) {
       final FieldBackedContextAccessor accessor = (FieldBackedContextAccessor) key;
       Object existingContext = accessor.$get$__datadogContext$(storeId);
@@ -58,7 +60,7 @@ public final class FieldBackedContextStore implements ContextStore<Object, Objec
         synchronized (accessor) {
           existingContext = accessor.$get$__datadogContext$(storeId);
           if (null == existingContext) {
-            existingContext = contextFactory.create(key);
+            existingContext = contextFactory.apply(key);
             accessor.$put$__datadogContext$(storeId, existingContext);
           }
         }

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/FieldBackedContextStore.java
@@ -1,5 +1,7 @@
 package datadog.trace.bootstrap;
 
+import datadog.instrument.fieldinject.GlobalObjectStore;
+import datadog.trace.api.InstrumenterConfig;
 import java.util.function.Function;
 
 /**
@@ -7,6 +9,9 @@ import java.util.function.Function;
  * fields. Delegates to a lazy {@link WeakMap} for keys that don't have a field for this store.
  */
 public final class FieldBackedContextStore implements ContextStore<Object, Object> {
+  private static final boolean MAP_PER_STORE =
+      InstrumenterConfig.get().isRuntimeContextMapPerStore();
+
   final int storeId;
 
   FieldBackedContextStore(final int storeId) {
@@ -17,8 +22,10 @@ public final class FieldBackedContextStore implements ContextStore<Object, Objec
   public Object get(final Object key) {
     if (key instanceof FieldBackedContextAccessor) {
       return ((FieldBackedContextAccessor) key).$get$__datadogContext$(storeId);
-    } else {
+    } else if (MAP_PER_STORE) {
       return weakStore().get(key);
+    } else {
+      return GlobalObjectStore.get(key, storeId);
     }
   }
 
@@ -26,8 +33,10 @@ public final class FieldBackedContextStore implements ContextStore<Object, Objec
   public void put(final Object key, final Object context) {
     if (key instanceof FieldBackedContextAccessor) {
       ((FieldBackedContextAccessor) key).$put$__datadogContext$(storeId, context);
-    } else {
+    } else if (MAP_PER_STORE) {
       weakStore().put(key, context);
+    } else {
+      GlobalObjectStore.put(key, storeId, context);
     }
   }
 
@@ -46,8 +55,10 @@ public final class FieldBackedContextStore implements ContextStore<Object, Objec
         }
       }
       return existingContext;
-    } else {
+    } else if (MAP_PER_STORE) {
       return weakStore().getOrPut(key, context);
+    } else {
+      return GlobalObjectStore.getOrPut(key, storeId, context);
     }
   }
 
@@ -66,8 +77,10 @@ public final class FieldBackedContextStore implements ContextStore<Object, Objec
         }
       }
       return existingContext;
-    } else {
+    } else if (MAP_PER_STORE) {
       return weakStore().getOrCompute(key, contextFactory);
+    } else {
+      return GlobalObjectStore.getOrCompute(key, storeId, contextFactory);
     }
   }
 
@@ -85,8 +98,10 @@ public final class FieldBackedContextStore implements ContextStore<Object, Objec
         }
       }
       return existingContext;
-    } else {
+    } else if (MAP_PER_STORE) {
       return weakStore().remove(key);
+    } else {
+      return GlobalObjectStore.remove(key, storeId);
     }
   }
 

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMapPerStore.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/WeakMapPerStore.java
@@ -3,7 +3,7 @@ package datadog.trace.bootstrap;
 import static datadog.trace.bootstrap.FieldBackedContextStores.getContextStore;
 
 import datadog.trace.api.internal.VisibleForTesting;
-import datadog.trace.bootstrap.ContextStore.KeyAwareFactory;
+import java.util.function.Function;
 
 /**
  * Weak "map-per-store" fall-back to track contexts when field-injection isn't possible.
@@ -59,7 +59,7 @@ public final class WeakMapPerStore<K, V> {
     return existingContext;
   }
 
-  V getOrCompute(K key, KeyAwareFactory<? super K, V> contextFactory) {
+  V getOrCompute(K key, Function<? super K, V> contextFactory) {
     V existingContext = get(key);
     if (null == existingContext) {
       // This whole part with using synchronized is only because
@@ -71,7 +71,7 @@ public final class WeakMapPerStore<K, V> {
       synchronized (map) {
         existingContext = get(key);
         if (null == existingContext) {
-          existingContext = contextFactory.create(key);
+          existingContext = contextFactory.apply(key);
           put(key, existingContext);
         }
       }

--- a/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/utils/StrongMapContextStore.java
+++ b/dd-java-agent/agent-ci-visibility/src/main/java/datadog/trace/civisibility/utils/StrongMapContextStore.java
@@ -3,6 +3,7 @@ package datadog.trace.civisibility.utils;
 import datadog.trace.bootstrap.ContextStore;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
 
 /** Substitute {@link ContextStore} that uses strong-references to track contexts. */
 public class StrongMapContextStore<K, C> implements ContextStore<K, C> {
@@ -25,8 +26,8 @@ public class StrongMapContextStore<K, C> implements ContextStore<K, C> {
   }
 
   @Override
-  public C getOrCompute(K key, KeyAwareFactory<? super K, C> contextFactory) {
-    return map.computeIfAbsent(key, contextFactory::create);
+  public C getOrCompute(K key, Function<? super K, C> contextFactory) {
+    return map.computeIfAbsent(key, contextFactory);
   }
 
   @Override

--- a/dd-java-agent/agent-installer/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
+++ b/dd-java-agent/agent-installer/src/main/java/datadog/trace/agent/tooling/AgentInstaller.java
@@ -6,6 +6,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.GlobalIgnoresMatcher
 import static net.bytebuddy.matcher.ElementMatchers.isDefaultFinalizer;
 
 import datadog.environment.SystemProperties;
+import datadog.instrument.fieldinject.GlobalObjectStore;
 import datadog.trace.agent.tooling.bytebuddy.SharedTypePools;
 import datadog.trace.agent.tooling.bytebuddy.iast.TaintableRedefinitionStrategyListener;
 import datadog.trace.agent.tooling.bytebuddy.matcher.DDElementMatchers;
@@ -54,6 +55,8 @@ public class AgentInstaller {
 
   private static final List<Runnable> LOG_MANAGER_CALLBACKS = new CopyOnWriteArrayList<>();
   private static final List<Runnable> MBEAN_SERVER_BUILDER_CALLBACKS = new CopyOnWriteArrayList<>();
+
+  private static final long GLOBAL_OBJECT_STORE_CLEAN_FREQUENCY_SECONDS = 1;
 
   static {
     enableByteBuddyRawTypes();
@@ -249,6 +252,15 @@ public class AgentInstaller {
               IntegrationsCollector.get().update(instrumentationNames, true);
             }
           });
+    }
+
+    if (!InstrumenterConfig.get().isRuntimeContextMapPerStore()) {
+      AgentTaskScheduler.get()
+          .scheduleAtFixedRate(
+              GlobalObjectStore::removeStaleEntries,
+              GLOBAL_OBJECT_STORE_CLEAN_FREQUENCY_SECONDS,
+              GLOBAL_OBJECT_STORE_CLEAN_FREQUENCY_SECONDS,
+              TimeUnit.SECONDS);
     }
 
     InstrumenterState.resetDefaultState();

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextInjector.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/context/FieldBackedContextInjector.java
@@ -3,6 +3,7 @@ package datadog.trace.agent.tooling.context;
 import static datadog.trace.bootstrap.FieldBackedContextStores.getContextStoreId;
 import static datadog.trace.util.Strings.getInternalName;
 
+import datadog.instrument.fieldinject.GlobalObjectStore;
 import datadog.trace.agent.tooling.bytebuddy.memoize.MemoizedMatchers;
 import datadog.trace.api.InstrumenterConfig;
 import datadog.trace.api.Pair;
@@ -48,7 +49,12 @@ public final class FieldBackedContextInjector implements AsmVisitorWrapper {
   static final String PUTTER_METHOD_DESCRIPTOR =
       Type.getMethodDescriptor(Type.VOID_TYPE, Type.INT_TYPE, Type.getType(Object.class));
 
-  static final String WEAK_REDIRECT_CLASS = getInternalName(WeakMapPerStore.class.getName());
+  static final String WEAK_REDIRECT_CLASS =
+      getInternalName(
+          (InstrumenterConfig.get().isRuntimeContextMapPerStore()
+                  ? WeakMapPerStore.class
+                  : GlobalObjectStore.class)
+              .getName());
 
   static final String WEAK_GET_METHOD_DESCRIPTOR =
       Type.getMethodDescriptor(

--- a/dd-java-agent/instrumentation/graal/graal-native-image-20.0/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/graal-native-image-20.0/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
@@ -124,7 +124,6 @@ public final class NativeImageGeneratorRunnerInstrumentation
               + "datadog.trace.bootstrap.CallDepthThreadLocalMap:build_time,"
               + "datadog.trace.bootstrap.CallDepthThreadLocalMap$ThreadLocalDepth:build_time,"
               + "datadog.trace.bootstrap.ContextStore$Factory:build_time,"
-              + "datadog.trace.bootstrap.ContextStore$KeyAwareFactory:build_time,"
               + "datadog.trace.bootstrap.DatadogClassLoader:build_time,"
               + "datadog.trace.bootstrap.InstrumentationClassLoader:build_time,"
               + "datadog.trace.bootstrap.FieldBackedContextStores:build_time,"

--- a/dd-java-agent/instrumentation/graal/graal-native-image-20.0/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
+++ b/dd-java-agent/instrumentation/graal/graal-native-image-20.0/src/main/java/datadog/trace/instrumentation/graal/nativeimage/NativeImageGeneratorRunnerInstrumentation.java
@@ -175,6 +175,8 @@ public final class NativeImageGeneratorRunnerInstrumentation
               + "datadog.slf4j.helpers.SubstituteLoggerFactory:build_time,"
               + "datadog.slf4j.impl.StaticLoggerBinder:build_time,"
               + "datadog.slf4j.LoggerFactory:build_time,"
+              + "datadog.instrument.fieldinject.GlobalObjectStore:build_time,"
+              + "datadog.instrument.fieldinject.GlobalObjectStore$LookupKey:build_time,"
               + "com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap:build_time,"
               + "com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap$1:build_time,"
               + "net.bytebuddy:build_time,"

--- a/dd-java-agent/instrumentation/reactive-streams-1.0/src/test/java/datadog/trace/instrumentation/reactivestreams/ReactiveStreamsContextPropagationTest.java
+++ b/dd-java-agent/instrumentation/reactive-streams-1.0/src/test/java/datadog/trace/instrumentation/reactivestreams/ReactiveStreamsContextPropagationTest.java
@@ -11,6 +11,7 @@ import datadog.trace.bootstrap.ContextStore;
 import datadog.trace.bootstrap.instrumentation.reactivestreams.HandoffContext;
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -176,23 +177,13 @@ class ReactiveStreamsContextPropagationTest {
 
     @Override
     public C getOrPut(final K key, final C context) {
-      final C existing = map.get(key);
-      if (existing != null) {
-        return existing;
-      }
-      map.put(key, context);
-      return context;
+      final C existing = map.putIfAbsent(key, context);
+      return existing != null ? existing : context;
     }
 
     @Override
-    public C getOrCompute(final K key, final KeyAwareFactory<? super K, C> contextFactory) {
-      final C existing = map.get(key);
-      if (existing != null) {
-        return existing;
-      }
-      final C created = contextFactory.create(key);
-      map.put(key, created);
-      return created;
+    public C getOrCompute(final K key, final Function<? super K, C> contextFactory) {
+      return map.computeIfAbsent(key, contextFactory);
     }
 
     @Override

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -60,6 +60,7 @@ public final class ConfigDefaults {
 
   static final boolean DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION = true;
   static final boolean DEFAULT_SERIALVERSIONUID_FIELD_INJECTION = true;
+  static final boolean DEFAULT_RUNTIME_CONTEXT_MAP_PER_STORE = true;
 
   static final boolean DEFAULT_EXPERIMENTATAL_JEE_SPLIT_BY_DEPLOYMENT = false;
   static final boolean DEFAULT_PRIORITY_SAMPLING_ENABLED = true;

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/TraceInstrumentationConfig.java
@@ -99,6 +99,7 @@ public final class TraceInstrumentationConfig {
       "trace.runtime.context.field.injection";
   public static final String SERIALVERSIONUID_FIELD_INJECTION =
       "trace.serialversionuid.field.injection";
+  public static final String RUNTIME_CONTEXT_MAP_PER_STORE = "trace.runtime.context.map-per-store";
 
   public static final String LOGS_INJECTION_ENABLED = "logs.injection.enabled";
   public static final String LOGS_INJECTION = "logs.injection";

--- a/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
+++ b/internal-api/src/main/java/datadog/trace/api/InstrumenterConfig.java
@@ -17,6 +17,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_METRICS_OTEL_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_RESOLVER_RESET_INTERVAL;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_RUM_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_RUNTIME_CONTEXT_MAP_PER_STORE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_SERIALVERSIONUID_FIELD_INJECTION;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TELEMETRY_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_ANNOTATIONS;
@@ -76,6 +77,7 @@ import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_SIMPL
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_USE_LOADCLASS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RESOLVER_USE_URL_CACHES;
 import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEXT_FIELD_INJECTION;
+import static datadog.trace.api.config.TraceInstrumentationConfig.RUNTIME_CONTEXT_MAP_PER_STORE;
 import static datadog.trace.api.config.TraceInstrumentationConfig.SERIALVERSIONUID_FIELD_INJECTION;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ANNOTATIONS;
 import static datadog.trace.api.config.TraceInstrumentationConfig.TRACE_ANNOTATION_ASYNC;
@@ -208,6 +210,7 @@ public class InstrumenterConfig {
 
   private final boolean runtimeContextFieldInjection;
   private final boolean serialVersionUIDFieldInjection;
+  private final boolean runtimeContextMapPerStore;
 
   private final String traceAnnotations;
   private final boolean traceAnnotationAsync;
@@ -355,6 +358,9 @@ public class InstrumenterConfig {
     serialVersionUIDFieldInjection =
         configProvider.getBoolean(
             SERIALVERSIONUID_FIELD_INJECTION, DEFAULT_SERIALVERSIONUID_FIELD_INJECTION);
+    runtimeContextMapPerStore =
+        configProvider.getBoolean(
+            RUNTIME_CONTEXT_MAP_PER_STORE, DEFAULT_RUNTIME_CONTEXT_MAP_PER_STORE);
 
     instrumentationConfigId = configProvider.getString(INSTRUMENTATION_CONFIG_ID, "");
 
@@ -657,6 +663,10 @@ public class InstrumenterConfig {
     return serialVersionUIDFieldInjection;
   }
 
+  public boolean isRuntimeContextMapPerStore() {
+    return runtimeContextMapPerStore;
+  }
+
   public String getTraceAnnotations() {
     return traceAnnotations;
   }
@@ -835,6 +845,8 @@ public class InstrumenterConfig {
         + runtimeContextFieldInjection
         + ", serialVersionUIDFieldInjection="
         + serialVersionUIDFieldInjection
+        + ", runtimeContextMapPerStore="
+        + runtimeContextMapPerStore
         + ", codeOriginEnabled="
         + codeOriginEnabled
         + ", traceAnnotations='"

--- a/internal-api/src/main/java/datadog/trace/bootstrap/ContextStore.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/ContextStore.java
@@ -1,5 +1,6 @@
 package datadog.trace.bootstrap;
 
+import java.util.function.Function;
 import javax.annotation.Nullable;
 
 /**
@@ -18,30 +19,16 @@ public interface ContextStore<K, C> {
    *
    * @param <C> context type
    */
-  interface Factory<C> extends KeyAwareFactory<Object, C> {
+  interface Factory<C> extends Function<Object, C> {
 
     /**
      * @return new context instance
      */
     C create();
 
-    default C create(Object key) {
+    default C apply(Object key) {
       return create();
     }
-  }
-
-  /**
-   * Factory interface to create context instances using context key instances
-   *
-   * @param <K> context key type
-   * @param <C> context value type
-   */
-  interface KeyAwareFactory<K, C> {
-
-    /**
-     * @return new context instance
-     */
-    C create(K key);
   }
 
   /**
@@ -91,7 +78,7 @@ public interface ContextStore<K, C> {
    * @param contextFactory factory instance to produce new context instances
    * @return existing context instance if present; otherwise new instance
    */
-  C getOrCompute(K key, KeyAwareFactory<? super K, C> contextFactory);
+  C getOrCompute(K key, Function<? super K, C> contextFactory);
 
   /**
    * Removes the context instance for the given key.

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -9780,6 +9780,14 @@
         "aliases": []
       }
     ],
+    "DD_TRACE_RUNTIME_CONTEXT_MAP_PER_STORE": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "true",
+        "aliases": []
+      }
+    ],
     "DD_TRACE_RXJAVA_ENABLED": [
       {
         "version": "A",


### PR DESCRIPTION
# What Does This Do

Adds a feature-flag to support switching non-field-injected `InstrumentationContext` from using a `WeakMap` per-store to instead use the shared `GlobalObjectStore` from [dd-instrument-java](https://github.com/DataDog/dd-instrument-java).

The default value of this feature-flag is `true`, in other words the historical behaviour of using a map-per-store:

To switch to `GlobalObjectStore` set the following environment variable:
```
DD_TRACE_RUNTIME_CONTEXT_MAP_PER_STORE=false
```
or add this JVM option:
```
-Ddd.trace.runtime.context.map-per-store=false
```

# Motivation

The `GlobalObjectStore` approach scales better for deployments using a lot of non-field-injected instrumentation context where periodic cleanup / GC cannot keep up. For example on AOT where we cannot field-inject classes linked at training time. See https://github.com/DataDog/dd-trace-java/issues/10479 for more details.

`GlobalObjectStore` uses a generational approach to evict old content, keeping the store bounded while still allowing tracking of recent instrumentation contexts. Whereas the map-per-store approach immediately drops new content if the store reaches capacity, and this causes async propagation issues on AOT until GC finally kicks in.

Since the generational strategy is relatively new, the idea is to roll this out incrementally as we complete further benchmarking of various real-world applications.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
