### PR TITLE
Migrate TracerHealthMetrics onto the Accumulator primitive (perf toolbox adoption)

### DIFF
--- a/dd-trace-core/src/jmh/java/datadog/trace/core/monitor/LegacyTracerHealthMetrics.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/monitor/LegacyTracerHealthMetrics.java
@@ -1,0 +1,264 @@
+package datadog.trace.core.monitor;
+
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP;
+import static datadog.trace.api.sampling.PrioritySampling.USER_DROP;
+import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP;
+
+import datadog.metrics.api.statsd.StatsDClient;
+import datadog.trace.common.writer.RemoteApi;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * A faithful reconstruction of the pre-{@code Accumulator} {@code TracerHealthMetrics} -- one
+ * {@link LongAdder} field per counter, hand-rolled switch statements, a hand-concatenated {@code
+ * summary()} -- as it stood at {@code 77964b3996} (the last commit on {@code master} before the
+ * migration), restricted to the exact methods {@link TracerHealthMetricsBenchmark} exercises. Kept
+ * as a standalone class here (not resurrected via checkout) purely for a same-run, same-JVM
+ * before/after comparison; it is not wired into anything and should never be.
+ */
+class LegacyTracerHealthMetrics {
+
+  private final LongAdder apiRequests = new LongAdder();
+  private final LongAdder apiErrors = new LongAdder();
+  private final LongAdder apiResponsesOK = new LongAdder();
+
+  private final LongAdder userDropEnqueuedTraces = new LongAdder();
+  private final LongAdder userKeepEnqueuedTraces = new LongAdder();
+  private final LongAdder samplerDropEnqueuedTraces = new LongAdder();
+  private final LongAdder samplerKeepEnqueuedTraces = new LongAdder();
+  private final LongAdder unsetPriorityEnqueuedTraces = new LongAdder();
+
+  private final LongAdder userDropDroppedTraces = new LongAdder();
+  private final LongAdder userKeepDroppedTraces = new LongAdder();
+  private final LongAdder samplerDropDroppedTraces = new LongAdder();
+  private final LongAdder samplerKeepDroppedTraces = new LongAdder();
+  private final LongAdder serialFailedDroppedTraces = new LongAdder();
+  private final LongAdder unsetPriorityDroppedTraces = new LongAdder();
+
+  private final LongAdder userDropDroppedSpans = new LongAdder();
+  private final LongAdder userKeepDroppedSpans = new LongAdder();
+  private final LongAdder samplerDropDroppedSpans = new LongAdder();
+  private final LongAdder samplerKeepDroppedSpans = new LongAdder();
+  private final LongAdder serialFailedDroppedSpans = new LongAdder();
+  private final LongAdder unsetPriorityDroppedSpans = new LongAdder();
+
+  private final LongAdder enqueuedSpans = new LongAdder();
+  private final LongAdder enqueuedBytes = new LongAdder();
+  private final LongAdder createdTraces = new LongAdder();
+  private final LongAdder createdSpans = new LongAdder();
+  private final LongAdder finishedSpans = new LongAdder();
+  private final LongAdder flushedTraces = new LongAdder();
+  private final LongAdder flushedBytes = new LongAdder();
+  private final LongAdder partialTraces = new LongAdder();
+  private final LongAdder partialBytes = new LongAdder();
+  private final LongAdder clientSpansWithoutContext = new LongAdder();
+
+  private final LongAdder singleSpanSampled = new LongAdder();
+  private final LongAdder singleSpanUnsampled = new LongAdder();
+
+  private final LongAdder capturedContinuations = new LongAdder();
+  private final LongAdder cancelledContinuations = new LongAdder();
+  private final LongAdder finishedContinuations = new LongAdder();
+
+  private final LongAdder activatedScopes = new LongAdder();
+  private final LongAdder closedScopes = new LongAdder();
+  private final LongAdder scopeStackOverflow = new LongAdder();
+  private final LongAdder scopeCloseErrors = new LongAdder();
+  private final LongAdder userScopeCloseErrors = new LongAdder();
+
+  private final LongAdder longRunningTracesWrite = new LongAdder();
+  private final LongAdder longRunningTracesDropped = new LongAdder();
+  private final LongAdder longRunningTracesExpired = new LongAdder();
+
+  private final LongAdder clientStatsProcessedSpans = new LongAdder();
+  private final LongAdder clientStatsProcessedTraces = new LongAdder();
+  private final LongAdder clientStatsP0DroppedSpans = new LongAdder();
+  private final LongAdder clientStatsP0DroppedTraces = new LongAdder();
+  private final LongAdder clientStatsRequests = new LongAdder();
+  private final LongAdder clientStatsErrors = new LongAdder();
+  private final LongAdder clientStatsDowngrades = new LongAdder();
+
+  private final LongAdder statsAggregateDropped = new LongAdder();
+  private final LongAdder statsInboxFull = new LongAdder();
+
+  private final StatsDClient statsd;
+
+  LegacyTracerHealthMetrics(StatsDClient statsd) {
+    this.statsd = statsd;
+  }
+
+  void onCreateSpan() {
+    createdSpans.increment();
+  }
+
+  void onFailedPublish(final int samplingPriority, final int spanCount) {
+    switch (samplingPriority) {
+      case USER_DROP:
+        userDropDroppedSpans.add(spanCount);
+        userDropDroppedTraces.increment();
+        break;
+      case USER_KEEP:
+        userKeepDroppedSpans.add(spanCount);
+        userKeepDroppedTraces.increment();
+        break;
+      case SAMPLER_DROP:
+        samplerDropDroppedSpans.add(spanCount);
+        samplerDropDroppedTraces.increment();
+        break;
+      case SAMPLER_KEEP:
+        samplerKeepDroppedSpans.add(spanCount);
+        samplerKeepDroppedTraces.increment();
+        break;
+      default:
+        unsetPriorityDroppedSpans.add(spanCount);
+        unsetPriorityDroppedTraces.increment();
+    }
+  }
+
+  void onPartialPublish(final int numberOfDroppedSpans) {
+    partialTraces.increment();
+    samplerDropDroppedSpans.add(numberOfDroppedSpans);
+  }
+
+  void onSend(final int traceCount, final int sizeInBytes, final RemoteApi.Response response) {
+    onSendAttempt(traceCount, sizeInBytes, response);
+  }
+
+  private void onSendAttempt(
+      final int traceCount, final int sizeInBytes, final RemoteApi.Response response) {
+    apiRequests.increment();
+    flushedTraces.add(traceCount);
+    flushedBytes.add(sizeInBytes);
+
+    if (response.exception().isPresent()) {
+      apiErrors.increment();
+    }
+
+    int status = response.status().orElse(0);
+    if (status != 0) {
+      if (200 == status) {
+        apiResponsesOK.increment();
+      } else {
+        statsd.incrementCounter("api.responses.total", "status:" + status);
+      }
+    }
+  }
+
+  String summary() {
+    return "apiRequests="
+        + apiRequests.sum()
+        + "\napiErrors="
+        + apiErrors.sum()
+        + "\napiResponsesOK="
+        + apiResponsesOK.sum()
+        + "\n"
+        + "\nuserDropEnqueuedTraces="
+        + userDropEnqueuedTraces.sum()
+        + "\nuserKeepEnqueuedTraces="
+        + userKeepEnqueuedTraces.sum()
+        + "\nsamplerDropEnqueuedTraces="
+        + samplerDropEnqueuedTraces.sum()
+        + "\nsamplerKeepEnqueuedTraces="
+        + samplerKeepEnqueuedTraces.sum()
+        + "\nunsetPriorityEnqueuedTraces="
+        + unsetPriorityEnqueuedTraces.sum()
+        + "\n"
+        + "\nuserDropDroppedTraces="
+        + userDropDroppedTraces.sum()
+        + "\nuserKeepDroppedTraces="
+        + userKeepDroppedTraces.sum()
+        + "\nsamplerDropDroppedTraces="
+        + samplerDropDroppedTraces.sum()
+        + "\nsamplerKeepDroppedTraces="
+        + samplerKeepDroppedTraces.sum()
+        + "\nserialFailedDroppedTraces="
+        + serialFailedDroppedTraces.sum()
+        + "\nunsetPriorityDroppedTraces="
+        + unsetPriorityDroppedTraces.sum()
+        + "\n"
+        + "\nuserDropDroppedSpans="
+        + userDropDroppedSpans.sum()
+        + "\nuserKeepDroppedSpans="
+        + userKeepDroppedSpans.sum()
+        + "\nsamplerDropDroppedSpans="
+        + samplerDropDroppedSpans.sum()
+        + "\nsamplerKeepDroppedSpans="
+        + samplerKeepDroppedSpans.sum()
+        + "\nserialFailedDroppedSpans="
+        + serialFailedDroppedSpans.sum()
+        + "\nunsetPriorityDroppedSpans="
+        + unsetPriorityDroppedSpans.sum()
+        + "\n"
+        + "\nenqueuedSpans="
+        + enqueuedSpans.sum()
+        + "\nenqueuedBytes="
+        + enqueuedBytes.sum()
+        + "\ncreatedTraces="
+        + createdTraces.sum()
+        + "\ncreatedSpans="
+        + createdSpans.sum()
+        + "\nfinishedSpans="
+        + finishedSpans.sum()
+        + "\nflushedTraces="
+        + flushedTraces.sum()
+        + "\nflushedBytes="
+        + flushedBytes.sum()
+        + "\npartialTraces="
+        + partialTraces.sum()
+        + "\npartialBytes="
+        + partialBytes.sum()
+        + "\n"
+        + "\nclientSpansWithoutContext="
+        + clientSpansWithoutContext.sum()
+        + "\n"
+        + "\nsingleSpanSampled="
+        + singleSpanSampled.sum()
+        + "\nsingleSpanUnsampled="
+        + singleSpanUnsampled.sum()
+        + "\n"
+        + "\ncapturedContinuations="
+        + capturedContinuations.sum()
+        + "\ncancelledContinuations="
+        + cancelledContinuations.sum()
+        + "\nfinishedContinuations="
+        + finishedContinuations.sum()
+        + "\n"
+        + "\nactivatedScopes="
+        + activatedScopes.sum()
+        + "\nclosedScopes="
+        + closedScopes.sum()
+        + "\nscopeStackOverflow="
+        + scopeStackOverflow.sum()
+        + "\nscopeCloseErrors="
+        + scopeCloseErrors.sum()
+        + "\nuserScopeCloseErrors="
+        + userScopeCloseErrors.sum()
+        + "\n"
+        + "\nlongRunningTracesWrite="
+        + longRunningTracesWrite.sum()
+        + "\nlongRunningTracesDropped="
+        + longRunningTracesDropped.sum()
+        + "\nlongRunningTracesExpired="
+        + longRunningTracesExpired.sum()
+        + "\n"
+        + "\nclientStatsRequests="
+        + clientStatsRequests.sum()
+        + "\nclientStatsErrors="
+        + clientStatsErrors.sum()
+        + "\nclientStatsDowngrades="
+        + clientStatsDowngrades.sum()
+        + "\nclientStatsP0DroppedSpans="
+        + clientStatsP0DroppedSpans.sum()
+        + "\nclientStatsP0DroppedTraces="
+        + clientStatsP0DroppedTraces.sum()
+        + "\nclientStatsProcessedSpans="
+        + clientStatsProcessedSpans.sum()
+        + "\nclientStatsProcessedTraces="
+        + clientStatsProcessedTraces.sum()
+        + "\nstatsAggregateDropped="
+        + statsAggregateDropped.sum()
+        + "\nstatsInboxFull="
+        + statsInboxFull.sum();
+  }
+}

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/monitor/TracerHealthMetricsBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/monitor/TracerHealthMetricsBenchmark.java
@@ -55,23 +55,21 @@ import org.openjdk.jmh.infra.Blackhole;
  * {@code synchronized}-stripe contention penalty the earlier design did. {@code
  * summaryWhileWriting} confirms the peek-not-drain design for {@code summary()}: concurrent readers
  * don't measurably slow writers (0.008 us/op, same as uncontended {@code onCreateSpan}), at the
- * cost of the read itself walking all 54 stripes non-destructively (~1.83 us/op) -- acceptable for
- * a diagnostic/tracer-flare call, never on the span-emission path. Results are stable across JDK 17
- * and JDK 25 (point estimates agree to the millisecond-precision printed below), confirming this is
- * the striping rewrite's effect, not a JIT/JVM-version artifact. <code>
- * Apple M1 Max, 10 CPUs - macOS/aarch64 - JDK 17 (Zulu) / JDK 25 (Zulu)
- * Benchmark                                                JDK17  JDK25  Units
- * TracerHealthMetricsBenchmark.onCreateSpan_lowContention   0.007  0.007  us/op
- * TracerHealthMetricsBenchmark.onCreateSpan_highContention  0.009  0.009  us/op
- * TracerHealthMetricsBenchmark.onFailedPublish_lowContention   0.007  0.007  us/op
- * TracerHealthMetricsBenchmark.onFailedPublish_highContention  0.010  0.010  us/op
- * TracerHealthMetricsBenchmark.onPartialPublish_lowContention  0.007  0.007  us/op
- * TracerHealthMetricsBenchmark.onPartialPublish_highContention 0.009  0.010  us/op
- * TracerHealthMetricsBenchmark.onSend_lowContention         0.009  0.009  us/op
- * TracerHealthMetricsBenchmark.onSend_highContention        0.013  0.013  us/op
- * TracerHealthMetricsBenchmark.summaryWhileWriting                0.373  0.373  us/op
- * TracerHealthMetricsBenchmark.summaryWhileWriting:...write        0.008  0.008  us/op
- * TracerHealthMetricsBenchmark.summaryWhileWriting:...read         1.835  1.833  us/op
+ * cost of the read itself walking all 54 stripes non-destructively (~1.9 us/op) -- acceptable for a
+ * diagnostic/tracer-flare call, never on the span-emission path. <code>
+ * Apple M1 Max, 10 CPUs - macOS/aarch64 - JDK 25 (Zulu)
+ * Benchmark                                                Score  Units
+ * TracerHealthMetricsBenchmark.onCreateSpan_lowContention   0.007  us/op
+ * TracerHealthMetricsBenchmark.onCreateSpan_highContention  0.009  us/op
+ * TracerHealthMetricsBenchmark.onFailedPublish_lowContention   0.007  us/op
+ * TracerHealthMetricsBenchmark.onFailedPublish_highContention  0.010  us/op
+ * TracerHealthMetricsBenchmark.onPartialPublish_lowContention  0.007  us/op
+ * TracerHealthMetricsBenchmark.onPartialPublish_highContention 0.009  us/op
+ * TracerHealthMetricsBenchmark.onSend_lowContention         0.009  us/op
+ * TracerHealthMetricsBenchmark.onSend_highContention        0.013  us/op
+ * TracerHealthMetricsBenchmark.summaryWhileWriting                0.386  us/op
+ * TracerHealthMetricsBenchmark.summaryWhileWriting:...write        0.008  us/op
+ * TracerHealthMetricsBenchmark.summaryWhileWriting:...read         1.899  us/op
  * </code>
  *
  * <p><b>Before/after results.</b> The {@code Accumulator}-backed implementation is now at parity
@@ -79,25 +77,25 @@ import org.openjdk.jmh.infra.Blackhole;
  * single-call-site benchmark, including under {@code Threads.MAX} contention -- a reversal of the
  * earlier {@code synchronized}-stripe design's 1.1-4.6x cost documented before the lock-free
  * rewrite (commit {@code 3ea84793d1}). {@code onSend}, the most expensive real call site (three
- * top-level calls plus one two-counter grouped update), now costs 0.6-0.75x of legacy at both
- * contention levels. {@code summary()} remains the one real cost: walking 54 stripes
- * non-destructively still costs ~2.5-2.6x what summing 52 plain {@code LongAdder} fields does
- * (~1.83 vs ~0.71 us/op) -- still far below the periodic (30s-default) {@code Flush} cadence and
- * the ad hoc/diagnostic calls that trigger it, so not disqualifying. Neither implementation's
- * writers are measurably slowed by a concurrent {@code summary()}/reader. <code>
- * Apple M1 Max, 10 CPUs - macOS/aarch64 - JDK 17 (Zulu) / JDK 25 (Zulu)
- * Benchmark                       New (JDK17/25)  Legacy (JDK17/25)  Ratio
- * onCreateSpan_lowContention        0.007 / 0.007    0.007 / 0.007    1.0x / 1.0x
- * onCreateSpan_highContention       0.009 / 0.009    0.010 / 0.010    0.9x / 0.9x
- * onFailedPublish_lowContention     0.007 / 0.007    0.008 / 0.008    0.9x / 0.9x
- * onFailedPublish_highContention    0.010 / 0.010    0.011 / 0.012    0.9x / 0.8x
- * onPartialPublish_lowContention    0.007 / 0.007    0.008 / 0.008    0.9x / 0.9x
- * onPartialPublish_highContention   0.009 / 0.010    0.012 / 0.012    0.75x / 0.8x
- * onSend_lowContention              0.009 / 0.009    0.012 / 0.013    0.75x / 0.7x
- * onSend_highContention             0.013 / 0.013    0.020 / 0.022    0.65x / 0.6x
- * summaryWhileWriting_write         0.008 / 0.008    0.009 / 0.008    0.9x / 1.0x
- * summaryWhileWriting_read          1.835 / 1.833    0.705 / 0.720    2.6x / 2.55x
- * (all figures us/op, avgt; JDK17 / JDK25)
+ * top-level calls plus one two-counter grouped update), now costs 0.6-0.7x of legacy. {@code
+ * summary()} remains the one real cost: walking 54 stripes non-destructively still costs ~2.6x what
+ * summing 52 plain {@code LongAdder} fields does (~1.9 vs ~0.73 us/op) -- still far below the
+ * periodic (30s-default) {@code Flush} cadence and the ad hoc/diagnostic calls that trigger it, so
+ * not disqualifying. Neither implementation's writers are measurably slowed by a concurrent {@code
+ * summary()}/reader. <code>
+ * Apple M1 Max, 10 CPUs - macOS/aarch64 - JDK 25 (Zulu)
+ * Benchmark                       New     Legacy  Ratio
+ * onCreateSpan_lowContention        0.007    0.007    1.0x
+ * onCreateSpan_highContention       0.009    0.009    1.0x
+ * onFailedPublish_lowContention     0.007    0.008    0.9x
+ * onFailedPublish_highContention    0.010    0.012    0.8x
+ * onPartialPublish_lowContention    0.007    0.007    1.0x
+ * onPartialPublish_highContention   0.009    0.012    0.75x
+ * onSend_lowContention              0.009    0.013    0.7x
+ * onSend_highContention             0.013    0.021    0.6x
+ * summaryWhileWriting_write         0.008    0.008    1.0x
+ * summaryWhileWriting_read          1.899    0.728    2.6x
+ * (all figures us/op, avgt)
  * </code> This means the migration's case no longer rests solely on eliminating the {@code
  * previousCounts}/{@code countIndex} hand-tracking ceremony and giving each counter an atomic
  * multi-field grouped update -- the lock-free rewrite makes it a speedup too, on every path except

--- a/dd-trace-core/src/jmh/java/datadog/trace/core/monitor/TracerHealthMetricsBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/core/monitor/TracerHealthMetricsBenchmark.java
@@ -1,0 +1,242 @@
+package datadog.trace.core.monitor;
+
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+
+import datadog.metrics.api.statsd.StatsDClient;
+import datadog.trace.common.writer.RemoteApi;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.GroupThreads;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Direct measurement of the real {@link TracerHealthMetrics} entry points hit on the tracing hot
+ * path -- the {@link datadog.metrics.api.Accumulator}-backed implementation, not a synthetic
+ * stand-in -- so the {@code AccumulatorBenchmark} numbers (raw {@code Accumulator} vs {@code
+ * LongAdder}) can be checked against what the real per-call-site shapes cost once real switches,
+ * multi-counter updates, and response-as-context dispatch are involved. All calls go through {@link
+ * StatsDClient#NO_OP} so only the accumulator-side cost is measured, not statsd transport.
+ *
+ * <p>{@code onCreateSpan}/{@code onFinishSpan}/{@code onActivateScope}/{@code onCloseScope} are the
+ * highest-frequency calls (once per span/scope) and are each a single {@code inc()}. {@code
+ * onFailedPublish} exercises a switch plus two independent (ungrouped) counter updates. {@code
+ * onPartialPublish} exercises the boxing-free {@code update(long, ObjLongConsumer)} grouped-update
+ * path. {@code onSend} exercises {@code onSendAttempt}'s split shape: three top-level calls plus
+ * one {@code update(response, ...)} grouping the two response-derived counters under one lock.
+ *
+ * <p>{@code summaryWhileWriting} pairs concurrent {@code onCreateSpan} writers against a single
+ * reader repeatedly calling {@code summary()} -- {@code summary()} only peeks ({@code
+ * Accumulator#sum()}), never drains, so it should not stall the periodic {@code Flush} task nor
+ * meaningfully slow down concurrent writers; this checks that design assumption under load rather
+ * than just asserting it.
+ *
+ * <p><b>Before/after.</b> The {@code legacy*} benchmarks run the identical inputs against {@link
+ * LegacyTracerHealthMetrics}, a faithful reconstruction of pre-migration {@code
+ * TracerHealthMetrics} (one {@code LongAdder} field per counter, hand-rolled switches, a
+ * hand-concatenated {@code summary()}) as it stood at {@code 77964b3996}, the last commit before
+ * this migration -- a same-run, same-JVM before/after comparison of the real class, not just the
+ * underlying primitive.
+ *
+ * <p><b>Results.</b> After {@link datadog.metrics.api.Accumulator}'s lock-free {@code
+ * AtomicLongArray}-striping rewrite, every hot single-counter call (uncontended) lands at
+ * 0.007-0.009 us/op -- indistinguishable from {@code AccumulatorBenchmark}'s raw {@code
+ * accumulatorIncrement_lowContention} (0.007 us/op). At {@code Threads.MAX} the real call sites
+ * stay just as flat (0.009-0.013 us/op): the CAS-based {@code getAndAdd} no longer pays the 3-4x
+ * {@code synchronized}-stripe contention penalty the earlier design did. {@code
+ * summaryWhileWriting} confirms the peek-not-drain design for {@code summary()}: concurrent readers
+ * don't measurably slow writers (0.008 us/op, same as uncontended {@code onCreateSpan}), at the
+ * cost of the read itself walking all 54 stripes non-destructively (~1.83 us/op) -- acceptable for
+ * a diagnostic/tracer-flare call, never on the span-emission path. Results are stable across JDK 17
+ * and JDK 25 (point estimates agree to the millisecond-precision printed below), confirming this is
+ * the striping rewrite's effect, not a JIT/JVM-version artifact. <code>
+ * Apple M1 Max, 10 CPUs - macOS/aarch64 - JDK 17 (Zulu) / JDK 25 (Zulu)
+ * Benchmark                                                JDK17  JDK25  Units
+ * TracerHealthMetricsBenchmark.onCreateSpan_lowContention   0.007  0.007  us/op
+ * TracerHealthMetricsBenchmark.onCreateSpan_highContention  0.009  0.009  us/op
+ * TracerHealthMetricsBenchmark.onFailedPublish_lowContention   0.007  0.007  us/op
+ * TracerHealthMetricsBenchmark.onFailedPublish_highContention  0.010  0.010  us/op
+ * TracerHealthMetricsBenchmark.onPartialPublish_lowContention  0.007  0.007  us/op
+ * TracerHealthMetricsBenchmark.onPartialPublish_highContention 0.009  0.010  us/op
+ * TracerHealthMetricsBenchmark.onSend_lowContention         0.009  0.009  us/op
+ * TracerHealthMetricsBenchmark.onSend_highContention        0.013  0.013  us/op
+ * TracerHealthMetricsBenchmark.summaryWhileWriting                0.373  0.373  us/op
+ * TracerHealthMetricsBenchmark.summaryWhileWriting:...write        0.008  0.008  us/op
+ * TracerHealthMetricsBenchmark.summaryWhileWriting:...read         1.835  1.833  us/op
+ * </code>
+ *
+ * <p><b>Before/after results.</b> The {@code Accumulator}-backed implementation is now at parity
+ * with, or measurably <em>faster</em> than, the {@code LongAdder} baseline it replaced on every
+ * single-call-site benchmark, including under {@code Threads.MAX} contention -- a reversal of the
+ * earlier {@code synchronized}-stripe design's 1.1-4.6x cost documented before the lock-free
+ * rewrite (commit {@code 3ea84793d1}). {@code onSend}, the most expensive real call site (three
+ * top-level calls plus one two-counter grouped update), now costs 0.6-0.75x of legacy at both
+ * contention levels. {@code summary()} remains the one real cost: walking 54 stripes
+ * non-destructively still costs ~2.5-2.6x what summing 52 plain {@code LongAdder} fields does
+ * (~1.83 vs ~0.71 us/op) -- still far below the periodic (30s-default) {@code Flush} cadence and
+ * the ad hoc/diagnostic calls that trigger it, so not disqualifying. Neither implementation's
+ * writers are measurably slowed by a concurrent {@code summary()}/reader. <code>
+ * Apple M1 Max, 10 CPUs - macOS/aarch64 - JDK 17 (Zulu) / JDK 25 (Zulu)
+ * Benchmark                       New (JDK17/25)  Legacy (JDK17/25)  Ratio
+ * onCreateSpan_lowContention        0.007 / 0.007    0.007 / 0.007    1.0x / 1.0x
+ * onCreateSpan_highContention       0.009 / 0.009    0.010 / 0.010    0.9x / 0.9x
+ * onFailedPublish_lowContention     0.007 / 0.007    0.008 / 0.008    0.9x / 0.9x
+ * onFailedPublish_highContention    0.010 / 0.010    0.011 / 0.012    0.9x / 0.8x
+ * onPartialPublish_lowContention    0.007 / 0.007    0.008 / 0.008    0.9x / 0.9x
+ * onPartialPublish_highContention   0.009 / 0.010    0.012 / 0.012    0.75x / 0.8x
+ * onSend_lowContention              0.009 / 0.009    0.012 / 0.013    0.75x / 0.7x
+ * onSend_highContention             0.013 / 0.013    0.020 / 0.022    0.65x / 0.6x
+ * summaryWhileWriting_write         0.008 / 0.008    0.009 / 0.008    0.9x / 1.0x
+ * summaryWhileWriting_read          1.835 / 1.833    0.705 / 0.720    2.6x / 2.55x
+ * (all figures us/op, avgt; JDK17 / JDK25)
+ * </code> This means the migration's case no longer rests solely on eliminating the {@code
+ * previousCounts}/{@code countIndex} hand-tracking ceremony and giving each counter an atomic
+ * multi-field grouped update -- the lock-free rewrite makes it a speedup too, on every path except
+ * the diagnostic {@code summary()} read.
+ */
+@State(Scope.Benchmark)
+@Warmup(iterations = 1, time = 10)
+@Measurement(iterations = 3, time = 10)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(MICROSECONDS)
+@Fork(2)
+public class TracerHealthMetricsBenchmark {
+
+  private final TracerHealthMetrics metrics = new TracerHealthMetrics(StatsDClient.NO_OP);
+  private final LegacyTracerHealthMetrics legacyMetrics =
+      new LegacyTracerHealthMetrics(StatsDClient.NO_OP);
+  private final RemoteApi.Response okResponse = RemoteApi.Response.success(200);
+
+  @Benchmark
+  @Threads(1)
+  public void onCreateSpan_lowContention() {
+    metrics.onCreateSpan();
+  }
+
+  @Benchmark
+  @Threads(Threads.MAX)
+  public void onCreateSpan_highContention() {
+    metrics.onCreateSpan();
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void onFailedPublish_lowContention() {
+    metrics.onFailedPublish(SAMPLER_DROP, 5);
+  }
+
+  @Benchmark
+  @Threads(Threads.MAX)
+  public void onFailedPublish_highContention() {
+    metrics.onFailedPublish(SAMPLER_DROP, 5);
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void onPartialPublish_lowContention() {
+    metrics.onPartialPublish(3);
+  }
+
+  @Benchmark
+  @Threads(Threads.MAX)
+  public void onPartialPublish_highContention() {
+    metrics.onPartialPublish(3);
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void onSend_lowContention() {
+    metrics.onSend(1, 512, okResponse);
+  }
+
+  @Benchmark
+  @Threads(Threads.MAX)
+  public void onSend_highContention() {
+    metrics.onSend(1, 512, okResponse);
+  }
+
+  @Benchmark
+  @Group("summaryWhileWriting")
+  @GroupThreads(4)
+  public void summaryWhileWriting_write() {
+    metrics.onCreateSpan();
+  }
+
+  @Benchmark
+  @Group("summaryWhileWriting")
+  @GroupThreads(1)
+  public void summaryWhileWriting_read(Blackhole blackhole) {
+    blackhole.consume(metrics.summary());
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void legacyOnCreateSpan_lowContention() {
+    legacyMetrics.onCreateSpan();
+  }
+
+  @Benchmark
+  @Threads(Threads.MAX)
+  public void legacyOnCreateSpan_highContention() {
+    legacyMetrics.onCreateSpan();
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void legacyOnFailedPublish_lowContention() {
+    legacyMetrics.onFailedPublish(SAMPLER_DROP, 5);
+  }
+
+  @Benchmark
+  @Threads(Threads.MAX)
+  public void legacyOnFailedPublish_highContention() {
+    legacyMetrics.onFailedPublish(SAMPLER_DROP, 5);
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void legacyOnPartialPublish_lowContention() {
+    legacyMetrics.onPartialPublish(3);
+  }
+
+  @Benchmark
+  @Threads(Threads.MAX)
+  public void legacyOnPartialPublish_highContention() {
+    legacyMetrics.onPartialPublish(3);
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void legacyOnSend_lowContention() {
+    legacyMetrics.onSend(1, 512, okResponse);
+  }
+
+  @Benchmark
+  @Threads(Threads.MAX)
+  public void legacyOnSend_highContention() {
+    legacyMetrics.onSend(1, 512, okResponse);
+  }
+
+  @Benchmark
+  @Group("legacySummaryWhileWriting")
+  @GroupThreads(4)
+  public void legacySummaryWhileWriting_write() {
+    legacyMetrics.onCreateSpan();
+  }
+
+  @Benchmark
+  @Group("legacySummaryWhileWriting")
+  @GroupThreads(1)
+  public void legacySummaryWhileWriting_read(Blackhole blackhole) {
+    blackhole.consume(legacyMetrics.summary());
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/monitor/TracerHealthMetrics.java
@@ -9,101 +9,149 @@ import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CLIENT;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import datadog.metrics.api.Accumulator;
 import datadog.metrics.api.statsd.StatsDClient;
+import datadog.metrics.api.statsd.StatsDCountReporter;
+import datadog.metrics.api.statsd.StatsDCounterKey;
 import datadog.trace.api.cache.RadixTreeCache;
 import datadog.trace.common.writer.RemoteApi;
 import datadog.trace.core.DDSpan;
 import datadog.trace.core.propagation.opg.OrgGuard;
 import datadog.trace.util.AgentTaskScheduler;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.LongAdder;
 import java.util.function.IntFunction;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable {
-  private static final Logger log = LoggerFactory.getLogger(TracerHealthMetrics.class);
+
+  /**
+   * One counter tracked by {@link TracerHealthMetrics}: a dogstatsd metric name + tags, plus the
+   * label {@link TracerHealthMetrics#summary()} renders it under. One constant per (counter, tag)
+   * combination -- several constants can share a metric name but differ by tag, mirroring the
+   * distinct {@code LongAdder} fields this enum replaces.
+   */
+  enum Metric implements StatsDCounterKey {
+    API_REQUESTS("apiRequests", "api.requests.total"),
+    API_ERRORS("apiErrors", "api.errors.total"),
+    // non-OK responses are reported immediately in onSendAttempt with different status tags
+    API_RESPONSES_OK("apiResponsesOK", "api.responses.total", "status:200"),
+
+    USER_DROP_ENQUEUED_TRACES(
+        "userDropEnqueuedTraces", "queue.enqueued.traces", "priority:user_drop"),
+    USER_KEEP_ENQUEUED_TRACES(
+        "userKeepEnqueuedTraces", "queue.enqueued.traces", "priority:user_keep"),
+    SAMPLER_DROP_ENQUEUED_TRACES(
+        "samplerDropEnqueuedTraces", "queue.enqueued.traces", "priority:sampler_drop"),
+    SAMPLER_KEEP_ENQUEUED_TRACES(
+        "samplerKeepEnqueuedTraces", "queue.enqueued.traces", "priority:sampler_keep"),
+    UNSET_PRIORITY_ENQUEUED_TRACES(
+        "unsetPriorityEnqueuedTraces", "queue.enqueued.traces", "priority:unset"),
+
+    USER_DROP_DROPPED_TRACES("userDropDroppedTraces", "queue.dropped.traces", "priority:user_drop"),
+    USER_KEEP_DROPPED_TRACES("userKeepDroppedTraces", "queue.dropped.traces", "priority:user_keep"),
+    SAMPLER_DROP_DROPPED_TRACES(
+        "samplerDropDroppedTraces", "queue.dropped.traces", "priority:sampler_drop"),
+    SAMPLER_KEEP_DROPPED_TRACES(
+        "samplerKeepDroppedTraces", "queue.dropped.traces", "priority:sampler_keep"),
+    SERIAL_FAILED_DROPPED_TRACES(
+        "serialFailedDroppedTraces", "queue.dropped.traces", "failure:serial"),
+    UNSET_PRIORITY_DROPPED_TRACES(
+        "unsetPriorityDroppedTraces", "queue.dropped.traces", "priority:unset"),
+
+    USER_DROP_DROPPED_SPANS("userDropDroppedSpans", "queue.dropped.spans", "priority:user_drop"),
+    USER_KEEP_DROPPED_SPANS("userKeepDroppedSpans", "queue.dropped.spans", "priority:user_keep"),
+    SAMPLER_DROP_DROPPED_SPANS(
+        "samplerDropDroppedSpans", "queue.dropped.spans", "priority:sampler_drop"),
+    SAMPLER_KEEP_DROPPED_SPANS(
+        "samplerKeepDroppedSpans", "queue.dropped.spans", "priority:sampler_keep"),
+    SERIAL_FAILED_DROPPED_SPANS(
+        "serialFailedDroppedSpans", "queue.dropped.spans", "failure:serial"),
+    UNSET_PRIORITY_DROPPED_SPANS(
+        "unsetPriorityDroppedSpans", "queue.dropped.spans", "priority:unset"),
+
+    ENQUEUED_SPANS("enqueuedSpans", "queue.enqueued.spans"),
+    ENQUEUED_BYTES("enqueuedBytes", "queue.enqueued.bytes"),
+    CREATED_TRACES("createdTraces", "trace.pending.created"),
+    CREATED_SPANS("createdSpans", "span.pending.created"),
+    FINISHED_SPANS("finishedSpans", "span.pending.finished"),
+    FLUSHED_TRACES("flushedTraces", "flush.traces.total"),
+    FLUSHED_BYTES("flushedBytes", "flush.bytes.total"),
+    PARTIAL_TRACES("partialTraces", "queue.partial.traces"),
+    PARTIAL_BYTES("partialBytes", "span.flushed.partial"),
+    CLIENT_SPANS_WITHOUT_CONTEXT("clientSpansWithoutContext", "span.client.no-context"),
+
+    SINGLE_SPAN_SAMPLED("singleSpanSampled", "span.sampling.sampled", "sampler:single-span"),
+    SINGLE_SPAN_UNSAMPLED("singleSpanUnsampled", "span.sampling.unsampled", "sampler:single-span"),
+
+    CAPTURED_CONTINUATIONS("capturedContinuations", "span.continuations.captured"),
+    CANCELLED_CONTINUATIONS("cancelledContinuations", "span.continuations.canceled"),
+    FINISHED_CONTINUATIONS("finishedContinuations", "span.continuations.finished"),
+
+    ACTIVATED_SCOPES("activatedScopes", "scope.activate.count"),
+    CLOSED_SCOPES("closedScopes", "scope.close.count"),
+    SCOPE_STACK_OVERFLOW("scopeStackOverflow", "scope.error.stack-overflow"),
+    SCOPE_CLOSE_ERRORS("scopeCloseErrors", "scope.close.error"),
+    USER_SCOPE_CLOSE_ERRORS("userScopeCloseErrors", "scope.user.close.error"),
+
+    LONG_RUNNING_TRACES_WRITE("longRunningTracesWrite", "long-running.write"),
+    LONG_RUNNING_TRACES_DROPPED("longRunningTracesDropped", "long-running.dropped"),
+    LONG_RUNNING_TRACES_EXPIRED("longRunningTracesExpired", "long-running.expired"),
+
+    ORG_GUARD_ENFORCE_MISMATCH("orgGuardEnforceMismatch", "org_guard.enforce", "reason:mismatch"),
+    ORG_GUARD_ENFORCE_STRICT_MISSING(
+        "orgGuardEnforceStrictMissing", "org_guard.enforce", "reason:strict_missing"),
+
+    CLIENT_STATS_PROCESSED_TRACES("clientStatsProcessedTraces", "stats.traces_in"),
+    CLIENT_STATS_PROCESSED_SPANS("clientStatsProcessedSpans", "stats.spans_in"),
+    CLIENT_STATS_P0_DROPPED_TRACES("clientStatsP0DroppedTraces", "stats.dropped_p0_traces"),
+    CLIENT_STATS_P0_DROPPED_SPANS("clientStatsP0DroppedSpans", "stats.dropped_p0_spans"),
+    CLIENT_STATS_REQUESTS("clientStatsRequests", "stats.flush_payloads"),
+    CLIENT_STATS_ERRORS("clientStatsErrors", "stats.flush_errors"),
+    CLIENT_STATS_DOWNGRADES("clientStatsDowngrades", "stats.agent_downgrades"),
+
+    STATS_AGGREGATE_DROPPED(
+        "statsAggregateDropped", "stats.dropped_aggregates", "reason:lru_eviction"),
+    STATS_INBOX_FULL("statsInboxFull", "stats.dropped_aggregates", "reason:inbox_full"),
+    ;
+
+    private final String summaryLabel;
+    private final String metricName;
+    private final String[] tags;
+
+    Metric(String summaryLabel, String metricName, String... tags) {
+      this.summaryLabel = summaryLabel;
+      this.metricName = metricName;
+      this.tags = tags;
+    }
+
+    @Override
+    public String getMetricName() {
+      return metricName;
+    }
+
+    @Override
+    public String[] getTags() {
+      return tags;
+    }
+
+    String getSummaryLabel() {
+      return summaryLabel;
+    }
+  }
 
   private static final IntFunction<String[]> STATUS_TAGS =
       httpStatus -> new String[] {"status:" + httpStatus};
 
   private static final String[] NO_TAGS = new String[0];
   private static final String[] COLLAPSED_WHOLE_KEY_TAGS = new String[] {"collapsed:whole_key"};
-  private static final String[] STATUS_OK_TAGS = STATUS_TAGS.apply(200);
   private final RadixTreeCache<String[]> statusTagsCache =
       new RadixTreeCache<>(16, 32, STATUS_TAGS, 200, 400);
 
   private final AtomicBoolean started = new AtomicBoolean(false);
   private volatile AgentTaskScheduler.Scheduled<TracerHealthMetrics> cancellation;
 
-  private final LongAdder apiRequests = new LongAdder();
-  private final LongAdder apiErrors = new LongAdder();
-  private final LongAdder apiResponsesOK = new LongAdder();
-
-  private final LongAdder userDropEnqueuedTraces = new LongAdder();
-  private final LongAdder userKeepEnqueuedTraces = new LongAdder();
-  private final LongAdder samplerDropEnqueuedTraces = new LongAdder();
-  private final LongAdder samplerKeepEnqueuedTraces = new LongAdder();
-  private final LongAdder unsetPriorityEnqueuedTraces = new LongAdder();
-
-  private final LongAdder userDropDroppedTraces = new LongAdder();
-  private final LongAdder userKeepDroppedTraces = new LongAdder();
-  private final LongAdder samplerDropDroppedTraces = new LongAdder();
-  private final LongAdder samplerKeepDroppedTraces = new LongAdder();
-  private final LongAdder serialFailedDroppedTraces = new LongAdder();
-  private final LongAdder unsetPriorityDroppedTraces = new LongAdder();
-
-  private final LongAdder userDropDroppedSpans = new LongAdder();
-  private final LongAdder userKeepDroppedSpans = new LongAdder();
-  private final LongAdder samplerDropDroppedSpans = new LongAdder();
-  private final LongAdder samplerKeepDroppedSpans = new LongAdder();
-  private final LongAdder serialFailedDroppedSpans = new LongAdder();
-  private final LongAdder unsetPriorityDroppedSpans = new LongAdder();
-
-  private final LongAdder enqueuedSpans = new LongAdder();
-  private final LongAdder enqueuedBytes = new LongAdder();
-  private final LongAdder createdTraces = new LongAdder();
-  private final LongAdder createdSpans = new LongAdder();
-  private final LongAdder finishedSpans = new LongAdder();
-  private final LongAdder flushedTraces = new LongAdder();
-  private final LongAdder flushedBytes = new LongAdder();
-  private final LongAdder partialTraces = new LongAdder();
-  private final LongAdder partialBytes = new LongAdder();
-  private final LongAdder clientSpansWithoutContext = new LongAdder();
-
-  private final LongAdder singleSpanSampled = new LongAdder();
-  private final LongAdder singleSpanUnsampled = new LongAdder();
-
-  private final LongAdder capturedContinuations = new LongAdder();
-  private final LongAdder cancelledContinuations = new LongAdder();
-  private final LongAdder finishedContinuations = new LongAdder();
-
-  private final LongAdder activatedScopes = new LongAdder();
-  private final LongAdder closedScopes = new LongAdder();
-  private final LongAdder scopeStackOverflow = new LongAdder();
-  private final LongAdder scopeCloseErrors = new LongAdder();
-  private final LongAdder userScopeCloseErrors = new LongAdder();
-
-  private final LongAdder longRunningTracesWrite = new LongAdder();
-  private final LongAdder longRunningTracesDropped = new LongAdder();
-  private final LongAdder longRunningTracesExpired = new LongAdder();
-
-  private final LongAdder orgGuardEnforceMismatch = new LongAdder();
-  private final LongAdder orgGuardEnforceStrictMissing = new LongAdder();
-
-  private final LongAdder clientStatsProcessedSpans = new LongAdder();
-  private final LongAdder clientStatsProcessedTraces = new LongAdder();
-  private final LongAdder clientStatsP0DroppedSpans = new LongAdder();
-  private final LongAdder clientStatsP0DroppedTraces = new LongAdder();
-  private final LongAdder clientStatsRequests = new LongAdder();
-  private final LongAdder clientStatsErrors = new LongAdder();
-  private final LongAdder clientStatsDowngrades = new LongAdder();
-
-  private final LongAdder statsAggregateDropped = new LongAdder();
-  private final LongAdder statsInboxFull = new LongAdder();
+  private final StatsDCountReporter<Metric> countReporter;
 
   private final StatsDClient statsd;
   private final long interval;
@@ -126,6 +174,7 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
     this.statsd = statsd;
     this.interval = interval;
     this.units = units;
+    this.countReporter = StatsDCountReporter.of(statsd, Metric.class);
   }
 
   @Override
@@ -140,21 +189,21 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   public void onPublish(final List<DDSpan> trace, final int samplingPriority) {
     switch (samplingPriority) {
       case USER_DROP:
-        userDropEnqueuedTraces.increment();
+        countReporter.inc(Metric.USER_DROP_ENQUEUED_TRACES);
         break;
       case USER_KEEP:
-        userKeepEnqueuedTraces.increment();
+        countReporter.inc(Metric.USER_KEEP_ENQUEUED_TRACES);
         break;
       case SAMPLER_DROP:
-        samplerDropEnqueuedTraces.increment();
+        countReporter.inc(Metric.SAMPLER_DROP_ENQUEUED_TRACES);
         break;
       case SAMPLER_KEEP:
-        samplerKeepEnqueuedTraces.increment();
+        countReporter.inc(Metric.SAMPLER_KEEP_ENQUEUED_TRACES);
         break;
       default:
-        unsetPriorityEnqueuedTraces.increment();
+        countReporter.inc(Metric.UNSET_PRIORITY_ENQUEUED_TRACES);
     }
-    enqueuedSpans.add(trace.size());
+    countReporter.add(Metric.ENQUEUED_SPANS, trace.size());
     checkForClientSpansWithoutContext(trace);
   }
 
@@ -163,7 +212,7 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
       if (span != null && span.getParentId() == ZERO) {
         String spanKind = span.getTag(SPAN_KIND, "undefined");
         if (SPAN_KIND_CLIENT.equals(spanKind)) {
-          this.clientSpansWithoutContext.increment();
+          countReporter.inc(Metric.CLIENT_SPANS_WITHOUT_CONTEXT);
         }
       }
     }
@@ -173,31 +222,31 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
   public void onFailedPublish(final int samplingPriority, final int spanCount) {
     switch (samplingPriority) {
       case USER_DROP:
-        userDropDroppedSpans.add(spanCount);
-        userDropDroppedTraces.increment();
+        countReporter.add(Metric.USER_DROP_DROPPED_SPANS, spanCount);
+        countReporter.inc(Metric.USER_DROP_DROPPED_TRACES);
         break;
       case USER_KEEP:
-        userKeepDroppedSpans.add(spanCount);
-        userKeepDroppedTraces.increment();
+        countReporter.add(Metric.USER_KEEP_DROPPED_SPANS, spanCount);
+        countReporter.inc(Metric.USER_KEEP_DROPPED_TRACES);
         break;
       case SAMPLER_DROP:
-        samplerDropDroppedSpans.add(spanCount);
-        samplerDropDroppedTraces.increment();
+        countReporter.add(Metric.SAMPLER_DROP_DROPPED_SPANS, spanCount);
+        countReporter.inc(Metric.SAMPLER_DROP_DROPPED_TRACES);
         break;
       case SAMPLER_KEEP:
-        samplerKeepDroppedSpans.add(spanCount);
-        samplerKeepDroppedTraces.increment();
+        countReporter.add(Metric.SAMPLER_KEEP_DROPPED_SPANS, spanCount);
+        countReporter.inc(Metric.SAMPLER_KEEP_DROPPED_TRACES);
         break;
       default:
-        unsetPriorityDroppedSpans.add(spanCount);
-        unsetPriorityDroppedTraces.increment();
+        countReporter.add(Metric.UNSET_PRIORITY_DROPPED_SPANS, spanCount);
+        countReporter.inc(Metric.UNSET_PRIORITY_DROPPED_TRACES);
     }
   }
 
   @Override
   public void onPartialPublish(final int numberOfDroppedSpans) {
-    partialTraces.increment();
-    samplerDropDroppedSpans.add(numberOfDroppedSpans);
+    countReporter.inc(Metric.PARTIAL_TRACES);
+    countReporter.add(Metric.SAMPLER_DROP_DROPPED_SPANS, numberOfDroppedSpans);
   }
 
   @Override
@@ -210,95 +259,97 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
 
   @Override
   public void onPartialFlush(final int sizeInBytes) {
-    partialBytes.add(sizeInBytes);
+    countReporter.add(Metric.PARTIAL_BYTES, sizeInBytes);
   }
 
   @Override
   public void onSingleSpanSample() {
-    singleSpanSampled.increment();
+    countReporter.inc(Metric.SINGLE_SPAN_SAMPLED);
   }
 
   @Override
   public void onSingleSpanUnsampled() {
-    singleSpanUnsampled.increment();
+    countReporter.inc(Metric.SINGLE_SPAN_UNSAMPLED);
   }
 
   @Override
   public void onSerialize(final int serializedSizeInBytes) {
     // DQH - Because of Java tracer's 2 phase acceptance and serialization scheme, this doesn't
     // map precisely
-    enqueuedBytes.add(serializedSizeInBytes);
+    countReporter.add(Metric.ENQUEUED_BYTES, serializedSizeInBytes);
   }
 
   @Override
   public void onFailedSerialize(final List<DDSpan> trace, final Throwable optionalCause) {
     if (trace != null) {
-      serialFailedDroppedTraces.increment();
-      serialFailedDroppedSpans.add(trace.size());
+      countReporter.inc(Metric.SERIAL_FAILED_DROPPED_TRACES);
+      countReporter.add(Metric.SERIAL_FAILED_DROPPED_SPANS, trace.size());
     }
   }
 
   @Override
   public void onCreateSpan() {
-    createdSpans.increment();
+    countReporter.inc(Metric.CREATED_SPANS);
   }
 
   @Override
   public void onFinishSpan() {
-    finishedSpans.increment();
+    countReporter.inc(Metric.FINISHED_SPANS);
   }
 
   @Override
   public void onCreateTrace() {
-    createdTraces.increment();
+    countReporter.inc(Metric.CREATED_TRACES);
   }
 
   @Override
   public void onScopeCloseError(boolean manual) {
-    scopeCloseErrors.increment();
     if (manual) {
-      userScopeCloseErrors.increment();
+      countReporter.inc(Metric.SCOPE_CLOSE_ERRORS);
+      countReporter.inc(Metric.USER_SCOPE_CLOSE_ERRORS);
+    } else {
+      countReporter.inc(Metric.SCOPE_CLOSE_ERRORS);
     }
   }
 
   @Override
   public void onCaptureContinuation() {
-    capturedContinuations.increment();
+    countReporter.inc(Metric.CAPTURED_CONTINUATIONS);
   }
 
   @Override
   public void onCancelContinuation() {
-    cancelledContinuations.increment();
+    countReporter.inc(Metric.CANCELLED_CONTINUATIONS);
   }
 
   @Override
   public void onFinishContinuation() {
-    finishedContinuations.increment();
+    countReporter.inc(Metric.FINISHED_CONTINUATIONS);
   }
 
   @Override
   public void onActivateScope() {
-    activatedScopes.increment();
+    countReporter.inc(Metric.ACTIVATED_SCOPES);
   }
 
   @Override
   public void onCloseScope() {
-    closedScopes.increment();
+    countReporter.inc(Metric.CLOSED_SCOPES);
   }
 
   @Override
   public void onScopeStackOverflow() {
-    scopeStackOverflow.increment();
+    countReporter.inc(Metric.SCOPE_STACK_OVERFLOW);
   }
 
   @Override
   public void onOrgGuardEnforce(OrgGuard.Reason reason) {
     switch (reason) {
       case MISMATCH:
-        orgGuardEnforceMismatch.increment();
+        countReporter.inc(Metric.ORG_GUARD_ENFORCE_MISMATCH);
         break;
       case STRICT_MISSING:
-        orgGuardEnforceStrictMissing.increment();
+        countReporter.inc(Metric.ORG_GUARD_ENFORCE_STRICT_MISSING);
         break;
     }
   }
@@ -317,68 +368,68 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
 
   @Override
   public void onLongRunningUpdate(final int dropped, final int write, final int expired) {
-    longRunningTracesWrite.add(write);
-    longRunningTracesDropped.add(dropped);
-    longRunningTracesExpired.add(expired);
+    countReporter.add(Metric.LONG_RUNNING_TRACES_WRITE, write);
+    countReporter.add(Metric.LONG_RUNNING_TRACES_DROPPED, dropped);
+    countReporter.add(Metric.LONG_RUNNING_TRACES_EXPIRED, expired);
   }
 
   private void onSendAttempt(
       final int traceCount, final int sizeInBytes, final RemoteApi.Response response) {
-    apiRequests.increment();
-    flushedTraces.add(traceCount);
+    countReporter.inc(Metric.API_REQUESTS);
+    countReporter.add(Metric.FLUSHED_TRACES, traceCount);
     // TODO: missing queue.spans (# of spans being sent)
-    flushedBytes.add(sizeInBytes);
+    countReporter.add(Metric.FLUSHED_BYTES, sizeInBytes);
 
     if (response.exception().isPresent()) {
       // covers communication errors -- both not receiving a response or
       // receiving malformed response (even when otherwise successful)
-      apiErrors.increment();
+      countReporter.inc(Metric.API_ERRORS);
     }
 
-    int status = response.status().orElse(0);
-    if (status != 0) {
-      if (200 == status) {
-        apiResponsesOK.increment();
-      } else {
-        statsd.incrementCounter("api.responses.total", statusTagsCache.get(status));
-      }
+    if (200 == response.status().orElse(0)) {
+      countReporter.inc(Metric.API_RESPONSES_OK);
+    }
+
+    final int status = response.status().orElse(0);
+    if (status != 0 && 200 != status) {
+      statsd.incrementCounter("api.responses.total", statusTagsCache.get(status));
     }
   }
 
   @Override
   public void onClientStatTraceComputed(int countedSpans, int totalSpans, boolean dropped) {
-    clientStatsProcessedTraces.increment();
-    clientStatsProcessedSpans.add(countedSpans);
+    countReporter.inc(Metric.CLIENT_STATS_PROCESSED_TRACES);
+    countReporter.add(Metric.CLIENT_STATS_PROCESSED_SPANS, countedSpans);
     if (dropped) {
-      clientStatsP0DroppedTraces.increment();
-      clientStatsP0DroppedSpans.add(totalSpans);
+      countReporter.inc(Metric.CLIENT_STATS_P0_DROPPED_TRACES);
+      countReporter.add(Metric.CLIENT_STATS_P0_DROPPED_SPANS, totalSpans);
     }
   }
 
   @Override
   public void onClientStatPayloadSent() {
-    clientStatsRequests.increment();
+    countReporter.inc(Metric.CLIENT_STATS_REQUESTS);
   }
 
   @Override
   public void onClientStatDowngraded() {
-    clientStatsDowngrades.increment();
+    countReporter.inc(Metric.CLIENT_STATS_DOWNGRADES);
   }
 
   @Override
   public void onClientStatErrorReceived() {
-    clientStatsErrors.increment();
+    countReporter.inc(Metric.CLIENT_STATS_ERRORS);
   }
 
   @Override
   public void onStatsAggregateDropped() {
-    statsAggregateDropped.increment();
+    countReporter.inc(Metric.STATS_AGGREGATE_DROPPED);
     statsd.count("datadog.tracer.stats.collapsed_spans", 1, COLLAPSED_WHOLE_KEY_TAGS);
   }
 
   @Override
   public void onStatsInboxFull() {
-    statsInboxFull.increment();
+    countReporter.inc(Metric.STATS_INBOX_FULL);
   }
 
   @Override
@@ -395,299 +446,22 @@ public class TracerHealthMetrics extends HealthMetrics implements AutoCloseable 
 
   private static class Flush implements AgentTaskScheduler.Task<TracerHealthMetrics> {
 
-    private static final String[] USER_DROP_TAG = new String[] {"priority:user_drop"};
-    private static final String[] USER_KEEP_TAG = new String[] {"priority:user_keep"};
-    private static final String[] SAMPLER_DROP_TAG = new String[] {"priority:sampler_drop"};
-    private static final String[] SAMPLER_KEEP_TAG = new String[] {"priority:sampler_keep"};
-    private static final String[] SERIAL_FAILED_TAG = new String[] {"failure:serial"};
-    private static final String[] UNSET_TAG = new String[] {"priority:unset"};
-    private static final String[] SINGLE_SPAN_SAMPLER = new String[] {"sampler:single-span"};
-    private static final String[] REASON_LRU_EVICTION_TAG = new String[] {"reason:lru_eviction"};
-    private static final String[] REASON_INBOX_FULL_TAG = new String[] {"reason:inbox_full"};
-    private static final String[] ORG_GUARD_MISMATCH_TAGS = new String[] {"reason:mismatch"};
-    private static final String[] ORG_GUARD_STRICT_MISSING_TAGS =
-        new String[] {"reason:strict_missing"};
-
-    private final long[] previousCounts = new long[54];
-
-    @SuppressFBWarnings("AT_STALE_THREAD_WRITE_OF_PRIMITIVE")
-    private int countIndex;
-
     @Override
     public void run(TracerHealthMetrics target) {
-      countIndex = -1; // reposition so _next_ value is 0
-      try {
-
-        reportIfChanged(target.statsd, "api.requests.total", target.apiRequests, NO_TAGS);
-        reportIfChanged(target.statsd, "api.errors.total", target.apiErrors, NO_TAGS);
-        // non-OK responses are reported immediately in onSendAttempt with different status tags
-        reportIfChanged(
-            target.statsd, "api.responses.total", target.apiResponsesOK, STATUS_OK_TAGS);
-
-        reportIfChanged(
-            target.statsd, "queue.enqueued.traces", target.userDropEnqueuedTraces, USER_DROP_TAG);
-        reportIfChanged(
-            target.statsd, "queue.enqueued.traces", target.userKeepEnqueuedTraces, USER_KEEP_TAG);
-        reportIfChanged(
-            target.statsd,
-            "queue.enqueued.traces",
-            target.samplerDropEnqueuedTraces,
-            SAMPLER_DROP_TAG);
-        reportIfChanged(
-            target.statsd,
-            "queue.enqueued.traces",
-            target.samplerKeepEnqueuedTraces,
-            SAMPLER_KEEP_TAG);
-        reportIfChanged(
-            target.statsd, "queue.enqueued.traces", target.unsetPriorityEnqueuedTraces, UNSET_TAG);
-
-        reportIfChanged(
-            target.statsd, "queue.dropped.traces", target.userDropDroppedTraces, USER_DROP_TAG);
-        reportIfChanged(
-            target.statsd, "queue.dropped.traces", target.userKeepDroppedTraces, USER_KEEP_TAG);
-        reportIfChanged(
-            target.statsd,
-            "queue.dropped.traces",
-            target.samplerDropDroppedTraces,
-            SAMPLER_DROP_TAG);
-        reportIfChanged(
-            target.statsd,
-            "queue.dropped.traces",
-            target.samplerKeepDroppedTraces,
-            SAMPLER_KEEP_TAG);
-        reportIfChanged(
-            target.statsd,
-            "queue.dropped.traces",
-            target.serialFailedDroppedTraces,
-            SERIAL_FAILED_TAG);
-        reportIfChanged(
-            target.statsd, "queue.dropped.traces", target.unsetPriorityDroppedTraces, UNSET_TAG);
-
-        reportIfChanged(
-            target.statsd, "queue.dropped.spans", target.userDropDroppedSpans, USER_DROP_TAG);
-        reportIfChanged(
-            target.statsd, "queue.dropped.spans", target.userKeepDroppedSpans, USER_KEEP_TAG);
-        reportIfChanged(
-            target.statsd, "queue.dropped.spans", target.samplerDropDroppedSpans, SAMPLER_DROP_TAG);
-        reportIfChanged(
-            target.statsd, "queue.dropped.spans", target.samplerKeepDroppedSpans, SAMPLER_KEEP_TAG);
-        reportIfChanged(
-            target.statsd,
-            "queue.dropped.spans",
-            target.serialFailedDroppedSpans,
-            SERIAL_FAILED_TAG);
-        reportIfChanged(
-            target.statsd, "queue.dropped.spans", target.unsetPriorityDroppedSpans, UNSET_TAG);
-
-        reportIfChanged(target.statsd, "queue.enqueued.spans", target.enqueuedSpans, NO_TAGS);
-        reportIfChanged(target.statsd, "queue.enqueued.bytes", target.enqueuedBytes, NO_TAGS);
-        reportIfChanged(target.statsd, "trace.pending.created", target.createdTraces, NO_TAGS);
-        reportIfChanged(target.statsd, "span.pending.created", target.createdSpans, NO_TAGS);
-        reportIfChanged(target.statsd, "span.pending.finished", target.finishedSpans, NO_TAGS);
-        reportIfChanged(target.statsd, "flush.traces.total", target.flushedTraces, NO_TAGS);
-        reportIfChanged(target.statsd, "flush.bytes.total", target.flushedBytes, NO_TAGS);
-        reportIfChanged(target.statsd, "queue.partial.traces", target.partialTraces, NO_TAGS);
-        reportIfChanged(target.statsd, "span.flushed.partial", target.partialBytes, NO_TAGS);
-        reportIfChanged(
-            target.statsd, "span.client.no-context", target.clientSpansWithoutContext, NO_TAGS);
-
-        reportIfChanged(
-            target.statsd, "span.sampling.sampled", target.singleSpanSampled, SINGLE_SPAN_SAMPLER);
-        reportIfChanged(
-            target.statsd,
-            "span.sampling.unsampled",
-            target.singleSpanUnsampled,
-            SINGLE_SPAN_SAMPLER);
-
-        reportIfChanged(
-            target.statsd, "span.continuations.captured", target.capturedContinuations, NO_TAGS);
-        reportIfChanged(
-            target.statsd, "span.continuations.canceled", target.cancelledContinuations, NO_TAGS);
-        reportIfChanged(
-            target.statsd, "span.continuations.finished", target.finishedContinuations, NO_TAGS);
-
-        reportIfChanged(target.statsd, "scope.activate.count", target.activatedScopes, NO_TAGS);
-        reportIfChanged(target.statsd, "scope.close.count", target.closedScopes, NO_TAGS);
-        reportIfChanged(
-            target.statsd, "scope.error.stack-overflow", target.scopeStackOverflow, NO_TAGS);
-        reportIfChanged(target.statsd, "scope.close.error", target.scopeCloseErrors, NO_TAGS);
-        reportIfChanged(
-            target.statsd, "scope.user.close.error", target.userScopeCloseErrors, NO_TAGS);
-
-        reportIfChanged(
-            target.statsd, "long-running.write", target.longRunningTracesWrite, NO_TAGS);
-        reportIfChanged(
-            target.statsd, "long-running.dropped", target.longRunningTracesDropped, NO_TAGS);
-        reportIfChanged(
-            target.statsd, "long-running.expired", target.longRunningTracesExpired, NO_TAGS);
-
-        reportIfChanged(
-            target.statsd,
-            "org_guard.enforce",
-            target.orgGuardEnforceMismatch,
-            ORG_GUARD_MISMATCH_TAGS);
-        reportIfChanged(
-            target.statsd,
-            "org_guard.enforce",
-            target.orgGuardEnforceStrictMissing,
-            ORG_GUARD_STRICT_MISSING_TAGS);
-
-        reportIfChanged(
-            target.statsd, "stats.traces_in", target.clientStatsProcessedTraces, NO_TAGS);
-        reportIfChanged(target.statsd, "stats.spans_in", target.clientStatsProcessedSpans, NO_TAGS);
-        reportIfChanged(
-            target.statsd, "stats.dropped_p0_traces", target.clientStatsP0DroppedTraces, NO_TAGS);
-        reportIfChanged(
-            target.statsd, "stats.dropped_p0_spans", target.clientStatsP0DroppedSpans, NO_TAGS);
-        reportIfChanged(target.statsd, "stats.flush_payloads", target.clientStatsRequests, NO_TAGS);
-        reportIfChanged(target.statsd, "stats.flush_errors", target.clientStatsErrors, NO_TAGS);
-        reportIfChanged(
-            target.statsd, "stats.agent_downgrades", target.clientStatsDowngrades, NO_TAGS);
-        reportIfChanged(
-            target.statsd,
-            "stats.dropped_aggregates",
-            target.statsAggregateDropped,
-            REASON_LRU_EVICTION_TAG);
-        reportIfChanged(
-            target.statsd,
-            "stats.dropped_aggregates",
-            target.statsInboxFull,
-            REASON_INBOX_FULL_TAG);
-
-      } catch (ArrayIndexOutOfBoundsException e) {
-        log.warn(
-            "previousCounts array needs resizing to at least {}, was {}",
-            countIndex + 1,
-            previousCounts.length);
-      }
-    }
-
-    private void reportIfChanged(
-        StatsDClient statsDClient, String aspect, LongAdder counter, String[] tags) {
-      long count = counter.sum();
-      long delta = count - previousCounts[++countIndex];
-      if (delta > 0) {
-        statsDClient.count(aspect, delta, tags);
-        previousCounts[countIndex] = count;
-      }
+      target.countReporter.flush();
     }
   }
 
   @Override
   public String summary() {
-    return "apiRequests="
-        + apiRequests.sum()
-        + "\napiErrors="
-        + apiErrors.sum()
-        + "\napiResponsesOK="
-        + apiResponsesOK.sum()
-        + "\n"
-        + "\nuserDropEnqueuedTraces="
-        + userDropEnqueuedTraces.sum()
-        + "\nuserKeepEnqueuedTraces="
-        + userKeepEnqueuedTraces.sum()
-        + "\nsamplerDropEnqueuedTraces="
-        + samplerDropEnqueuedTraces.sum()
-        + "\nsamplerKeepEnqueuedTraces="
-        + samplerKeepEnqueuedTraces.sum()
-        + "\nunsetPriorityEnqueuedTraces="
-        + unsetPriorityEnqueuedTraces.sum()
-        + "\n"
-        + "\nuserDropDroppedTraces="
-        + userDropDroppedTraces.sum()
-        + "\nuserKeepDroppedTraces="
-        + userKeepDroppedTraces.sum()
-        + "\nsamplerDropDroppedTraces="
-        + samplerDropDroppedTraces.sum()
-        + "\nsamplerKeepDroppedTraces="
-        + samplerKeepDroppedTraces.sum()
-        + "\nserialFailedDroppedTraces="
-        + serialFailedDroppedTraces.sum()
-        + "\nunsetPriorityDroppedTraces="
-        + unsetPriorityDroppedTraces.sum()
-        + "\n"
-        + "\nuserDropDroppedSpans="
-        + userDropDroppedSpans.sum()
-        + "\nuserKeepDroppedSpans="
-        + userKeepDroppedSpans.sum()
-        + "\nsamplerDropDroppedSpans="
-        + samplerDropDroppedSpans.sum()
-        + "\nsamplerKeepDroppedSpans="
-        + samplerKeepDroppedSpans.sum()
-        + "\nserialFailedDroppedSpans="
-        + serialFailedDroppedSpans.sum()
-        + "\nunsetPriorityDroppedSpans="
-        + unsetPriorityDroppedSpans.sum()
-        + "\n"
-        + "\nenqueuedSpans="
-        + enqueuedSpans.sum()
-        + "\nenqueuedBytes="
-        + enqueuedBytes.sum()
-        + "\ncreatedTraces="
-        + createdTraces.sum()
-        + "\ncreatedSpans="
-        + createdSpans.sum()
-        + "\nfinishedSpans="
-        + finishedSpans.sum()
-        + "\nflushedTraces="
-        + flushedTraces.sum()
-        + "\nflushedBytes="
-        + flushedBytes.sum()
-        + "\npartialTraces="
-        + partialTraces.sum()
-        + "\npartialBytes="
-        + partialBytes.sum()
-        + "\n"
-        + "\nclientSpansWithoutContext="
-        + clientSpansWithoutContext.sum()
-        + "\n"
-        + "\nsingleSpanSampled="
-        + singleSpanSampled.sum()
-        + "\nsingleSpanUnsampled="
-        + singleSpanUnsampled.sum()
-        + "\n"
-        + "\ncapturedContinuations="
-        + capturedContinuations.sum()
-        + "\ncancelledContinuations="
-        + cancelledContinuations.sum()
-        + "\nfinishedContinuations="
-        + finishedContinuations.sum()
-        + "\n"
-        + "\nactivatedScopes="
-        + activatedScopes.sum()
-        + "\nclosedScopes="
-        + closedScopes.sum()
-        + "\nscopeStackOverflow="
-        + scopeStackOverflow.sum()
-        + "\nscopeCloseErrors="
-        + scopeCloseErrors.sum()
-        + "\nuserScopeCloseErrors="
-        + userScopeCloseErrors.sum()
-        + "\n"
-        + "\nlongRunningTracesWrite="
-        + longRunningTracesWrite.sum()
-        + "\nlongRunningTracesDropped="
-        + longRunningTracesDropped.sum()
-        + "\nlongRunningTracesExpired="
-        + longRunningTracesExpired.sum()
-        + "\n"
-        + "\nclientStatsRequests="
-        + clientStatsRequests.sum()
-        + "\nclientStatsErrors="
-        + clientStatsErrors.sum()
-        + "\nclientStatsDowngrades="
-        + clientStatsDowngrades.sum()
-        + "\nclientStatsP0DroppedSpans="
-        + clientStatsP0DroppedSpans.sum()
-        + "\nclientStatsP0DroppedTraces="
-        + clientStatsP0DroppedTraces.sum()
-        + "\nclientStatsProcessedSpans="
-        + clientStatsProcessedSpans.sum()
-        + "\nclientStatsProcessedTraces="
-        + clientStatsProcessedTraces.sum()
-        + "\nstatsAggregateDropped="
-        + statsAggregateDropped.sum()
-        + "\nstatsInboxFull="
-        + statsInboxFull.sum();
+    Accumulator.Counts<Metric> live = countReporter.live();
+    StringBuilder summary = new StringBuilder();
+    for (Metric metric : live.keys()) {
+      if (summary.length() > 0) {
+        summary.append('\n');
+      }
+      summary.append(metric.getSummaryLabel()).append('=').append(live.get(metric));
+    }
+    return summary.toString();
   }
 }


### PR DESCRIPTION
# What Does This Do

Trial migration of `TracerHealthMetrics` onto `Accumulator<E>` (#12351), the concrete case cited in that PR's review discussion as the motivating ceremony.

- Replaces ~49 `LongAdder` fields and the hand-rolled `previousCounts[]`/`countIndex` delta-tracking (with its `ArrayIndexOutOfBoundsException` safety-net catch) in `Flush.run()` with a single `Accumulator<Metric>` (nested `TracerHealthMetrics.Metric` enum), using `accumulateAndReset()` for the periodic drain.
- `summary()` reads a live value (`storedTotal.plus(counters.sum())`) that never races the periodic `Flush` drain, using the primitive's non-destructive `sum()`/`Counts.plus()`.
- Adds reusable `StatsDCounterKey`/`StatsDCountReporter` glue in `metrics-api`, decoupled from `internal-api` via a `ToLongFunction<E>` accessor.
- `HealthMetricsTest` and `MetricsReliabilityTest` pass **unmodified** — same `statsd.count(...)` call shape per flush, same `summary()` labels.

# Motivation

`Accumulator` (#12351) had no real caller yet, and review pushed back on whether the abstraction earns its keep versus the status quo (`LongAdder` + hand-rolled delta tracking). Rather than keep arguing in the abstract, this wires it into `TracerHealthMetrics` — the concrete case already cited in that discussion — to settle the question on working code:

- **Ergonomics**: eliminates the `previousCounts`/`countIndex` hand-tracking ceremony (`Accumulator.accumulateAndReset()` already returns the delta since the last drain) and the 49 individual `reportIfChanged` call sites, for a **187-line (28%) reduction** in `TracerHealthMetrics` (656 → 469 lines vs. pre-migration at `77964b3996`), despite now inlining all 54 `Metric` constants that previously lived in a separate file.
- **Performance**: see benchmark results below — no longer a speed-for-ergonomics trade.

# Additional Notes

## Benchmark results (`TracerHealthMetricsBenchmark`, direct measurement of real call sites)

`Accumulator` was rewritten after this trial started to a lock-free `AtomicLongArray`-striped design (see #12351). Under that design, the new implementation is now at parity with, or measurably **faster** than, the legacy `LongAdder` baseline on every single-call-site benchmark, including under `Threads.MAX` contention. Confirmed stable across JDK 17 and JDK 25 (point estimates agree almost exactly between JVMs).

```
Apple M1 Max, 10 CPUs - macOS/aarch64 - JDK 17 (Zulu) / JDK 25 (Zulu)
Benchmark                       New (JDK17/25)  Legacy (JDK17/25)  Ratio
onCreateSpan_lowContention        0.007 / 0.007    0.007 / 0.007    1.0x / 1.0x
onCreateSpan_highContention       0.009 / 0.009    0.010 / 0.010    0.9x / 0.9x
onFailedPublish_lowContention     0.007 / 0.007    0.008 / 0.008    0.9x / 0.9x
onFailedPublish_highContention    0.010 / 0.010    0.011 / 0.012    0.9x / 0.8x
onPartialPublish_lowContention    0.007 / 0.007    0.008 / 0.008    0.9x / 0.9x
onPartialPublish_highContention   0.009 / 0.010    0.012 / 0.012    0.75x / 0.8x
onSend_lowContention              0.009 / 0.009    0.012 / 0.013    0.75x / 0.7x
onSend_highContention             0.013 / 0.013    0.020 / 0.022    0.65x / 0.6x
summaryWhileWriting_write         0.008 / 0.008    0.009 / 0.008    0.9x / 1.0x
summaryWhileWriting_read          1.835 / 1.833    0.705 / 0.720    2.6x / 2.55x
(all figures us/op, avgt; JDK17 / JDK25)
```

The only remaining cost is the diagnostic `summary()` read (walking all 54 stripes non-destructively, ~2.5-2.6x legacy) — well below the periodic 30s-default `Flush` cadence and the ad hoc/diagnostic calls that trigger it, so not disqualifying.

Note: `AccumulatorBenchmark`'s own javadoc (on #12351) went through two corrections. A width-8, per-thread-distributed write-side comparison was added (the single-counter benchmarks were the degenerate worst case for the `longAdderGroup` baseline), and a Fork(5)/15-sample re-run showed the drain-side "regression" from an earlier correction (13.357 us/op, ~5.5x worse) was itself a correlated anomaly across two low-sample runs — the verified number is 2.746 us/op, roughly at parity with (and in this reading faster than) `longAdderGroup`'s noisy 4.770 ± 1.795 us/op. Neither correction changes this PR's real-call-site numbers above, which were re-measured directly.

## Test plan

- [x] `./gradlew :dd-trace-core:test --tests "datadog.trace.core.monitor.HealthMetricsTest"` — 40/40 passing, no test-file changes
- [x] `./gradlew :dd-trace-core:test --tests "datadog.trace.common.metrics.MetricsReliabilityTest"` — passing, no test-file changes
- [x] `./gradlew :products:metrics:metrics-api:test --tests "datadog.metrics.api.statsd.StatsDCountReporterTest"` — new tests passing
- [x] `./gradlew :internal-api:test --tests "datadog.trace.util.AccumulatorTest"` — passing (on base branch)
- [x] `./gradlew :dd-trace-core:jmh -Pjmh.includes=TracerHealthMetricsBenchmark` — run on both JDK 17 and JDK 25, results above
- [x] `/techdebt` — clean, no fixable debt (this branch is itself a debt-removal commit)
- [x] `/perf-review` — 1 flag-as-measure finding (SEV-3, non-blocking, now stale — predates the `update()` removal, no capturing-lambda call sites remain on this branch)

# Contributor Checklist

- [x] Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue
- [ ] Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- [ ] Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- [ ] Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [APMLP-1779]

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APMLP-1779]: https://datadoghq.atlassian.net/browse/APMLP-1779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
