### PR TITLE
Avoid Maven Central fallback when proxy is configured

### DIFF
--- a/buildSrc/src/main/kotlin/datadog/gradle/plugin/muzzle/MuzzleMavenRepoUtils.kt
+++ b/buildSrc/src/main/kotlin/datadog/gradle/plugin/muzzle/MuzzleMavenRepoUtils.kt
@@ -38,7 +38,8 @@ internal object MuzzleMavenRepoUtils {
       listOf(central)
     } else {
       val proxy = RemoteRepository.Builder("central-proxy", "default", mavenProxyUrl).build()
-      listOf(proxy, central)
+      // TODO: temporary hack for Maven Central rate limiting
+      listOf(proxy /*, central*/)
     }
   }
 

--- a/buildSrc/src/test/kotlin/datadog/gradle/plugin/muzzle/MuzzleMavenRepoUtilsTest.kt
+++ b/buildSrc/src/test/kotlin/datadog/gradle/plugin/muzzle/MuzzleMavenRepoUtilsTest.kt
@@ -9,6 +9,7 @@ import org.eclipse.aether.resolution.VersionRangeResolutionException
 import org.eclipse.aether.resolution.VersionRangeResult
 import org.eclipse.aether.util.version.GenericVersionScheme
 import org.gradle.api.GradleException
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
@@ -128,7 +129,9 @@ class MuzzleMavenRepoUtilsTest {
       .containsExactly("central" to MAVEN_CENTRAL_URL)
   }
 
+  // TODO: Re-enable after removing the temporary Maven Central rate limiting workaround.
   @Test
+  @Disabled("Temporarily using the configured proxy without a Maven Central fallback")
   @EnabledIfEnvironmentVariable(named = "MAVEN_REPOSITORY_PROXY", matches = ".*")
   fun `defaultMuzzleRepos queries the configured proxy before Maven Central`() {
     val proxyUrl = System.getenv("MAVEN_REPOSITORY_PROXY")

--- a/gradle/repositories.gradle
+++ b/gradle/repositories.gradle
@@ -9,7 +9,10 @@ repositories {
       allowInsecureProtocol = true
     }
   }
-  mavenCentral()
+  // TODO: temporary fix for Maven Central rate limiting
+  else {
+    mavenCentral()
+  }
   // add maven central repository for snapshot dependencies
   maven {
     content {


### PR DESCRIPTION
# What Does This Do
This is a **temporary workaround** for Maven Central rate limiting. The previous Muzzle fallback remains visible in a comment for straightforward restoration, and the test that asserts the fallback is disabled with a corresponding TODO.

When a Maven repository proxy is configured, use it instead of retaining Maven Central as a fallback for project dependency resolution and Muzzle version discovery.

# Motivation

Adding the proxy before Maven Central did not isolate CI from Maven Central. Gradle dynamic-version resolution and Muzzle's Aether version-range resolution can inspect every configured repository, so CI continued making direct Maven Central requests and received HTTP 429 responses.

Combining repository metadata also allowed Muzzle to discover a newly published dependency version from Maven Central before it was available through the configured proxy. Muzzle then generated compatibility tasks for a version that the proxy could not resolve. Making version discovery proxy-only keeps the generated task set aligned with the artifacts available to the build.

# Additional Notes

Representative failure evidence:

    Could not GET 'https://repo.maven.apache.org/maven2/.../maven-metadata.xml'.
    Received status code 429 from server: Too Many Requests

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: N/A
