### PR TITLE
refactor(propagation): Parse OpenTelemetry tracestate member

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -286,8 +286,7 @@ public class HttpCodec {
         ExtractedContext traceContext,
         ExtractionCache<C> extractionCache) {
       // Propagate newly extracted W3C tracestate to first valid context
-      String extractedTracestate = traceContext.getPropagationTags().getW3CTracestate();
-      firstContext.getPropagationTags().updateW3CTracestate(extractedTracestate);
+      firstContext.getPropagationTags().updateW3CTracestateFrom(traceContext.getPropagationTags());
       // Check if parent spans differ to reconcile them
       if (firstContext.getSpanId() != traceContext.getSpanId()) {
         // Override parent span id with W3C one

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
@@ -95,6 +95,11 @@ public abstract class PropagationTags {
    */
   public abstract void updateW3CTracestate(String tracestate);
 
+  /** Updates the original W3C tracestate header from {@code source}. */
+  public void updateW3CTracestateFrom(PropagationTags source) {
+    updateW3CTracestate(source.getW3CTracestate());
+  }
+
   /**
    * Constructs a header value that includes valid propagated _dd.p.* tags and possibly a new
    * sampling decision tag _dd.p.dm based on the current state. Returns null if the value length

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -1,0 +1,30 @@
+package datadog.trace.core.propagation.ptags;
+
+final class OtelTraceState {
+  private final String value;
+  private final int inheritedPosition;
+
+  private OtelTraceState(String value, int inheritedPosition) {
+    this.value = value;
+    this.inheritedPosition = inheritedPosition;
+  }
+
+  static OtelTraceState parse(String raw, int inheritedPosition) {
+    if (raw == null || raw.isEmpty()) {
+      return null;
+    }
+    return new OtelTraceState(raw, inheritedPosition);
+  }
+
+  String getValue() {
+    return value;
+  }
+
+  int length() {
+    return value.length();
+  }
+
+  int getInheritedPosition() {
+    return inheritedPosition;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -5,18 +5,18 @@ final class OtelTraceState {
   private final int originalPosition;
   private final int originalSize;
 
-  private OtelTraceState(String value, int inheritedPosition, int originalMemberContributionSize) {
+  private OtelTraceState(String value, int originalPosition, int originalSize) {
     this.value = value;
-    this.originalPosition = inheritedPosition;
-    this.originalSize = originalMemberContributionSize;
+    this.originalPosition = originalPosition;
+    this.originalSize = originalSize;
   }
 
   static OtelTraceState parse(
-      String raw, int inheritedPosition, int originalMemberContributionSize) {
+      String raw, int originalPosition, int originalSize) {
     if (raw == null || raw.isEmpty()) {
       return null;
     }
-    return new OtelTraceState(raw, inheritedPosition, originalMemberContributionSize);
+    return new OtelTraceState(raw, originalPosition, originalSize);
   }
 
   String getValue() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -2,13 +2,13 @@ package datadog.trace.core.propagation.ptags;
 
 final class OtelTraceState {
   private final String value;
-  private final int inheritedPosition;
-  private final int originalMemberContributionSize;
+  private final int originalPosition;
+  private final int originalSize;
 
   private OtelTraceState(String value, int inheritedPosition, int originalMemberContributionSize) {
     this.value = value;
-    this.inheritedPosition = inheritedPosition;
-    this.originalMemberContributionSize = originalMemberContributionSize;
+    this.originalPosition = inheritedPosition;
+    this.originalSize = originalMemberContributionSize;
   }
 
   static OtelTraceState parse(
@@ -27,11 +27,11 @@ final class OtelTraceState {
     return value.length();
   }
 
-  int getInheritedPosition() {
-    return inheritedPosition;
+  int getOriginalPosition() {
+    return originalPosition;
   }
 
-  int getOriginalMemberContributionSize() {
-    return originalMemberContributionSize;
+  int getOriginalSize() {
+    return originalSize;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -11,8 +11,7 @@ final class OtelTraceState {
     this.originalSize = originalSize;
   }
 
-  static OtelTraceState parse(
-      String raw, int originalPosition, int originalSize) {
+  static OtelTraceState parse(String raw, int originalPosition, int originalSize) {
     if (raw == null || raw.isEmpty()) {
       return null;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -3,17 +3,20 @@ package datadog.trace.core.propagation.ptags;
 final class OtelTraceState {
   private final String value;
   private final int inheritedPosition;
+  private final int originalMemberContributionSize;
 
-  private OtelTraceState(String value, int inheritedPosition) {
+  private OtelTraceState(String value, int inheritedPosition, int originalMemberContributionSize) {
     this.value = value;
     this.inheritedPosition = inheritedPosition;
+    this.originalMemberContributionSize = originalMemberContributionSize;
   }
 
-  static OtelTraceState parse(String raw, int inheritedPosition) {
+  static OtelTraceState parse(
+      String raw, int inheritedPosition, int originalMemberContributionSize) {
     if (raw == null || raw.isEmpty()) {
       return null;
     }
-    return new OtelTraceState(raw, inheritedPosition);
+    return new OtelTraceState(raw, inheritedPosition, originalMemberContributionSize);
   }
 
   String getValue() {
@@ -26,5 +29,9 @@ final class OtelTraceState {
 
   int getInheritedPosition() {
     return inheritedPosition;
+  }
+
+  int getOriginalMemberContributionSize() {
+    return originalMemberContributionSize;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
@@ -112,6 +112,8 @@ public class PTagsFactory implements PropagationTags.Factory {
 
     private volatile TagValue orgPropagationMarkerTagValue;
 
+    private volatile OtelTraceState otelTraceState;
+
     // Static cache for the most-recently-seen rate → TagValue. In steady state a service uses one
     // rate, so this eliminates the char[] + String allocation on every new PTags instance.
     // Writes are benign-racy: two threads computing the same rate produce equal TagValues.
@@ -540,7 +542,20 @@ public class PTagsFactory implements PropagationTags.Factory {
 
     @Override
     public void updateW3CTracestate(String tracestate) {
+      clearCachedHeader(W3C);
       this.tracestate = tracestate;
+      setOtelTraceState(W3CPTagsCodec.extractOtelTraceState(tracestate));
+    }
+
+    OtelTraceState getOtelTraceState() {
+      return otelTraceState;
+    }
+
+    void setOtelTraceState(OtelTraceState otelTraceState) {
+      if (this.otelTraceState != otelTraceState) {
+        this.otelTraceState = otelTraceState;
+        clearCachedHeader(W3C);
+      }
     }
 
     String getError() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
@@ -542,9 +542,23 @@ public class PTagsFactory implements PropagationTags.Factory {
 
     @Override
     public void updateW3CTracestate(String tracestate) {
+      setW3CTracestate(tracestate, W3CPTagsCodec.extractOtelTraceState(tracestate));
+    }
+
+    @Override
+    public void updateW3CTracestateFrom(PropagationTags source) {
+      if (!(source instanceof PTags)) {
+        super.updateW3CTracestateFrom(source);
+        return;
+      }
+      PTags sourcePTags = (PTags) source;
+      setW3CTracestate(sourcePTags.tracestate, sourcePTags.getOtelTraceState());
+    }
+
+    private void setW3CTracestate(String tracestate, OtelTraceState otelTraceState) {
       clearCachedHeader(W3C);
       this.tracestate = tracestate;
-      setOtelTraceState(W3CPTagsCodec.extractOtelTraceState(tracestate));
+      this.otelTraceState = otelTraceState;
     }
 
     OtelTraceState getOtelTraceState() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -50,13 +50,19 @@ public class W3CPTagsCodec extends PTagsCodec {
     int ddMemberValueEnd = -1; // dd member value end position including OWS (exclusive)
     int memberIndex = 0;
     int ddMemberIndex = -1;
+    int otelMemberValueStart = -1;
+    int otelMemberValueEnd = -1;
+    int otelMemberPosition = 0;
+    int otherMemberPosition = 0;
     while (memberStart < len) {
       if (memberIndex == MAX_MEMBER_COUNT) {
         // TODO should we return one with an error?
         // TODO should we try to pick up the `dd` member anyway?
         return tagsFactory.empty();
       }
-      if (ddMemberIndex == -1 && value.startsWith(DATADOG_MEMBER_KEY, memberStart)) {
+      boolean datadogMember = value.startsWith(DATADOG_MEMBER_KEY, memberStart);
+      boolean otelMember = value.startsWith(OTEL_MEMBER_KEY, memberStart);
+      if (ddMemberIndex == -1 && datadogMember) {
         ddMemberStart = memberStart;
         ddMemberIndex = memberIndex;
       }
@@ -69,6 +75,7 @@ public class W3CPTagsCodec extends PTagsCodec {
       if (ddMemberValueStart == -1 && ddMemberIndex != -1) {
         ddMemberValueStart = pos;
       }
+      int memberValueStart = pos;
       pos = validateMemberValue(value, pos);
       if (pos < 0) {
         // TODO should we return one with an error?
@@ -76,6 +83,15 @@ public class W3CPTagsCodec extends PTagsCodec {
       }
       if (ddMemberValueEnd == -1 && ddMemberIndex != -1) {
         ddMemberValueEnd = pos;
+      }
+      if (otelMemberValueStart == -1) {
+        if (otelMember) {
+          otelMemberValueStart = memberValueStart;
+          otelMemberValueEnd = stripTrailingOWC(value, memberValueStart, pos);
+          otelMemberPosition = otherMemberPosition;
+        } else if (!datadogMember) {
+          otherMemberPosition++;
+        }
       }
       memberStart = findNextMember(value, pos);
       if (memberStart < 0) {
@@ -85,9 +101,15 @@ public class W3CPTagsCodec extends PTagsCodec {
       memberIndex++;
     }
 
+    OtelTraceState otelTraceState =
+        otelMemberValueStart < 0
+            ? null
+            : OtelTraceState.parse(
+                value.substring(otelMemberValueStart, otelMemberValueEnd), otelMemberPosition);
+
     if (ddMemberIndex == -1) {
       // There was no dd member, so create an empty one with the _suffix_
-      return empty(tagsFactory, value, extractOtelTraceState(value));
+      return empty(tagsFactory, value, otelTraceState);
     }
 
     List<TagElement> tagPairs = null;
@@ -159,7 +181,13 @@ public class W3CPTagsCodec extends PTagsCodec {
               if (tagKey.equals(TRACE_ID_TAG)) {
                 return tagsFactory.createInvalid(PROPAGATION_ERROR_MALFORMED_TID + tagValue);
               }
-              return empty(tagsFactory, value, firstMemberStart, ddMemberStart, ddMemberValueEnd);
+              return empty(
+                  tagsFactory,
+                  value,
+                  firstMemberStart,
+                  ddMemberStart,
+                  ddMemberValueEnd,
+                  otelTraceState);
             }
             if (tagKey.equals(DECISION_MAKER_TAG)) {
               decisionMakerTagValue = tagValue;
@@ -203,7 +231,7 @@ public class W3CPTagsCodec extends PTagsCodec {
         maxUnknownSize,
         lastParentId,
         orgPropagationMarkerTagValue,
-        extractOtelTraceState(value));
+        otelTraceState);
   }
 
   @Override
@@ -801,21 +829,6 @@ public class W3CPTagsCodec extends PTagsCodec {
   private static W3CPTags empty(
       PTagsFactory factory, String original, OtelTraceState otelTraceState) {
     return empty(factory, original, 0, -1, -1, otelTraceState);
-  }
-
-  private static W3CPTags empty(
-      PTagsFactory factory,
-      String original,
-      int firstMemberStart,
-      int ddMemberStart,
-      int ddMemberValueEnd) {
-    return empty(
-        factory,
-        original,
-        firstMemberStart,
-        ddMemberStart,
-        ddMemberValueEnd,
-        extractOtelTraceState(original));
   }
 
   private static W3CPTags empty(

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -21,6 +21,7 @@ public class W3CPTagsCodec extends PTagsCodec {
 
   private static final int MAX_HEADER_SIZE = 256;
   private static final String DATADOG_MEMBER_KEY = "dd=";
+  private static final String OTEL_MEMBER_KEY = "ot=";
   private static final int EMPTY_SIZE = DATADOG_MEMBER_KEY.length(); // 3
   private static final char MEMBER_SEPARATOR = ',';
   private static final char ELEMENT_SEPARATOR = ';';
@@ -86,7 +87,7 @@ public class W3CPTagsCodec extends PTagsCodec {
 
     if (ddMemberIndex == -1) {
       // There was no dd member, so create an empty one with the _suffix_
-      return empty(tagsFactory, value);
+      return empty(tagsFactory, value, extractOtelTraceState(value));
     }
 
     List<TagElement> tagPairs = null;
@@ -201,7 +202,8 @@ public class W3CPTagsCodec extends PTagsCodec {
         ddMemberValueEnd,
         maxUnknownSize,
         lastParentId,
-        orgPropagationMarkerTagValue);
+        orgPropagationMarkerTagValue,
+        extractOtelTraceState(value));
   }
 
   @Override
@@ -225,6 +227,10 @@ public class W3CPTagsCodec extends PTagsCodec {
     } else if (pTags.tracestate != null) {
       // We assume there is no Datadog list-member
       size += pTags.tracestate.length();
+    }
+    OtelTraceState otelTraceState = pTags.getOtelTraceState();
+    if (otelTraceState != null) {
+      size += OTEL_MEMBER_KEY.length() + otelTraceState.length() + 1;
     }
     return size;
   }
@@ -290,9 +296,8 @@ public class W3CPTagsCodec extends PTagsCodec {
       sb.setLength(0);
       size = 0;
     }
-    // Append all other non-Datadog list-members
-    int newSize = cleanUpAndAppendSuffix(sb, ptags, size);
-    if (newSize != size) {
+    // Append the managed OTel member and all other non-Datadog list-members
+    if (appendOtelAndVendorMembers(sb, ptags, size != 0)) {
       // We don't care about the total size in bytes here, but only the fact that we added something
       // that should be returned
       size = Math.max(size, EMPTY_SIZE + 1);
@@ -698,50 +703,104 @@ public class W3CPTagsCodec extends PTagsCodec {
     return size;
   }
 
-  private static int cleanUpAndAppendSuffix(StringBuilder sb, PTags ptags, int size) {
+  private static boolean appendOtelAndVendorMembers(
+      StringBuilder sb, PTags ptags, boolean hasDatadogMember) {
     String original = ptags.tracestate;
-    if (original == null) {
-      return size;
-    }
-    int ddMemberStart = (ptags instanceof W3CPTags) ? ((W3CPTags) ptags).ddMemberStart : -1;
-    int remainingMemberAllowed = size == 0 ? MAX_MEMBER_COUNT : MAX_MEMBER_COUNT - 1;
-    int len = original.length();
-    int memberStart = findNextMember(original, 0);
-    while (memberStart < len) {
+    OtelTraceState otelTraceState = ptags.getOtelTraceState();
+    int remainingMembers = MAX_MEMBER_COUNT - (hasDatadogMember ? 1 : 0);
+    int otherMemberPosition = 0;
+    boolean otelTraceStateAppended = false;
+    boolean memberAppended = false;
+    int len = original == null ? 0 : original.length();
+    int memberStart = original == null ? 0 : findNextMember(original, 0);
+    while (memberStart < len && remainingMembers > 0) {
       // Look for member end position
       int memberEnd = original.indexOf(MEMBER_SEPARATOR, memberStart);
       if (memberEnd < 0) {
         memberEnd = len;
       }
-      // Try to define Datadog member start if not already found
-      if (ddMemberStart == -1) {
-        if (original.startsWith(DATADOG_MEMBER_KEY, memberStart)) {
-          ddMemberStart = memberStart;
-        }
-      }
-      // Skip Datadog member (already added with prefix and tags)
-      if (memberStart != ddMemberStart) {
-        if (sb.length() > 0) {
-          sb.append(MEMBER_SEPARATOR);
-          size++;
+      boolean managedMember =
+          original.startsWith(DATADOG_MEMBER_KEY, memberStart)
+              || original.startsWith(OTEL_MEMBER_KEY, memberStart);
+      if (!managedMember) {
+        if (otelTraceState != null
+            && !otelTraceStateAppended
+            && otelTraceState.getInheritedPosition() == otherMemberPosition) {
+          appendMember(sb, OTEL_MEMBER_KEY, otelTraceState.getValue());
+          remainingMembers--;
+          otelTraceStateAppended = true;
+          memberAppended = true;
+          if (remainingMembers == 0) {
+            break;
+          }
         }
         int end = stripTrailingOWC(original, memberStart, memberEnd);
-        sb.append(original, memberStart, end);
-        size += (end - memberStart);
-        remainingMemberAllowed--;
+        appendMember(sb, original, memberStart, end);
+        remainingMembers--;
+        otherMemberPosition++;
+        memberAppended = true;
       }
-      // Check if remaining members are allowed
-      if (remainingMemberAllowed == 0) {
-        memberStart = len;
-      } else {
-        memberStart = findNextMember(original, memberEnd + 1);
-      }
+      memberStart = findNextMember(original, memberEnd + 1);
     }
-    return size;
+    if (otelTraceState != null
+        && !otelTraceStateAppended
+        && remainingMembers > 0
+        && otelTraceState.getInheritedPosition() == otherMemberPosition) {
+      appendMember(sb, OTEL_MEMBER_KEY, otelTraceState.getValue());
+      memberAppended = true;
+    }
+    return memberAppended;
+  }
+
+  private static void appendMember(StringBuilder sb, String member, int start, int end) {
+    if (sb.length() != 0) {
+      sb.append(MEMBER_SEPARATOR);
+    }
+    sb.append(member, start, end);
+  }
+
+  private static void appendMember(StringBuilder sb, String key, String value) {
+    if (sb.length() != 0) {
+      sb.append(MEMBER_SEPARATOR);
+    }
+    sb.append(key).append(value);
+  }
+
+  static OtelTraceState extractOtelTraceState(String tracestate) {
+    if (tracestate == null || tracestate.isEmpty()) {
+      return null;
+    }
+    int otherMemberPosition = 0;
+    int memberStart = findNextMember(tracestate, 0);
+    while (memberStart < tracestate.length()) {
+      int memberValueStart = validateMemberKey(tracestate, memberStart);
+      if (memberValueStart < 0) {
+        return null;
+      }
+      int memberValueEnd = validateMemberValue(tracestate, memberValueStart);
+      if (memberValueEnd < 0) {
+        return null;
+      }
+      if (tracestate.startsWith(OTEL_MEMBER_KEY, memberStart)) {
+        int end = stripTrailingOWC(tracestate, memberValueStart, memberValueEnd);
+        return OtelTraceState.parse(
+            tracestate.substring(memberValueStart, end), otherMemberPosition);
+      }
+      if (!tracestate.startsWith(DATADOG_MEMBER_KEY, memberStart)) {
+        otherMemberPosition++;
+      }
+      memberStart = findNextMember(tracestate, memberValueEnd);
+    }
+    return null;
   }
 
   static W3CPTags empty(PTagsFactory factory, String original) {
-    return empty(factory, original, 0, -1, -1);
+    return empty(factory, original, extractOtelTraceState(original));
+  }
+
+  private static W3CPTags empty(
+      PTagsFactory factory, String original, OtelTraceState otelTraceState) {
+    return empty(factory, original, 0, -1, -1, otelTraceState);
   }
 
   private static W3CPTags empty(
@@ -750,6 +809,22 @@ public class W3CPTagsCodec extends PTagsCodec {
       int firstMemberStart,
       int ddMemberStart,
       int ddMemberValueEnd) {
+    return empty(
+        factory,
+        original,
+        firstMemberStart,
+        ddMemberStart,
+        ddMemberValueEnd,
+        extractOtelTraceState(original));
+  }
+
+  private static W3CPTags empty(
+      PTagsFactory factory,
+      String original,
+      int firstMemberStart,
+      int ddMemberStart,
+      int ddMemberValueEnd,
+      OtelTraceState otelTraceState) {
     return new W3CPTags(
         factory,
         null,
@@ -764,7 +839,8 @@ public class W3CPTagsCodec extends PTagsCodec {
         ddMemberValueEnd,
         0,
         null,
-        null);
+        null,
+        otelTraceState);
   }
 
   private static class W3CPTags extends PTags {
@@ -799,7 +875,8 @@ public class W3CPTagsCodec extends PTagsCodec {
         int ddMemberValueEnd,
         int maxUnknownSize,
         CharSequence lastParentId,
-        TagValue orgPropagationMarkerTagValue) {
+        TagValue orgPropagationMarkerTagValue,
+        OtelTraceState otelTraceState) {
       super(
           factory,
           tagPairs,
@@ -815,6 +892,7 @@ public class W3CPTagsCodec extends PTagsCodec {
       this.ddMemberStart = ddMemberStart;
       this.ddMemberValueEnd = ddMemberValueEnd;
       this.maxUnknownSize = maxUnknownSize;
+      setOtelTraceState(otelTraceState);
     }
 
     @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -50,6 +50,7 @@ public class W3CPTagsCodec extends PTagsCodec {
     int ddMemberValueEnd = -1; // dd member value end position including OWS (exclusive)
     int memberIndex = 0;
     int ddMemberIndex = -1;
+    OtelTraceState otelTraceState = null;
     while (memberStart < len) {
       if (memberIndex == MAX_MEMBER_COUNT) {
         // TODO should we return one with an error?

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -50,8 +50,10 @@ public class W3CPTagsCodec extends PTagsCodec {
     int ddMemberValueEnd = -1; // dd member value end position including OWS (exclusive)
     int memberIndex = 0;
     int ddMemberIndex = -1;
+    int otelMemberStart = -1;
     int otelMemberValueStart = -1;
     int otelMemberValueEnd = -1;
+    int otelMemberEnd = -1;
     int otelMemberPosition = 0;
     int otherMemberPosition = 0;
     while (memberStart < len) {
@@ -86,8 +88,10 @@ public class W3CPTagsCodec extends PTagsCodec {
       }
       if (otelMemberValueStart == -1) {
         if (otelMember) {
+          otelMemberStart = memberStart;
           otelMemberValueStart = memberValueStart;
           otelMemberValueEnd = stripTrailingOWC(value, memberValueStart, pos);
+          otelMemberEnd = pos;
           otelMemberPosition = otherMemberPosition;
         } else if (!datadogMember) {
           otherMemberPosition++;
@@ -105,7 +109,9 @@ public class W3CPTagsCodec extends PTagsCodec {
         otelMemberValueStart < 0
             ? null
             : OtelTraceState.parse(
-                value.substring(otelMemberValueStart, otelMemberValueEnd), otelMemberPosition);
+                value.substring(otelMemberValueStart, otelMemberValueEnd),
+                otelMemberPosition,
+                memberContributionSize(value, firstMemberStart, otelMemberStart, otelMemberEnd));
 
     if (ddMemberIndex == -1) {
       // There was no dd member, so create an empty one with the _suffix_
@@ -245,19 +251,23 @@ public class W3CPTagsCodec extends PTagsCodec {
     if (pTags.getSamplingPriority() != PrioritySampling.UNSET) {
       size += 5; // 's:-?[0-9]' + delimiter
     }
+    boolean includesOriginalTracestate = false;
     if (pTags instanceof W3CPTags) {
       W3CPTags w3CPTags = (W3CPTags) pTags;
       size += w3CPTags.maxUnknownSize;
       if (w3CPTags.ddMemberStart != -1) {
         size +=
             (w3CPTags.tracestate.length() - (w3CPTags.ddMemberValueEnd - w3CPTags.ddMemberStart));
+        includesOriginalTracestate = true;
       }
     } else if (pTags.tracestate != null) {
       // We assume there is no Datadog list-member
       size += pTags.tracestate.length();
+      includesOriginalTracestate = true;
     }
     OtelTraceState otelTraceState = pTags.getOtelTraceState();
     if (otelTraceState != null) {
+      size -= includesOriginalTracestate ? otelTraceState.getOriginalMemberContributionSize() : 0;
       size += OTEL_MEMBER_KEY.length() + otelTraceState.length() + 1;
     }
     return size;
@@ -799,7 +809,8 @@ public class W3CPTagsCodec extends PTagsCodec {
       return null;
     }
     int otherMemberPosition = 0;
-    int memberStart = findNextMember(tracestate, 0);
+    int firstMemberStart = findNextMember(tracestate, 0);
+    int memberStart = firstMemberStart;
     while (memberStart < tracestate.length()) {
       int memberValueStart = validateMemberKey(tracestate, memberStart);
       if (memberValueStart < 0) {
@@ -812,7 +823,9 @@ public class W3CPTagsCodec extends PTagsCodec {
       if (tracestate.startsWith(OTEL_MEMBER_KEY, memberStart)) {
         int end = stripTrailingOWC(tracestate, memberValueStart, memberValueEnd);
         return OtelTraceState.parse(
-            tracestate.substring(memberValueStart, end), otherMemberPosition);
+            tracestate.substring(memberValueStart, end),
+            otherMemberPosition,
+            memberContributionSize(tracestate, firstMemberStart, memberStart, memberValueEnd));
       }
       if (!tracestate.startsWith(DATADOG_MEMBER_KEY, memberStart)) {
         otherMemberPosition++;
@@ -820,6 +833,13 @@ public class W3CPTagsCodec extends PTagsCodec {
       memberStart = findNextMember(tracestate, memberValueEnd);
     }
     return null;
+  }
+
+  private static int memberContributionSize(
+      String tracestate, int firstMemberStart, int memberStart, int memberEnd) {
+    int memberSize = memberEnd - memberStart;
+    boolean isOnlyMember = memberStart == firstMemberStart && memberEnd == tracestate.length();
+    return isOnlyMember ? memberSize : memberSize + 1;
   }
 
   static W3CPTags empty(PTagsFactory factory, String original) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -57,19 +57,19 @@ public class W3CPTagsCodec extends PTagsCodec {
     int otelMemberPosition = 0;
     int otherMemberPosition = 0;
     while (memberStart < len) {
+      int currentMemberStart = memberStart;
       if (memberIndex == MAX_MEMBER_COUNT) {
         // TODO should we return one with an error?
         // TODO should we try to pick up the `dd` member anyway?
         return tagsFactory.empty();
       }
-      boolean datadogMember = value.startsWith(DATADOG_MEMBER_KEY, memberStart);
-      boolean otelMember = value.startsWith(OTEL_MEMBER_KEY, memberStart);
+      boolean datadogMember = value.startsWith(DATADOG_MEMBER_KEY, currentMemberStart);
       if (ddMemberIndex == -1 && datadogMember) {
-        ddMemberStart = memberStart;
+        ddMemberStart = currentMemberStart;
         ddMemberIndex = memberIndex;
       }
       // Validate the member key
-      int pos = validateMemberKey(value, memberStart);
+      int pos = validateMemberKey(value, currentMemberStart);
       if (pos < 0) {
         // TODO should we return one with an error?
         return tagsFactory.empty();
@@ -86,23 +86,28 @@ public class W3CPTagsCodec extends PTagsCodec {
       if (ddMemberValueEnd == -1 && ddMemberIndex != -1) {
         ddMemberValueEnd = pos;
       }
-      if (otelMemberValueStart == -1) {
-        if (otelMember) {
-          otelMemberStart = memberStart;
-          otelMemberValueStart = memberValueStart;
-          otelMemberValueEnd = stripTrailingOWC(value, memberValueStart, pos);
-          otelMemberEnd = pos;
-          otelMemberPosition = otherMemberPosition;
-        } else if (!datadogMember) {
-          otherMemberPosition++;
-        }
-      }
       memberStart = findNextMember(value, pos);
       if (memberStart < 0) {
         // TODO should we return one with an error?
         return tagsFactory.empty();
       }
       memberIndex++;
+      if (otelMemberValueStart != -1) {
+        continue;
+      }
+      if (datadogMember) {
+        continue;
+      }
+      boolean otelMember = value.startsWith(OTEL_MEMBER_KEY, currentMemberStart);
+      if (otelMember) {
+        otelMemberStart = currentMemberStart;
+        otelMemberValueStart = memberValueStart;
+        otelMemberValueEnd = stripTrailingOWC(value, memberValueStart, pos);
+        otelMemberEnd = pos;
+        otelMemberPosition = otherMemberPosition;
+      } else {
+        otherMemberPosition++;
+      }
     }
 
     OtelTraceState otelTraceState =

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -272,7 +272,7 @@ public class W3CPTagsCodec extends PTagsCodec {
     }
     OtelTraceState otelTraceState = pTags.getOtelTraceState();
     if (otelTraceState != null) {
-      size -= includesOriginalTracestate ? otelTraceState.getOriginalMemberContributionSize() : 0;
+      size -= includesOriginalTracestate ? otelTraceState.getOriginalSize() : 0;
       size += OTEL_MEMBER_KEY.length() + otelTraceState.length() + 1;
     }
     return size;
@@ -768,7 +768,7 @@ public class W3CPTagsCodec extends PTagsCodec {
       if (!managedMember) {
         if (otelTraceState != null
             && !otelTraceStateAppended
-            && otelTraceState.getInheritedPosition() == otherMemberPosition) {
+            && otelTraceState.getOriginalPosition() == otherMemberPosition) {
           appendMember(sb, OTEL_MEMBER_KEY, otelTraceState.getValue());
           remainingMembers--;
           otelTraceStateAppended = true;
@@ -788,7 +788,7 @@ public class W3CPTagsCodec extends PTagsCodec {
     if (otelTraceState != null
         && !otelTraceStateAppended
         && remainingMembers > 0
-        && otelTraceState.getInheritedPosition() == otherMemberPosition) {
+        && otelTraceState.getOriginalPosition() == otherMemberPosition) {
       appendMember(sb, OTEL_MEMBER_KEY, otelTraceState.getValue());
       memberAppended = true;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -50,8 +50,6 @@ public class W3CPTagsCodec extends PTagsCodec {
     int ddMemberValueEnd = -1; // dd member value end position including OWS (exclusive)
     int memberIndex = 0;
     int ddMemberIndex = -1;
-    OtelTraceState otelTraceState = null;
-    int otherMemberPosition = 0;
     while (memberStart < len) {
       if (memberIndex == MAX_MEMBER_COUNT) {
         // TODO should we return one with an error?
@@ -82,14 +80,15 @@ public class W3CPTagsCodec extends PTagsCodec {
         ddMemberIndex = memberIndex;
         ddMemberValueEnd = memberValueEnd;
       } else if (otelMember) {
+        // Position to retain for this member (if left unchanged)
+        // Indexing after an eventual dd= member which will be placed first
+        int memberPosition = memberIndex - (ddMemberStart >= 0 ? 1 : 0);
         otelTraceState =
             OtelTraceState.parse(
                 value.substring(
                     memberValueStart, stripTrailingOWC(value, memberValueStart, memberValueEnd)),
-                otherMemberPosition,
+                memberPosition,
                 memberContributionSize(value, firstMemberStart, memberStart, memberValueEnd));
-      } else {
-        otherMemberPosition++;
       }
 
       memberIndex++;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -50,73 +50,55 @@ public class W3CPTagsCodec extends PTagsCodec {
     int ddMemberValueEnd = -1; // dd member value end position including OWS (exclusive)
     int memberIndex = 0;
     int ddMemberIndex = -1;
-    int otelMemberStart = -1;
-    int otelMemberValueStart = -1;
-    int otelMemberValueEnd = -1;
-    int otelMemberEnd = -1;
-    int otelMemberPosition = 0;
+    OtelTraceState otelTraceState = null;
     int otherMemberPosition = 0;
     while (memberStart < len) {
-      int currentMemberStart = memberStart;
       if (memberIndex == MAX_MEMBER_COUNT) {
         // TODO should we return one with an error?
         // TODO should we try to pick up the `dd` member anyway?
         return tagsFactory.empty();
       }
-      boolean datadogMember = value.startsWith(DATADOG_MEMBER_KEY, currentMemberStart);
-      if (ddMemberIndex == -1 && datadogMember) {
-        ddMemberStart = currentMemberStart;
-        ddMemberIndex = memberIndex;
-      }
       // Validate the member key
-      int pos = validateMemberKey(value, currentMemberStart);
-      if (pos < 0) {
+      int memberValueStart = validateMemberKey(value, memberStart);
+      if (memberValueStart < 0) {
         // TODO should we return one with an error?
         return tagsFactory.empty();
       }
-      if (ddMemberValueStart == -1 && ddMemberIndex != -1) {
-        ddMemberValueStart = pos;
-      }
-      int memberValueStart = pos;
-      pos = validateMemberValue(value, pos);
-      if (pos < 0) {
+      int memberValueEnd = validateMemberValue(value, memberValueStart);
+      if (memberValueEnd < 0) {
         // TODO should we return one with an error?
         return tagsFactory.empty();
       }
-      if (ddMemberValueEnd == -1 && ddMemberIndex != -1) {
-        ddMemberValueEnd = pos;
+
+      boolean datadogMember =
+          ddMemberIndex == -1 && value.startsWith(DATADOG_MEMBER_KEY, memberStart);
+      boolean otelMember =
+          !datadogMember
+              && otelTraceState == null
+              && value.startsWith(OTEL_MEMBER_KEY, memberStart);
+      if (datadogMember) {
+        ddMemberStart = memberStart;
+        ddMemberValueStart = memberValueStart;
+        ddMemberIndex = memberIndex;
+        ddMemberValueEnd = memberValueEnd;
+      } else if (otelMember) {
+        otelTraceState =
+            OtelTraceState.parse(
+                value.substring(
+                    memberValueStart, stripTrailingOWC(value, memberValueStart, memberValueEnd)),
+                otherMemberPosition,
+                memberContributionSize(value, firstMemberStart, memberStart, memberValueEnd));
+      } else {
+        otherMemberPosition++;
       }
-      memberStart = findNextMember(value, pos);
+
+      memberIndex++;
+      memberStart = findNextMember(value, memberValueEnd);
       if (memberStart < 0) {
         // TODO should we return one with an error?
         return tagsFactory.empty();
       }
-      memberIndex++;
-      if (otelMemberValueStart != -1) {
-        continue;
-      }
-      if (datadogMember) {
-        continue;
-      }
-      boolean otelMember = value.startsWith(OTEL_MEMBER_KEY, currentMemberStart);
-      if (otelMember) {
-        otelMemberStart = currentMemberStart;
-        otelMemberValueStart = memberValueStart;
-        otelMemberValueEnd = stripTrailingOWC(value, memberValueStart, pos);
-        otelMemberEnd = pos;
-        otelMemberPosition = otherMemberPosition;
-      } else {
-        otherMemberPosition++;
-      }
     }
-
-    OtelTraceState otelTraceState =
-        otelMemberValueStart < 0
-            ? null
-            : OtelTraceState.parse(
-                value.substring(otelMemberValueStart, otelMemberValueEnd),
-                otelMemberPosition,
-                memberContributionSize(value, firstMemberStart, otelMemberStart, otelMemberEnd));
 
     if (ddMemberIndex == -1) {
       // There was no dd member, so create an empty one with the _suffix_

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateParsingTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateParsingTest.java
@@ -25,7 +25,7 @@ class OtelTraceStateParsingTest {
     assertNotNull(state);
     assertEquals(VALUE, state.getValue());
     assertEquals(VALUE.length(), state.length());
-    assertEquals(INHERITED_POSITION, state.getInheritedPosition());
-    assertEquals(ORIGINAL_MEMBER_CONTRIBUTION_SIZE, state.getOriginalMemberContributionSize());
+    assertEquals(INHERITED_POSITION, state.getOriginalPosition());
+    assertEquals(ORIGINAL_MEMBER_CONTRIBUTION_SIZE, state.getOriginalSize());
   }
 }

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateParsingTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateParsingTest.java
@@ -1,0 +1,31 @@
+package datadog.trace.core.propagation.ptags;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class OtelTraceStateParsingTest {
+  private static final String VALUE = "rv:0123456789abcd";
+  private static final int INHERITED_POSITION = 2;
+  private static final int ORIGINAL_MEMBER_CONTRIBUTION_SIZE = 21;
+
+  @Test
+  void ignoresAbsentValues() {
+    assertNull(OtelTraceState.parse(null, INHERITED_POSITION, ORIGINAL_MEMBER_CONTRIBUTION_SIZE));
+    assertNull(OtelTraceState.parse("", INHERITED_POSITION, ORIGINAL_MEMBER_CONTRIBUTION_SIZE));
+  }
+
+  @Test
+  void retainsValueAndMemberMetadata() {
+    OtelTraceState state =
+        OtelTraceState.parse(VALUE, INHERITED_POSITION, ORIGINAL_MEMBER_CONTRIBUTION_SIZE);
+
+    assertNotNull(state);
+    assertEquals(VALUE, state.getValue());
+    assertEquals(VALUE.length(), state.length());
+    assertEquals(INHERITED_POSITION, state.getInheritedPosition());
+    assertEquals(ORIGINAL_MEMBER_CONTRIBUTION_SIZE, state.getOriginalMemberContributionSize());
+  }
+}


### PR DESCRIPTION
# What Does This Do

Refactors W3C tracestate handling so the OpenTelemetry `ot` member is
represented separately while its value remains opaque.

- Extracts and re-emits the raw `ot` member.
- Preserves its inherited position when rebuilding tracestate.
- Does not interpret `rv` or `th` or connect the member to sampling.

# Motivation

Isolate the tracestate parsing foundation from the consistent-sampling
behavior added by the follow-up PR.

# Additional Notes

This is the first PR in a two-PR stack. The sampling behavior follows in
#12397.

Validation:

- `:dd-trace-core:compileJava`
- `:dd-trace-core:spotlessCheck`
- `git diff --check`

# Contributor Checklist

- [x] Format the title according to the contribution guidelines.
- [x] Assign the required `type:` and `comp:` labels.
- [x] Keep sampling behavior and tests in the follow-up PR.

Jira ticket: [APMAPI-2171]

[APMAPI-2171]: https://datadoghq.atlassian.net/browse/APMAPI-2171
