### PR TITLE
Avoid Maven Central fallback in build setup

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -13,10 +13,8 @@ pluginManagement {
         isAllowInsecureProtocol = true
       }
     }
+    gradlePluginPortal()
     // TODO: temporary fix for Maven Central rate limiting
-    if (!settings.extra.has("gradlePluginProxy")) {
-      gradlePluginPortal()
-    }
     if (!settings.extra.has("mavenRepositoryProxy")) {
       mavenCentral()
     }
@@ -31,22 +29,14 @@ dependencyResolutionManagement {
   }
   repositories {
     mavenLocal()
-    // TODO: temporary fix for Maven Central rate limiting
-    if (settings.extra.has("gradlePluginProxy")) {
-      maven {
-        url = uri(settings.extra["gradlePluginProxy"] as String)
-        isAllowInsecureProtocol = true
-      }
-    }
     if (settings.extra.has("mavenRepositoryProxy")) {
       maven {
         url = uri(settings.extra["mavenRepositoryProxy"] as String)
         isAllowInsecureProtocol = true
       }
     }
-    if (!settings.extra.has("gradlePluginProxy")) {
-      gradlePluginPortal()
-    }
+    gradlePluginPortal()
+    // TODO: temporary fix for Maven Central rate limiting
     if (!settings.extra.has("mavenRepositoryProxy")) {
       mavenCentral()
     }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -13,8 +13,13 @@ pluginManagement {
         isAllowInsecureProtocol = true
       }
     }
-    gradlePluginPortal()
-    mavenCentral()
+    // TODO: temporary fix for Maven Central rate limiting
+    if (!settings.extra.has("gradlePluginProxy")) {
+      gradlePluginPortal()
+    }
+    if (!settings.extra.has("mavenRepositoryProxy")) {
+      mavenCentral()
+    }
   }
 }
 
@@ -26,14 +31,25 @@ dependencyResolutionManagement {
   }
   repositories {
     mavenLocal()
+    // TODO: temporary fix for Maven Central rate limiting
+    if (settings.extra.has("gradlePluginProxy")) {
+      maven {
+        url = uri(settings.extra["gradlePluginProxy"] as String)
+        isAllowInsecureProtocol = true
+      }
+    }
     if (settings.extra.has("mavenRepositoryProxy")) {
       maven {
         url = uri(settings.extra["mavenRepositoryProxy"] as String)
         isAllowInsecureProtocol = true
       }
     }
-    gradlePluginPortal()
-    mavenCentral()
+    if (!settings.extra.has("gradlePluginProxy")) {
+      gradlePluginPortal()
+    }
+    if (!settings.extra.has("mavenRepositoryProxy")) {
+      mavenCentral()
+    }
     // Hosts gradle-tooling-api; used by the smoke-test plugin to run nested Gradle builds
     // pinned to older Gradle versions.
     maven {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -84,7 +84,15 @@ gradlePlugin {
 apply(from = "$rootDir/../gradle/repositories.gradle")
 
 repositories {
-  gradlePluginPortal()
+  // TODO: temporary fix for Maven Central rate limiting
+  if (rootProject.hasProperty("gradlePluginProxy")) {
+    maven {
+      url = uri(rootProject.property("gradlePluginProxy") as String)
+      isAllowInsecureProtocol = true
+    }
+  } else {
+    gradlePluginPortal()
+  }
 }
 
 dependencies {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -84,15 +84,7 @@ gradlePlugin {
 apply(from = "$rootDir/../gradle/repositories.gradle")
 
 repositories {
-  // TODO: temporary fix for Maven Central rate limiting
-  if (rootProject.hasProperty("gradlePluginProxy")) {
-    maven {
-      url = uri(rootProject.property("gradlePluginProxy") as String)
-      isAllowInsecureProtocol = true
-    }
-  } else {
-    gradlePluginPortal()
-  }
+  gradlePluginPortal()
 }
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,10 +14,8 @@ pluginManagement {
         isAllowInsecureProtocol = true
       }
     }
+    gradlePluginPortal()
     // TODO: temporary fix for Maven Central rate limiting
-    if (!settings.extra.has("gradlePluginProxy")) {
-      gradlePluginPortal()
-    }
     if (!settings.extra.has("mavenRepositoryProxy")) {
       mavenCentral()
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,8 +14,13 @@ pluginManagement {
         isAllowInsecureProtocol = true
       }
     }
-    gradlePluginPortal()
-    mavenCentral()
+    // TODO: temporary fix for Maven Central rate limiting
+    if (!settings.extra.has("gradlePluginProxy")) {
+      gradlePluginPortal()
+    }
+    if (!settings.extra.has("mavenRepositoryProxy")) {
+      mavenCentral()
+    }
     // Hosts gradle-tooling-api, a transitive dep of the build-logic:smoke-test plugin used
     // to run nested Gradle builds for smoke-test applications pinned to older Gradle versions.
     maven {


### PR DESCRIPTION
# What Does This Do

Avoids adding explicit Maven Central repositories when a Maven proxy is configured. Gradle Plugin Portal remains enabled for plugin markers.

# Motivation

Temporary workaround for Maven Central rate limiting during dependency-cache population.

# Additional Notes

Follow-up to #12403. Plugin repository handling remains unchanged because the configured proxy does not resolve every plugin marker.

Validation: `./gradlew help` and `./gradlew spotlessKotlinGradleCheck`

# Contributor Checklist

Required labels are applied.

Jira ticket: [N/A]