### PR TITLE
Exclude unused transitive dependencies from Muzzle checks

### DIFF
--- a/dd-java-agent/instrumentation/aws-java/aws-java-sns-1.0/build.gradle
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sns-1.0/build.gradle
@@ -8,6 +8,7 @@ muzzle {
     module = "aws-java-sdk-sns"
     versions = "[1.12.113,2)"
     assertInverse = true
+    excludeDependency 'joda-time:joda-time'
   }
 }
 

--- a/dd-java-agent/instrumentation/cucumber-5.4/build.gradle
+++ b/dd-java-agent/instrumentation/cucumber-5.4/build.gradle
@@ -8,6 +8,7 @@ muzzle {
     group = 'io.cucumber'
     module = 'cucumber-core'
     versions = '[5.4.0,)'
+    excludeDependency 'io.cucumber:query'
   }
 }
 

--- a/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-7.3/build.gradle
+++ b/dd-java-agent/instrumentation/elasticsearch/elasticsearch-transport/elasticsearch-transport-7.3/build.gradle
@@ -9,6 +9,7 @@ muzzle {
     versions = "[7.3,8.0.0)"
     assertInverse = true
     skipVersions = ["7.11.0", "7.17.8"]
+    excludeDependency 'org.apache.logging.log4j:log4j-api'
   }
   pass {
     group = "org.elasticsearch"
@@ -16,6 +17,7 @@ muzzle {
     versions = "[7.3,8.0.0)"
     assertInverse = true
     skipVersions = ["7.11.0", "7.17.8", "8.8.0", "9.3.0"]
+    excludeDependency 'org.apache.logging.log4j:log4j-api'
   }
 }
 

--- a/dd-java-agent/instrumentation/spring/spring-cloud-zuul-2.0/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-cloud-zuul-2.0/build.gradle
@@ -9,6 +9,7 @@ muzzle {
     versions = "[,]"
     extraDependency "com.netflix.zuul:zuul-core:1.3.1"
     extraDependency "javax.servlet:javax.servlet-api:3.1.0"
+    excludeDependency 'org.apache.logging.log4j:log4j-to-slf4j'
     assertInverse = true
   }
 }

--- a/dd-java-agent/instrumentation/spring/spring-rabbit-1.5/build.gradle
+++ b/dd-java-agent/instrumentation/spring/spring-rabbit-1.5/build.gradle
@@ -8,6 +8,7 @@ muzzle {
     module = 'spring-boot-starter-amqp'
     versions = '[1.5.0.RELEASE,3)'
     extraDependency 'com.rabbitmq:amqp-client:2.7.0'
+    excludeDependency 'org.apache.logging.log4j:log4j-to-slf4j'
   }
 }
 


### PR DESCRIPTION
# What Does This Do

Exclude unused transitive dependencies from generated Muzzle configurations:

- Log4j API from the Elasticsearch transport 7.3 directives
- Log4j-to-SLF4J from the Spring Rabbit 1.5 and Spring Cloud Zuul 2.0 directives
- Joda-Time from the AWS SNS 1.0 directive
- Cucumber Query from the Cucumber 5.4 directive

# Motivation

Muzzle resolves the complete transitive graph of every tested coordinate, including dependencies that the instrumentation does not reference.

The Log4j dependencies require parent POMs that Depot rejects with `403 Forbidden`. Falling back to Maven Central then receives `429 Too Many Requests`. The AWS SNS inverse check for version 1.9.0 similarly reaches a dynamic `joda-time:[2.2,)` dependency. Cucumber formatter dependencies also introduce dynamic `io.cucumber:query` ranges. Resolving either range requests rate-limited Maven metadata.

These resolution errors happen before Muzzle can perform compatibility validation. Excluding the unused artifacts keeps the generated classpaths focused on dependencies needed for linkage. Instrumentation compile, test, and runtime dependencies are unchanged, as are direct checks of the Log4j instrumentation.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR
