### PR TITLE
feat(otlp): cache OpenTelemetry trace state in OTLP export

### DIFF
--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceTraceSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceTraceSampler.java
@@ -61,20 +61,13 @@ public class RateByServiceTraceSampler implements Sampler, PrioritySampler, Remo
     boolean sampled = sampler.sample(span);
     int samplingPriority = sampled ? PrioritySampling.SAMPLER_KEEP : PrioritySampling.SAMPLER_DROP;
 
-    if (rates.hasAgentRates()) {
-      span.setSamplingPriority(
-          samplingPriority,
-          SAMPLING_AGENT_RATE,
-          sampler.getSampleRate(),
-          SamplingMechanism.AGENT_RATE,
-          sampled);
-    } else {
-      span.setSamplingPriority(
-          samplingPriority,
-          SAMPLING_AGENT_RATE,
-          sampler.getSampleRate(),
-          SamplingMechanism.AGENT_RATE);
-    }
+    Boolean probabilitySamplingResult = rates.hasAgentRates() ? sampled : null;
+    span.setSamplingPriority(
+        samplingPriority,
+        SAMPLING_AGENT_RATE,
+        sampler.getSampleRate(),
+        SamplingMechanism.AGENT_RATE,
+        probabilitySamplingResult);
   }
 
   private <T extends CoreSpan<T>> String getSpanEnv(final T span) {

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceTraceSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceTraceSampler.java
@@ -58,16 +58,19 @@ public class RateByServiceTraceSampler implements Sampler, PrioritySampler, Remo
 
     final RateSamplersByEnvAndService rates = serviceRates;
     RateSampler sampler = rates.getSampler(env, serviceName);
+    boolean sampled = sampler.sample(span);
+    int samplingPriority = sampled ? PrioritySampling.SAMPLER_KEEP : PrioritySampling.SAMPLER_DROP;
 
-    if (sampler.sample(span)) {
+    if (rates.hasAgentRates()) {
       span.setSamplingPriority(
-          PrioritySampling.SAMPLER_KEEP,
+          samplingPriority,
           SAMPLING_AGENT_RATE,
           sampler.getSampleRate(),
-          SamplingMechanism.AGENT_RATE);
+          SamplingMechanism.AGENT_RATE,
+          sampled);
     } else {
       span.setSamplingPriority(
-          PrioritySampling.SAMPLER_DROP,
+          samplingPriority,
           SAMPLING_AGENT_RATE,
           sampler.getSampleRate(),
           SamplingMechanism.AGENT_RATE);
@@ -161,7 +164,7 @@ public class RateByServiceTraceSampler implements Sampler, PrioritySampler, Remo
     if (canIncrease && anyCapped) {
       lastCappedNanos = now;
     }
-    serviceRates = new RateSamplersByEnvAndService(updatedEnvServiceRates, fallbackSampler);
+    serviceRates = new RateSamplersByEnvAndService(updatedEnvServiceRates, fallbackSampler, true);
   }
 
   private static RateSampler createRateSampler(final double sampleRate) {
@@ -183,15 +186,23 @@ public class RateByServiceTraceSampler implements Sampler, PrioritySampler, Remo
 
     private final Map<String, TreeMap<String, RateSampler>> envServiceRates;
     private final RateSampler fallbackSampler;
+    private final boolean hasAgentRates;
 
     RateSamplersByEnvAndService() {
-      this(Collections.emptyMap(), DEFAULT_SAMPLER);
+      this(Collections.emptyMap(), DEFAULT_SAMPLER, false);
     }
 
     RateSamplersByEnvAndService(
-        Map<String, TreeMap<String, RateSampler>> envServiceRates, RateSampler fallbackSampler) {
+        Map<String, TreeMap<String, RateSampler>> envServiceRates,
+        RateSampler fallbackSampler,
+        boolean hasAgentRates) {
       this.envServiceRates = envServiceRates;
       this.fallbackSampler = fallbackSampler;
+      this.hasAgentRates = hasAgentRates;
+    }
+
+    boolean hasAgentRates() {
+      return hasAgentRates;
     }
 
     RateSampler getFallbackSampler() {

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceTraceSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RateByServiceTraceSampler.java
@@ -113,10 +113,12 @@ public class RateByServiceTraceSampler implements Sampler, PrioritySampler, Remo
         new TreeMap<>(String::compareToIgnoreCase);
 
     RateSampler fallbackSampler = RateSamplersByEnvAndService.DEFAULT_SAMPLER;
+    boolean hasAgentRates = false;
     for (final Map.Entry<String, Number> entry : newServiceRates.entrySet()) {
       if (entry.getValue() == null) {
         continue;
       }
+      hasAgentRates = true;
       double rate = entry.getValue().doubleValue();
 
       EnvAndService envAndService = EnvAndService.fromString(entry.getKey());
@@ -157,7 +159,8 @@ public class RateByServiceTraceSampler implements Sampler, PrioritySampler, Remo
     if (canIncrease && anyCapped) {
       lastCappedNanos = now;
     }
-    serviceRates = new RateSamplersByEnvAndService(updatedEnvServiceRates, fallbackSampler, true);
+    serviceRates =
+        new RateSamplersByEnvAndService(updatedEnvServiceRates, fallbackSampler, hasAgentRates);
   }
 
   private static RateSampler createRateSampler(final double sampleRate) {
@@ -179,6 +182,7 @@ public class RateByServiceTraceSampler implements Sampler, PrioritySampler, Remo
 
     private final Map<String, TreeMap<String, RateSampler>> envServiceRates;
     private final RateSampler fallbackSampler;
+    // Whether this snapshot contains at least one non-null Agent-provided rate.
     private final boolean hasAgentRates;
 
     RateSamplersByEnvAndService() {

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RuleBasedTraceSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RuleBasedTraceSampler.java
@@ -147,31 +147,20 @@ public class RuleBasedTraceSampler<T extends CoreSpan<T>> implements Sampler, Pr
       fallbackSampler.setSamplingPriority(span);
     } else {
       boolean sampled = matchedRule.sample(span);
+      int samplingPriority;
       if (sampled) {
-        if (rateLimiter.tryAcquire()) {
-          span.setSamplingPriority(
-              PrioritySampling.USER_KEEP,
-              SAMPLING_RULE_RATE,
-              matchedRule.getSampler().getSampleRate(),
-              matchedRule.getMechanism(),
-              Boolean.TRUE);
-        } else {
-          span.setSamplingPriority(
-              PrioritySampling.USER_DROP,
-              SAMPLING_RULE_RATE,
-              matchedRule.getSampler().getSampleRate(),
-              matchedRule.getMechanism(),
-              Boolean.TRUE);
-        }
+        samplingPriority =
+            rateLimiter.tryAcquire() ? PrioritySampling.USER_KEEP : PrioritySampling.USER_DROP;
         span.setMetric(SAMPLING_LIMIT_RATE, rateLimit);
       } else {
-        span.setSamplingPriority(
-            PrioritySampling.USER_DROP,
-            SAMPLING_RULE_RATE,
-            matchedRule.getSampler().getSampleRate(),
-            matchedRule.getMechanism(),
-            Boolean.FALSE);
+        samplingPriority = PrioritySampling.USER_DROP;
       }
+      span.setSamplingPriority(
+          samplingPriority,
+          SAMPLING_RULE_RATE,
+          matchedRule.getSampler().getSampleRate(),
+          matchedRule.getMechanism(),
+          Boolean.valueOf(sampled));
     }
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RuleBasedTraceSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RuleBasedTraceSampler.java
@@ -146,19 +146,22 @@ public class RuleBasedTraceSampler<T extends CoreSpan<T>> implements Sampler, Pr
     if (matchedRule == null) {
       fallbackSampler.setSamplingPriority(span);
     } else {
-      if (matchedRule.sample(span)) {
+      boolean sampled = matchedRule.sample(span);
+      if (sampled) {
         if (rateLimiter.tryAcquire()) {
           span.setSamplingPriority(
               PrioritySampling.USER_KEEP,
               SAMPLING_RULE_RATE,
               matchedRule.getSampler().getSampleRate(),
-              matchedRule.getMechanism());
+              matchedRule.getMechanism(),
+              true);
         } else {
           span.setSamplingPriority(
               PrioritySampling.USER_DROP,
               SAMPLING_RULE_RATE,
               matchedRule.getSampler().getSampleRate(),
-              matchedRule.getMechanism());
+              matchedRule.getMechanism(),
+              true);
         }
         span.setMetric(SAMPLING_LIMIT_RATE, rateLimit);
       } else {
@@ -166,7 +169,8 @@ public class RuleBasedTraceSampler<T extends CoreSpan<T>> implements Sampler, Pr
             PrioritySampling.USER_DROP,
             SAMPLING_RULE_RATE,
             matchedRule.getSampler().getSampleRate(),
-            matchedRule.getMechanism());
+            matchedRule.getMechanism(),
+            false);
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/common/sampling/RuleBasedTraceSampler.java
+++ b/dd-trace-core/src/main/java/datadog/trace/common/sampling/RuleBasedTraceSampler.java
@@ -154,14 +154,14 @@ public class RuleBasedTraceSampler<T extends CoreSpan<T>> implements Sampler, Pr
               SAMPLING_RULE_RATE,
               matchedRule.getSampler().getSampleRate(),
               matchedRule.getMechanism(),
-              true);
+              Boolean.TRUE);
         } else {
           span.setSamplingPriority(
               PrioritySampling.USER_DROP,
               SAMPLING_RULE_RATE,
               matchedRule.getSampler().getSampleRate(),
               matchedRule.getMechanism(),
-              true);
+              Boolean.TRUE);
         }
         span.setMetric(SAMPLING_LIMIT_RATE, rateLimit);
       } else {
@@ -170,7 +170,7 @@ public class RuleBasedTraceSampler<T extends CoreSpan<T>> implements Sampler, Pr
             SAMPLING_RULE_RATE,
             matchedRule.getSampler().getSampleRate(),
             matchedRule.getMechanism(),
-            false);
+            Boolean.FALSE);
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -124,6 +124,13 @@ public interface CoreSpan<T extends CoreSpan<T>> {
   T setSamplingPriority(
       int samplingPriority, CharSequence rate, double sampleRate, int samplingMechanism);
 
+  T setSamplingPriority(
+      int samplingPriority,
+      CharSequence rate,
+      double sampleRate,
+      int samplingMechanism,
+      boolean sampled);
+
   T setSpanSamplingPriority(double rate, int limit);
 
   T setMetric(CharSequence name, int value);

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreSpan.java
@@ -122,14 +122,11 @@ public interface CoreSpan<T extends CoreSpan<T>> {
   T setSamplingPriority(int samplingPriority, int samplingMechanism);
 
   T setSamplingPriority(
-      int samplingPriority, CharSequence rate, double sampleRate, int samplingMechanism);
-
-  T setSamplingPriority(
       int samplingPriority,
       CharSequence rate,
       double sampleRate,
       int samplingMechanism,
-      boolean sampled);
+      Boolean probabilitySamplingResult);
 
   T setSpanSamplingPriority(double rate, int limit);
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -647,6 +647,27 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper, S
   @Override
   public DDSpan setSamplingPriority(
       int samplingPriority, CharSequence rate, double sampleRate, int samplingMechanism) {
+    setSamplingPriorityWithRate(samplingPriority, rate, sampleRate, samplingMechanism);
+    return this;
+  }
+
+  @Override
+  public DDSpan setSamplingPriority(
+      int samplingPriority,
+      CharSequence rate,
+      double sampleRate,
+      int samplingMechanism,
+      boolean sampled) {
+    if (setSamplingPriorityWithRate(samplingPriority, rate, sampleRate, samplingMechanism)) {
+      context
+          .getPropagationTags()
+          .updateOtelTraceState(getTraceId().toLong(), sampleRate, sampled, samplingPriority);
+    }
+    return this;
+  }
+
+  private boolean setSamplingPriorityWithRate(
+      int samplingPriority, CharSequence rate, double sampleRate, int samplingMechanism) {
     if (context.setSamplingPriority(samplingPriority, samplingMechanism)) {
       setMetric(rate, sampleRate);
       if (samplingMechanism == SamplingMechanism.AGENT_RATE
@@ -655,8 +676,9 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper, S
           || samplingMechanism == SamplingMechanism.REMOTE_ADAPTIVE_RULE) {
         context.getPropagationTags().updateKnuthSamplingRate(sampleRate);
       }
+      return true;
     }
-    return this;
+    return false;
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -646,22 +646,20 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper, S
 
   @Override
   public DDSpan setSamplingPriority(
-      int samplingPriority, CharSequence rate, double sampleRate, int samplingMechanism) {
-    setSamplingPriorityWithRate(samplingPriority, rate, sampleRate, samplingMechanism);
-    return this;
-  }
-
-  @Override
-  public DDSpan setSamplingPriority(
       int samplingPriority,
       CharSequence rate,
       double sampleRate,
       int samplingMechanism,
-      boolean sampled) {
-    if (setSamplingPriorityWithRate(samplingPriority, rate, sampleRate, samplingMechanism)) {
+      Boolean probabilitySamplingResult) {
+    if (setSamplingPriorityWithRate(samplingPriority, rate, sampleRate, samplingMechanism)
+        && probabilitySamplingResult != null) {
       context
           .getPropagationTags()
-          .updateOtelTraceState(getTraceId().toLong(), sampleRate, sampled, samplingPriority);
+          .updateOtelTraceState(
+              getTraceId().toLong(),
+              sampleRate,
+              probabilitySamplingResult.booleanValue(),
+              samplingPriority);
     }
     return this;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpan.java
@@ -656,10 +656,7 @@ public class DDSpan implements AgentSpan, CoreSpan<DDSpan>, AttachableWrapper, S
       context
           .getPropagationTags()
           .updateOtelTraceState(
-              getTraceId().toLong(),
-              sampleRate,
-              probabilitySamplingResult.booleanValue(),
-              samplingPriority);
+              getTraceId().toLong(), sampleRate, probabilitySamplingResult.booleanValue());
     }
     return this;
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/DDSpanContext.java
@@ -444,7 +444,13 @@ public class DDSpanContext
       setOrigin(origin);
     }
     if (samplingPriority != PrioritySampling.UNSET) {
-      setSamplingPriority(samplingPriority, SamplingMechanism.UNKNOWN);
+      if (this.propagationTags.getSamplingPriority() == samplingPriority) {
+        // Extractors already applied this priority to the propagation tags. Initialize the local
+        // field without reapplying the decision as an unknown local override.
+        SAMPLING_PRIORITY_UPDATER.set(this, samplingPriority);
+      } else {
+        setSamplingPriority(samplingPriority, SamplingMechanism.UNKNOWN);
+      }
     }
     setTag(PARENT_ID, this.propagationTags.getLastParentId());
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceCollector.java
@@ -3,11 +3,14 @@ package datadog.trace.core.otlp.trace;
 import static datadog.trace.core.DDSpanContext.SPAN_SAMPLING_MECHANISM_TAG;
 
 import datadog.trace.core.CoreSpan;
+import datadog.trace.core.DDSpan;
 import datadog.trace.core.otlp.common.OtlpPayload;
 import java.util.List;
 
 /** Collects traces ready for export. */
 public abstract class OtlpTraceCollector {
+
+  private static final String OTEL_TRACE_STATE_PREFIX = "ot=";
 
   /** Adds spans from the given trace to the collector. */
   public abstract void addTrace(List<? extends CoreSpan<?>> spans);
@@ -21,5 +24,16 @@ public abstract class OtlpTraceCollector {
   protected final boolean shouldExport(CoreSpan<?> span) {
     return span.samplingPriority() > 0 // trace-level sampling priority
         || span.getTag(SPAN_SAMPLING_MECHANISM_TAG) != null; // span-level sampling priority
+  }
+
+  protected final String getOtlpOtelTraceState(List<? extends CoreSpan<?>> spans) {
+    for (CoreSpan<?> span : spans) {
+      if (span instanceof DDSpan) {
+        String otelTraceState =
+            ((DDSpan) span).spanContext().getPropagationTags().getOtelTraceState();
+        return otelTraceState == null ? null : OTEL_TRACE_STATE_PREFIX + otelTraceState;
+      }
+    }
+    return null;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceJson.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceJson.java
@@ -33,7 +33,6 @@ import datadog.trace.core.DDSpan;
 import datadog.trace.core.Metadata;
 import datadog.trace.core.MetadataConsumer;
 import datadog.trace.core.PendingTrace;
-import datadog.trace.core.propagation.PropagationTags;
 import java.util.List;
 import java.util.Map;
 
@@ -49,8 +48,11 @@ public final class OtlpTraceJson {
 
   /** Writes one complete {@code Span} JSON object. */
   public static void writeSpan(
-      JsonWriter writer, DDSpan span, MetaWriter metaWriter, List<? extends AgentSpanLink> links) {
-    PropagationTags propagationTags = span.spanContext().getPropagationTags();
+      JsonWriter writer,
+      DDSpan span,
+      MetaWriter metaWriter,
+      List<? extends AgentSpanLink> links,
+      String otelTraceState) {
 
     writer.beginObject();
 
@@ -59,9 +61,12 @@ public final class OtlpTraceJson {
 
     int samplingPriority = span.samplingPriority();
     // TODO Cache the effective tracestate once per trace.
-    String tracestate = propagationTags.getW3CTracestate(samplingPriority);
-    if (tracestate != null) {
-      writer.name("traceState").value(tracestate);
+    String traceState = span.spanContext().getPropagationTags().getW3CTracestate(samplingPriority);
+    if (traceState == null) {
+      traceState = otelTraceState;
+    }
+    if (traceState != null) {
+      writer.name("traceState").value(traceState);
     }
 
     if (span.getParentId() != 0) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceJson.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceJson.java
@@ -57,7 +57,9 @@ public final class OtlpTraceJson {
     writer.name("traceId").value(hexTraceId(span.getTraceId()));
     writer.name("spanId").value(hexSpanId(span.getSpanId()));
 
-    String tracestate = propagationTags.getW3CTracestate();
+    int samplingPriority = span.samplingPriority();
+    // TODO Cache the effective tracestate once per trace.
+    String tracestate = propagationTags.getW3CTracestate(samplingPriority);
     if (tracestate != null) {
       writer.name("traceState").value(tracestate);
     }
@@ -67,7 +69,7 @@ public final class OtlpTraceJson {
     }
 
     int traceFlags = NO_TRACE_FLAGS;
-    if (span.samplingPriority() > 0) {
+    if (samplingPriority > 0) {
       traceFlags |= SAMPLED_TRACE_FLAG;
     }
     if (span.spanContext().isRemote()) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollector.java
@@ -46,6 +46,7 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
   private OtelInstrumentationScope currentScope;
   private DDSpan currentSpan;
   private List<? extends AgentSpanLink> currentSpanLinks = Collections.emptyList();
+  private String currentOtelTraceState;
 
   /** Adds the given trace spans to the collector. */
   @Override
@@ -56,8 +57,9 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
     }
 
     try {
+      String otelTraceState = getOtlpOtelTraceState(spans);
       for (CoreSpan<?> span : spans) {
-        visitSpan(span);
+        visitSpan(span, otelTraceState);
       }
     } catch (Throwable e) {
       // reset the buffer for subsequent traces
@@ -114,6 +116,7 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
     currentScope = null;
     currentSpan = null;
     currentSpanLinks = Collections.emptyList();
+    currentOtelTraceState = null;
   }
 
   private void visitScopedSpans(OtelInstrumentationScope scope) {
@@ -128,7 +131,7 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
     writer.name("spans").beginArray();
   }
 
-  private void visitSpan(CoreSpan<?> span) {
+  private void visitSpan(CoreSpan<?> span, String otelTraceState) {
     if (!shouldExport(span)) {
       return;
     }
@@ -141,6 +144,7 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
     }
     currentSpan = (DDSpan) span;
     currentSpanLinks = currentSpan.getLinks();
+    currentOtelTraceState = otelTraceState;
   }
 
   // called once we've processed all scopes and span messages
@@ -185,12 +189,13 @@ public final class OtlpTraceJsonCollector extends OtlpTraceCollector {
       metaWriter.includeProcessTags();
       firstSpanInScope = false;
     }
-    writeSpan(writer, currentSpan, metaWriter, currentSpanLinks);
+    writeSpan(writer, currentSpan, metaWriter, currentSpanLinks, currentOtelTraceState);
     anySpanWritten = true;
 
     // reset temporary elements for next span
     currentSpan = null;
     currentSpanLinks = Collections.emptyList();
+    currentOtelTraceState = null;
 
     if (writer.size() > MAX_CAPACITY_BYTES) {
       throw new IllegalStateException(

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProto.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProto.java
@@ -47,7 +47,6 @@ import datadog.trace.core.Metadata;
 import datadog.trace.core.MetadataConsumer;
 import datadog.trace.core.PendingTrace;
 import datadog.trace.core.otlp.common.OtlpProtoBuffer;
-import datadog.trace.core.propagation.PropagationTags;
 
 /** Provides optimized writers for OpenTelemetry's "trace.proto" wire protocol. */
 public final class OtlpTraceProto {
@@ -82,8 +81,8 @@ public final class OtlpTraceProto {
       DDSpan span,
       MetaWriter metaWriter,
       int nestedSpanLinkBytes,
-      OtlpProtoBuffer protobuf) {
-    PropagationTags propagationTags = span.spanContext().getPropagationTags();
+      OtlpProtoBuffer protobuf,
+      String otelTraceState) {
 
     writeTag(buf, 1, LEN_WIRE_TYPE);
     writeTraceId(buf, span.getTraceId());
@@ -93,10 +92,13 @@ public final class OtlpTraceProto {
 
     int samplingPriority = span.samplingPriority();
     // TODO Cache the effective tracestate once per trace.
-    String tracestate = propagationTags.getW3CTracestate(samplingPriority);
-    if (tracestate != null) {
+    String traceState = span.spanContext().getPropagationTags().getW3CTracestate(samplingPriority);
+    if (traceState == null) {
+      traceState = otelTraceState;
+    }
+    if (traceState != null) {
       writeTag(buf, 3, LEN_WIRE_TYPE);
-      writeString(buf, tracestate);
+      writeString(buf, traceState);
     }
 
     if (span.getParentId() != 0) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProto.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProto.java
@@ -91,7 +91,9 @@ public final class OtlpTraceProto {
     writeTag(buf, 2, LEN_WIRE_TYPE);
     writeSpanId(buf, span.getSpanId());
 
-    String tracestate = propagationTags.getW3CTracestate();
+    int samplingPriority = span.samplingPriority();
+    // TODO Cache the effective tracestate once per trace.
+    String tracestate = propagationTags.getW3CTracestate(samplingPriority);
     if (tracestate != null) {
       writeTag(buf, 3, LEN_WIRE_TYPE);
       writeString(buf, tracestate);
@@ -103,7 +105,7 @@ public final class OtlpTraceProto {
     }
 
     int traceFlags = NO_TRACE_FLAGS;
-    if (span.samplingPriority() > 0) {
+    if (samplingPriority > 0) {
       traceFlags |= SAMPLED_TRACE_FLAG;
     }
     if (span.spanContext().isRemote()) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProtoCollector.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/otlp/trace/OtlpTraceProtoCollector.java
@@ -47,6 +47,7 @@ public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
 
   private OtelInstrumentationScope currentScope;
   private DDSpan currentSpan;
+  private String currentOtelTraceState;
 
   /** Adds the given trace spans to the collector. */
   @Override
@@ -57,9 +58,10 @@ public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
     }
 
     try {
+      String otelTraceState = getOtlpOtelTraceState(spans);
       // OtlpProtoBuffer collects spans in reverse
       for (int i = spans.size() - 1; i >= 0; i--) {
-        visitSpan(spans.get(i));
+        visitSpan(spans.get(i), otelTraceState);
       }
     } catch (Throwable e) {
       // reset the buffer for subsequent traces
@@ -109,6 +111,7 @@ public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
 
     currentScope = null;
     currentSpan = null;
+    currentOtelTraceState = null;
   }
 
   private void visitScopedSpans(OtelInstrumentationScope scope) {
@@ -118,7 +121,7 @@ public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
     currentScope = scope;
   }
 
-  private void visitSpan(CoreSpan<?> span) {
+  private void visitSpan(CoreSpan<?> span, String otelTraceState) {
     if (!shouldExport(span)) {
       return;
     }
@@ -131,6 +134,7 @@ public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
       completeSpan();
     }
     currentSpan = (DDSpan) span;
+    currentOtelTraceState = otelTraceState;
     currentSpan.getLinks().forEach(this::visitSpanLink);
   }
 
@@ -178,10 +182,12 @@ public final class OtlpTraceProtoCollector extends OtlpTraceCollector {
   // called once we've processed all span-links in a specific span
   private void completeSpan() {
 
-    scopedBytes += recordSpanMessage(buf, currentSpan, metaWriter, spanBytes, protobuf);
+    scopedBytes +=
+        recordSpanMessage(buf, currentSpan, metaWriter, spanBytes, protobuf, currentOtelTraceState);
 
     // reset temporary elements for next span
     currentSpan = null;
+    currentOtelTraceState = null;
     spanBytes = 0;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -285,8 +285,10 @@ public class HttpCodec {
         ExtractedContext firstContext,
         ExtractedContext traceContext,
         ExtractionCache<C> extractionCache) {
-      // Propagate newly extracted W3C tracestate to first valid context
-      firstContext.getPropagationTags().updateW3CTracestateFrom(traceContext.getPropagationTags());
+      firstContext
+          .getPropagationTags()
+          .updateW3CTracestateFrom(
+              traceContext.getPropagationTags(), firstContext.getSamplingPriority());
       // Check if parent spans differ to reconcile them
       if (firstContext.getSpanId() != traceContext.getSpanId()) {
         // Override parent span id with W3C one

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -286,8 +286,7 @@ public class HttpCodec {
         ExtractedContext traceContext,
         ExtractionCache<C> extractionCache) {
       // Propagate newly extracted W3C tracestate to first valid context
-      String extractedTracestate = traceContext.getPropagationTags().getW3CTracestate();
-      firstContext.getPropagationTags().updateW3CTracestate(extractedTracestate);
+      firstContext.getPropagationTags().updateW3CTracestateFrom(traceContext.getPropagationTags());
       // Check if parent spans differ to reconcile them
       if (firstContext.getSpanId() != traceContext.getSpanId()) {
         // Override parent span id with W3C one

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/HttpCodec.java
@@ -285,10 +285,8 @@ public class HttpCodec {
         ExtractedContext firstContext,
         ExtractedContext traceContext,
         ExtractionCache<C> extractionCache) {
-      firstContext
-          .getPropagationTags()
-          .updateW3CTracestateFrom(
-              traceContext.getPropagationTags(), firstContext.getSamplingPriority());
+      // Propagate newly extracted W3C tracestate to first valid context
+      firstContext.getPropagationTags().updateW3CTracestateFrom(traceContext.getPropagationTags());
       // Check if parent spans differ to reconcile them
       if (firstContext.getSpanId() != traceContext.getSpanId()) {
         // Override parent span id with W3C one

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
@@ -67,6 +67,9 @@ public abstract class PropagationTags {
 
   public abstract void forceKeep(int samplingMechanism);
 
+  public abstract void updateOtelTraceState(
+      long traceIdLowOrderBits, double sampleRate, boolean sampled, int samplingPriority);
+
   public abstract int getSamplingPriority();
 
   public abstract void updateTraceOrigin(CharSequence origin);

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
@@ -68,7 +68,7 @@ public abstract class PropagationTags {
   public abstract void forceKeep(int samplingMechanism);
 
   public abstract void updateOtelTraceState(
-      long traceIdLowOrderBits, double sampleRate, boolean sampled, int samplingPriority);
+      long traceIdLowOrderBits, double sampleRate, boolean sampled);
 
   public abstract int getSamplingPriority();
 
@@ -98,11 +98,10 @@ public abstract class PropagationTags {
    */
   public abstract void updateW3CTracestate(String tracestate);
 
-  /**
-   * Enriches these tags with the W3C tracestate from {@code source} and the reconciled sampling
-   * priority.
-   */
-  public abstract void updateW3CTracestateFrom(PropagationTags source, int samplingPriority);
+  /** Updates the original W3C tracestate header from {@code source}. */
+  public void updateW3CTracestateFrom(PropagationTags source) {
+    updateW3CTracestate(source.getW3CTracestate());
+  }
 
   /**
    * Constructs a header value that includes valid propagated _dd.p.* tags and possibly a new
@@ -119,6 +118,15 @@ public abstract class PropagationTags {
    * state. A {@code null} override falls back to {@link #headerValue(HeaderType)}.
    */
   public abstract String headerValue(HeaderType headerType, CharSequence lastParentIdOverride);
+
+  /**
+   * Like {@link #headerValue(HeaderType, CharSequence)}, but resolves W3C sampling state using the
+   * supplied sampling priority.
+   */
+  public String headerValue(
+      HeaderType headerType, CharSequence lastParentIdOverride, int samplingPriority) {
+    return headerValue(headerType, lastParentIdOverride);
+  }
 
   /**
    * Fills a provided tagMap with valid propagated _dd.p.* tags and possibly a new sampling decision

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
@@ -90,6 +90,11 @@ public abstract class PropagationTags {
    */
   public abstract String getW3CTracestate();
 
+  /** Gets the W3C tracestate with OTel sampling state resolved for the supplied priority. */
+  public String getW3CTracestate(int samplingPriority) {
+    return getW3CTracestate();
+  }
+
   /**
    * Stores the original <a href="https://www.w3.org/TR/trace-context/#tracestate-header">W3C
    * tracestate header</a> value.

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
@@ -95,6 +95,11 @@ public abstract class PropagationTags {
    */
   public abstract void updateW3CTracestate(String tracestate);
 
+  /** Updates the original W3C tracestate header from {@code source}. */
+  public void updateW3CTracestateFrom(PropagationTags source) {
+    updateW3CTracestate(source.getW3CTracestate());
+  }
+
   /**
    * Constructs a header value that includes valid propagated _dd.p.* tags and possibly a new
    * sampling decision tag _dd.p.dm based on the current state. Returns null if the value length

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
@@ -98,10 +98,11 @@ public abstract class PropagationTags {
    */
   public abstract void updateW3CTracestate(String tracestate);
 
-  /** Updates the original W3C tracestate header from {@code source}. */
-  public void updateW3CTracestateFrom(PropagationTags source) {
-    updateW3CTracestate(source.getW3CTracestate());
-  }
+  /**
+   * Enriches these tags with the W3C tracestate from {@code source} and the reconciled sampling
+   * priority.
+   */
+  public abstract void updateW3CTracestateFrom(PropagationTags source, int samplingPriority);
 
   /**
    * Constructs a header value that includes valid propagated _dd.p.* tags and possibly a new

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/PropagationTags.java
@@ -96,6 +96,13 @@ public abstract class PropagationTags {
   }
 
   /**
+   * Gets the OpenTelemetry {@code ot} tracestate member value, without the member key.
+   *
+   * @return The OpenTelemetry tracestate value, or {@code null} if none is present.
+   */
+  public abstract String getOtelTraceState();
+
+  /**
    * Stores the original <a href="https://www.w3.org/TR/trace-context/#tracestate-header">W3C
    * tracestate header</a> value.
    *

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/W3CHttpCodec.java
@@ -65,25 +65,28 @@ class W3CHttpCodec {
     @Override
     public <C> void inject(
         final DDSpanContext context, final C carrier, final CarrierSetter<C> setter) {
-      injectTraceParent(context, carrier, setter);
-      injectTraceState(context, carrier, setter);
+      int samplingPriority = context.getSamplingPriority();
+      injectTraceParent(context, carrier, setter, samplingPriority);
+      injectTraceState(context, carrier, setter, samplingPriority);
       injectBaggage(context, carrier, setter);
     }
 
-    private <C> void injectTraceParent(DDSpanContext context, C carrier, CarrierSetter<C> setter) {
+    private <C> void injectTraceParent(
+        DDSpanContext context, C carrier, CarrierSetter<C> setter, int samplingPriority) {
       String traceparent =
-          W3CTraceParent.from(
-              context.getTraceId(), context.getSpanId(), context.getSamplingPriority() > 0);
+          W3CTraceParent.from(context.getTraceId(), context.getSpanId(), samplingPriority > 0);
       setter.set(carrier, TRACE_PARENT_KEY, traceparent);
     }
 
-    private <C> void injectTraceState(DDSpanContext context, C carrier, CarrierSetter<C> setter) {
+    private <C> void injectTraceState(
+        DDSpanContext context, C carrier, CarrierSetter<C> setter, int samplingPriority) {
       PropagationTags propagationTags = context.getPropagationTags();
       // Supply the injecting span's id for the W3C `p:` as a parameter rather than mutating it into
       // the (possibly trace-level, shared) tags — keeps transient per-injection identity out of
       // shared state, so concurrent sibling injects can't race on it.
       String tracestate =
-          propagationTags.headerValue(W3C, DDSpanId.toHexStringPadded(context.getSpanId()));
+          propagationTags.headerValue(
+              W3C, DDSpanId.toHexStringPadded(context.getSpanId()), samplingPriority);
       if (tracestate != null && !tracestate.isEmpty()) {
         setter.set(carrier, TRACE_STATE_KEY, tracestate);
       }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -1,0 +1,30 @@
+package datadog.trace.core.propagation.ptags;
+
+final class OtelTraceState {
+  private final String value;
+  private final int inheritedPosition;
+
+  private OtelTraceState(String value, int inheritedPosition) {
+    this.value = value;
+    this.inheritedPosition = inheritedPosition;
+  }
+
+  static OtelTraceState parse(String raw, int inheritedPosition) {
+    if (raw == null || raw.isEmpty()) {
+      return null;
+    }
+    return new OtelTraceState(raw, inheritedPosition);
+  }
+
+  String getValue() {
+    return value;
+  }
+
+  int length() {
+    return value.length();
+  }
+
+  int getInheritedPosition() {
+    return inheritedPosition;
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -160,12 +160,7 @@ final class OtelTraceState {
     if (threshold == NO_VALUE) {
       return this;
     }
-    return create(
-        randomValue,
-        NO_VALUE,
-        value,
-        originalSize,
-        hasLocallyGeneratedRandomValue());
+    return create(randomValue, NO_VALUE, value, originalSize, hasLocallyGeneratedRandomValue());
   }
 
   OtelTraceState reconcileSamplingDecision(boolean sampled) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -8,8 +8,8 @@ final class OtelTraceState {
   private static final long MAX_THRESHOLD = (1L << 56) - 1;
   private static final double THRESHOLD_RANGE = 1L << 56;
   private static final long NO_VALUE = -1;
-  private static final int HAS_MULTIPLE_RANDOM_VALUES = 1;
-  private static final int HAS_LOCALLY_GENERATED_RANDOM_VALUE = 1 << 1;
+  private static final int FLAGS_HAS_MULTIPLE_RANDOM_VALUES = 1;
+  private static final int FLAGS_HAS_LOCALLY_GENERATED_RANDOM_VALUE = 1 << 1;
   private static final String RANDOM_VALUE_KEY = "rv:";
   private static final String THRESHOLD_KEY = "th:";
   private static final int DEFAULT_VALUE_CAPACITY =
@@ -20,6 +20,7 @@ final class OtelTraceState {
   private final long threshold;
   private final int originalPosition;
   private final int originalSize;
+  // Combination of FLAGS_HAS_MULTIPLE_RANDOM_VALUES and FLAGS_HAS_LOCALLY_GENERATED_RANDOM_VALUE.
   private final int flags;
 
   private OtelTraceState(
@@ -46,6 +47,7 @@ final class OtelTraceState {
     int flags = 0;
     StringBuilder normalized = null;
     int start = 0;
+    // Iterate over semicolon-delimited OTel tracestate key-value pairs.
     while (start < raw.length()) {
       int end = raw.indexOf(';', start);
       if (end < 0) {
@@ -57,15 +59,14 @@ final class OtelTraceState {
       }
       int fieldValueStart = separator < 0 ? end : separator + 1;
       if (hasKey(raw, start, end, separator, 'r', 'v')) {
+        boolean validRandomValueLength = end - fieldValueStart == HEX_DIGITS;
         long parsedRandomValue =
-            end - fieldValueStart == HEX_DIGITS
-                ? parseLowercaseHex(raw, fieldValueStart, end)
-                : NO_VALUE;
+            validRandomValueLength ? parseLowercaseHex(raw, fieldValueStart, end) : NO_VALUE;
         if (parsedRandomValue != NO_VALUE) {
           if (randomValue == NO_VALUE) {
             randomValue = parsedRandomValue;
           } else {
-            flags |= HAS_MULTIPLE_RANDOM_VALUES;
+            flags |= FLAGS_HAS_MULTIPLE_RANDOM_VALUES;
           }
           if (normalized != null) {
             appendField(normalized, raw, start, end);
@@ -74,10 +75,9 @@ final class OtelTraceState {
           normalized = startNormalizing(raw, normalized, start);
         }
       } else if (hasKey(raw, start, end, separator, 't', 'h')) {
+        boolean validThresholdLength = fieldValueStart < end && end - fieldValueStart <= HEX_DIGITS;
         long parsedThreshold =
-            fieldValueStart < end && end - fieldValueStart <= HEX_DIGITS
-                ? parseLowercaseHex(raw, fieldValueStart, end)
-                : NO_VALUE;
+            validThresholdLength ? parseLowercaseHex(raw, fieldValueStart, end) : NO_VALUE;
         if (parsedThreshold != NO_VALUE) {
           if (threshold == NO_VALUE) {
             threshold = parsedThreshold;
@@ -161,7 +161,11 @@ final class OtelTraceState {
       return this;
     }
     return create(
-        randomValue, NO_VALUE, value, originalSize, hasLocallyGeneratedRandomValue());
+        randomValue,
+        NO_VALUE,
+        value,
+        originalSize,
+        hasLocallyGeneratedRandomValue());
   }
 
   String getValue() {
@@ -205,7 +209,7 @@ final class OtelTraceState {
         threshold,
         0,
         originalSize,
-        locallyGeneratedRandomValue ? HAS_LOCALLY_GENERATED_RANDOM_VALUE : 0);
+        locallyGeneratedRandomValue ? FLAGS_HAS_LOCALLY_GENERATED_RANDOM_VALUE : 0);
   }
 
   private static StringBuilder startNormalizing(String raw, StringBuilder normalized, int start) {
@@ -297,11 +301,11 @@ final class OtelTraceState {
   }
 
   private boolean hasMultipleRandomValues() {
-    return (flags & HAS_MULTIPLE_RANDOM_VALUES) != 0;
+    return (flags & FLAGS_HAS_MULTIPLE_RANDOM_VALUES) != 0;
   }
 
   private boolean hasLocallyGeneratedRandomValue() {
-    return (flags & HAS_LOCALLY_GENERATED_RANDOM_VALUE) != 0;
+    return (flags & FLAGS_HAS_LOCALLY_GENERATED_RANDOM_VALUE) != 0;
   }
 
   private static void appendHex(StringBuilder value, long number, int digits) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -5,18 +5,18 @@ final class OtelTraceState {
   private final int originalPosition;
   private final int originalSize;
 
-  private OtelTraceState(String value, int inheritedPosition, int originalMemberContributionSize) {
+  private OtelTraceState(String value, int originalPosition, int originalSize) {
     this.value = value;
-    this.originalPosition = inheritedPosition;
-    this.originalSize = originalMemberContributionSize;
+    this.originalPosition = originalPosition;
+    this.originalSize = originalSize;
   }
 
   static OtelTraceState parse(
-      String raw, int inheritedPosition, int originalMemberContributionSize) {
+      String raw, int originalPosition, int originalSize) {
     if (raw == null || raw.isEmpty()) {
       return null;
     }
-    return new OtelTraceState(raw, inheritedPosition, originalMemberContributionSize);
+    return new OtelTraceState(raw, originalPosition, originalSize);
   }
 
   String getValue() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -138,9 +138,10 @@ final class OtelTraceState {
 
     long threshold = computeThreshold(sampleRate);
     long randomValue = computeRandomValue(traceIdLowOrderBits);
-    if (sampled && randomValue < threshold) {
+    boolean finalSampled = samplingPriority > 0;
+    if (finalSampled && randomValue < threshold) {
       randomValue = threshold;
-    } else if (!sampled && randomValue >= threshold) {
+    } else if (!finalSampled && randomValue >= threshold) {
       randomValue = threshold == 0 ? 0 : threshold - 1;
     }
 
@@ -165,6 +166,13 @@ final class OtelTraceState {
         value,
         originalSize,
         hasLocallyGeneratedRandomValue());
+  }
+
+  OtelTraceState reconcileSamplingDecision(boolean sampled) {
+    if (randomValue == NO_VALUE || threshold == NO_VALUE || sampled == (randomValue >= threshold)) {
+      return this;
+    }
+    return removeThresholdForLimiterDemotion();
   }
 
   String getValue() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -2,13 +2,13 @@ package datadog.trace.core.propagation.ptags;
 
 final class OtelTraceState {
   private final String value;
-  private final int inheritedPosition;
-  private final int originalMemberContributionSize;
+  private final int originalPosition;
+  private final int originalSize;
 
   private OtelTraceState(String value, int inheritedPosition, int originalMemberContributionSize) {
     this.value = value;
-    this.inheritedPosition = inheritedPosition;
-    this.originalMemberContributionSize = originalMemberContributionSize;
+    this.originalPosition = inheritedPosition;
+    this.originalSize = originalMemberContributionSize;
   }
 
   static OtelTraceState parse(
@@ -27,11 +27,11 @@ final class OtelTraceState {
     return value.length();
   }
 
-  int getInheritedPosition() {
-    return inheritedPosition;
+  int getOriginalPosition() {
+    return originalPosition;
   }
 
-  int getOriginalMemberContributionSize() {
-    return originalMemberContributionSize;
+  int getOriginalSize() {
+    return originalSize;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -47,8 +47,8 @@ final class OtelTraceState {
     int flags = 0;
     StringBuilder normalized = null;
     int start = 0;
-    // Iterate over semicolon-delimited OTel tracestate key-value pairs.
-    while (start < raw.length()) {
+    // Iterate over semicolon-delimited OTel tracestate fields, including trailing empty fields.
+    while (start <= raw.length()) {
       int end = raw.indexOf(';', start);
       if (end < 0) {
         end = raw.length();
@@ -58,6 +58,7 @@ final class OtelTraceState {
         separator = -1;
       }
       int fieldValueStart = separator < 0 ? end : separator + 1;
+      boolean validField;
       if (hasKey(raw, start, end, separator, 'r', 'v')) {
         boolean validRandomValueLength = end - fieldValueStart == HEX_DIGITS;
         long parsedRandomValue =
@@ -68,11 +69,9 @@ final class OtelTraceState {
           } else {
             flags |= FLAGS_HAS_MULTIPLE_RANDOM_VALUES;
           }
-          if (normalized != null) {
-            appendField(normalized, raw, start, end);
-          }
+          validField = true;
         } else {
-          normalized = startNormalizing(raw, normalized, start);
+          validField = false;
         }
       } else if (hasKey(raw, start, end, separator, 't', 'h')) {
         boolean validThresholdLength = fieldValueStart < end && end - fieldValueStart <= HEX_DIGITS;
@@ -82,24 +81,28 @@ final class OtelTraceState {
           if (threshold == NO_VALUE) {
             threshold = parsedThreshold;
           }
-          if (normalized != null) {
-            appendField(normalized, raw, start, end);
-          }
+          validField = true;
         } else {
-          normalized = startNormalizing(raw, normalized, start);
+          validField = false;
         }
-      } else if (start < end) {
+      } else {
+        validField = start < end;
+      }
+      if (validField) {
         if (normalized != null) {
-          appendField(normalized, raw, start, end);
+          int separatorSize = normalized.length() == 0 ? 0 : 1;
+          int fieldLength = end - start;
+          if (normalized.length() + separatorSize + fieldLength <= MAX_VALUE_LENGTH) {
+            if (separatorSize != 0) {
+              normalized.append(';');
+            }
+            normalized.append(raw, start, end);
+          }
         }
       } else {
         normalized = startNormalizing(raw, normalized, start);
       }
       start = end + 1;
-    }
-
-    if (raw.charAt(raw.length() - 1) == ';') {
-      normalized = startNormalizing(raw, normalized, raw.length());
     }
 
     String value = normalized == null ? raw : normalized.toString();
@@ -125,16 +128,12 @@ final class OtelTraceState {
     int originalSize = current == null ? 0 : current.originalSize;
 
     // `sampled` is the raw probability result; `samplingPriority` may be changed by rate limiting.
-    if (sampled && samplingPriority <= 0) {
+    boolean limiterDemoted = sampled && samplingPriority <= 0;
+    if (limiterDemoted) {
       if (current != null) {
         return current.removeThresholdForLimiterDemotion();
       }
-      return create(
-          computeRandomValue(traceIdLowOrderBits),
-          NO_VALUE,
-          currentValue,
-          originalSize,
-          true);
+      return null;
     }
 
     long threshold = computeThreshold(sampleRate);
@@ -187,18 +186,23 @@ final class OtelTraceState {
   private static OtelTraceState create(
       long randomValue,
       long threshold,
-      String previousValue,
+      String existingValue,
       int originalSize,
       boolean locallyGeneratedRandomValue) {
     StringBuilder value = new StringBuilder(DEFAULT_VALUE_CAPACITY);
     if (randomValue != NO_VALUE) {
-      appendRandomValue(value, randomValue);
+      value.append(RANDOM_VALUE_KEY);
+      appendHex(value, randomValue, HEX_DIGITS);
     }
     if (threshold != NO_VALUE) {
-      appendThreshold(value, threshold);
+      if (value.length() > 0) {
+        value.append(';');
+      }
+      value.append(THRESHOLD_KEY);
+      appendHex(value, threshold, thresholdHexDigits(threshold));
     }
-    if (previousValue != null) {
-      appendUnknownFields(value, previousValue);
+    if (existingValue != null) {
+      appendUnknownFields(value, existingValue);
     }
     if (value.length() == 0) {
       return null;
@@ -223,56 +227,31 @@ final class OtelTraceState {
     return normalized;
   }
 
-  private static void appendRandomValue(StringBuilder value, long randomValue) {
-    if (appendFieldPrefix(value, RANDOM_VALUE_KEY.length() + HEX_DIGITS)) {
-      value.append(RANDOM_VALUE_KEY);
-      appendHex(value, randomValue, HEX_DIGITS);
-    }
-  }
-
-  private static void appendThreshold(StringBuilder value, long threshold) {
-    int hexDigits = thresholdHexDigits(threshold);
-    if (appendFieldPrefix(value, THRESHOLD_KEY.length() + hexDigits)) {
-      value.append(THRESHOLD_KEY);
-      appendHex(value, threshold, hexDigits);
-    }
-  }
-
-  private static void appendUnknownFields(StringBuilder value, String previousValue) {
+  /** Appends fields other than {@code rv} and {@code th} from the existing value. */
+  private static void appendUnknownFields(StringBuilder value, String existingValue) {
     int start = 0;
-    while (start < previousValue.length()) {
-      int end = previousValue.indexOf(';', start);
+    while (start < existingValue.length()) {
+      int end = existingValue.indexOf(';', start);
       if (end < 0) {
-        end = previousValue.length();
+        end = existingValue.length();
       }
-      int separator = previousValue.indexOf(':', start);
+      int separator = existingValue.indexOf(':', start);
       if (separator >= end) {
         separator = -1;
       }
-      if (!hasKey(previousValue, start, end, separator, 'r', 'v')
-          && !hasKey(previousValue, start, end, separator, 't', 'h')) {
-        appendField(value, previousValue, start, end);
+      if (!hasKey(existingValue, start, end, separator, 'r', 'v')
+          && !hasKey(existingValue, start, end, separator, 't', 'h')) {
+        int separatorSize = value.length() == 0 ? 0 : 1;
+        int fieldLength = end - start;
+        if (value.length() + separatorSize + fieldLength <= MAX_VALUE_LENGTH) {
+          if (separatorSize != 0) {
+            value.append(';');
+          }
+          value.append(existingValue, start, end);
+        }
       }
       start = end + 1;
     }
-  }
-
-  private static void appendField(StringBuilder value, String field, int start, int end) {
-    if (!appendFieldPrefix(value, end - start)) {
-      return;
-    }
-    value.append(field, start, end);
-  }
-
-  private static boolean appendFieldPrefix(StringBuilder value, int fieldLength) {
-    int separatorSize = value.length() == 0 ? 0 : 1;
-    if (value.length() + separatorSize + fieldLength > MAX_VALUE_LENGTH) {
-      return false;
-    }
-    if (separatorSize != 0) {
-      value.append(';');
-    }
-    return true;
   }
 
   private static boolean hasKey(

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -12,6 +12,8 @@ final class OtelTraceState {
   private static final int HAS_LOCALLY_GENERATED_RANDOM_VALUE = 1 << 1;
   private static final String RANDOM_VALUE_KEY = "rv:";
   private static final String THRESHOLD_KEY = "th:";
+  private static final int DEFAULT_VALUE_CAPACITY =
+      RANDOM_VALUE_KEY.length() + HEX_DIGITS + 1 + THRESHOLD_KEY.length() + HEX_DIGITS;
 
   private final String value;
   private final long randomValue;
@@ -184,7 +186,7 @@ final class OtelTraceState {
       String previousValue,
       int originalSize,
       boolean locallyGeneratedRandomValue) {
-    StringBuilder value = new StringBuilder();
+    StringBuilder value = new StringBuilder(DEFAULT_VALUE_CAPACITY);
     if (randomValue != NO_VALUE) {
       appendRandomValue(value, randomValue);
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -11,8 +11,7 @@ final class OtelTraceState {
     this.originalSize = originalSize;
   }
 
-  static OtelTraceState parse(
-      String raw, int originalPosition, int originalSize) {
+  static OtelTraceState parse(String raw, int originalPosition, int originalSize) {
     if (raw == null || raw.isEmpty()) {
       return null;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -1,21 +1,154 @@
 package datadog.trace.core.propagation.ptags;
 
+import java.util.ArrayList;
+import java.util.List;
+
 final class OtelTraceState {
+  static final int MAX_VALUE_LENGTH = 256;
+
+  private static final int HEX_DIGITS = 14;
+  private static final long KNUTH_FACTOR = 1111111111111111111L;
+  private static final long MAX_THRESHOLD = (1L << 56) - 1;
+  private static final double THRESHOLD_RANGE = 1L << 56;
+
   private final String value;
+  private final String randomValue;
+  private final String threshold;
+  private final String[] unknownFields;
+  private final int randomValueCount;
   private final int originalPosition;
   private final int originalSize;
+  private final boolean locallyGeneratedRandomValue;
 
-  private OtelTraceState(String value, int originalPosition, int originalSize) {
+  private OtelTraceState(
+      String value,
+      String randomValue,
+      String threshold,
+      String[] unknownFields,
+      int randomValueCount,
+      int originalPosition,
+      int originalSize,
+      boolean locallyGeneratedRandomValue) {
     this.value = value;
+    this.randomValue = randomValue;
+    this.threshold = threshold;
+    this.unknownFields = unknownFields;
+    this.randomValueCount = randomValueCount;
     this.originalPosition = originalPosition;
     this.originalSize = originalSize;
+    this.locallyGeneratedRandomValue = locallyGeneratedRandomValue;
   }
 
   static OtelTraceState parse(String raw, int originalPosition, int originalSize) {
     if (raw == null || raw.isEmpty()) {
       return null;
     }
-    return new OtelTraceState(raw, originalPosition, originalSize);
+    List<String> fields = new ArrayList<>();
+    List<String> unknownFields = new ArrayList<>();
+    String randomValue = null;
+    String threshold = null;
+    int randomValueCount = 0;
+    boolean changed = false;
+    int start = 0;
+    while (start < raw.length()) {
+      int end = raw.indexOf(';', start);
+      if (end < 0) {
+        end = raw.length();
+      }
+      String field = raw.substring(start, end);
+      int separator = field.indexOf(':');
+      String key = separator > 0 ? field.substring(0, separator) : field;
+      String fieldValue = separator > 0 ? field.substring(separator + 1) : "";
+      if ("rv".equals(key)) {
+        if (fieldValue.length() == HEX_DIGITS && isLowercaseHex(fieldValue)) {
+          fields.add(field);
+          if (randomValue == null) {
+            randomValue = fieldValue;
+          }
+          randomValueCount++;
+        } else {
+          changed = true;
+        }
+      } else if ("th".equals(key)) {
+        if (!fieldValue.isEmpty()
+            && fieldValue.length() <= HEX_DIGITS
+            && isLowercaseHex(fieldValue)) {
+          fields.add(field);
+          if (threshold == null) {
+            threshold = fieldValue;
+          }
+        } else {
+          changed = true;
+        }
+      } else if (!field.isEmpty()) {
+        fields.add(field);
+        unknownFields.add(field);
+      } else {
+        changed = true;
+      }
+      start = end + 1;
+    }
+
+    String value = join(fields);
+    if (value == null) {
+      return null;
+    }
+    if (!value.equals(raw)) {
+      changed = true;
+    }
+    return new OtelTraceState(
+        value,
+        randomValue,
+        threshold,
+        unknownFields.toArray(new String[0]),
+        randomValueCount,
+        changed ? 0 : originalPosition,
+        originalSize,
+        false);
+  }
+
+  static OtelTraceState updateProbability(
+      OtelTraceState current,
+      long traceIdLowOrderBits,
+      double sampleRate,
+      boolean sampled,
+      int samplingPriority) {
+    if (sampleRate <= 0 || sampled && samplingPriority <= 0) {
+      return current == null ? null : current.removeLocalProbability();
+    }
+
+    long threshold = Math.round((1 - sampleRate) * THRESHOLD_RANGE);
+    threshold = Math.max(0, Math.min(threshold, MAX_THRESHOLD));
+    long randomValue = (~(traceIdLowOrderBits * KNUTH_FACTOR)) >>> 8;
+    if (sampled && randomValue < threshold) {
+      randomValue = threshold;
+    } else if (!sampled && randomValue >= threshold) {
+      randomValue = threshold == 0 ? 0 : threshold - 1;
+    }
+
+    String[] unknownFields = current == null ? new String[0] : current.unknownFields;
+    int originalSize = current == null ? 0 : current.originalSize;
+    return create(
+        formatRandomValue(randomValue),
+        formatThreshold(threshold),
+        unknownFields,
+        0,
+        originalSize,
+        true);
+  }
+
+  OtelTraceState removeForNonProbabilityDecision() {
+    if (!locallyGeneratedRandomValue && threshold == null && randomValueCount <= 1) {
+      return this;
+    }
+    String retainedRandomValue = locallyGeneratedRandomValue ? null : randomValue;
+    return create(
+        retainedRandomValue,
+        null,
+        unknownFields,
+        0,
+        originalSize,
+        false);
   }
 
   String getValue() {
@@ -32,5 +165,97 @@ final class OtelTraceState {
 
   int getOriginalSize() {
     return originalSize;
+  }
+
+  private OtelTraceState removeLocalProbability() {
+    return locallyGeneratedRandomValue
+        ? create(null, null, unknownFields, 0, originalSize, false)
+        : this;
+  }
+
+  private static OtelTraceState create(
+      String randomValue,
+      String threshold,
+      String[] unknownFields,
+      int originalPosition,
+      int originalSize,
+      boolean locallyGeneratedRandomValue) {
+    StringBuilder value = new StringBuilder();
+    append(value, randomValue == null ? null : "rv:" + randomValue);
+    append(value, threshold == null ? null : "th:" + threshold);
+    for (String field : unknownFields) {
+      append(value, field);
+    }
+    if (value.length() == 0) {
+      return null;
+    }
+    return new OtelTraceState(
+        value.toString(),
+        randomValue,
+        threshold,
+        unknownFields,
+        randomValue == null ? 0 : 1,
+        originalPosition,
+        originalSize,
+        locallyGeneratedRandomValue);
+  }
+
+  private static void append(StringBuilder value, String field) {
+    if (field == null || field.isEmpty()) {
+      return;
+    }
+    int separatorSize = value.length() == 0 ? 0 : 1;
+    if (value.length() + separatorSize + field.length() > MAX_VALUE_LENGTH) {
+      return;
+    }
+    if (separatorSize != 0) {
+      value.append(';');
+    }
+    value.append(field);
+  }
+
+  private static String join(List<String> fields) {
+    if (fields.isEmpty()) {
+      return null;
+    }
+    StringBuilder value = new StringBuilder();
+    for (String field : fields) {
+      if (value.length() != 0) {
+        value.append(';');
+      }
+      value.append(field);
+    }
+    return value.toString();
+  }
+
+  private static boolean isLowercaseHex(String value) {
+    for (int i = 0; i < value.length(); i++) {
+      char character = value.charAt(i);
+      if (!((character >= '0' && character <= '9') || (character >= 'a' && character <= 'f'))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static String formatRandomValue(long randomValue) {
+    String hex = Long.toHexString(randomValue);
+    if (hex.length() == HEX_DIGITS) {
+      return hex;
+    }
+    StringBuilder padded = new StringBuilder(HEX_DIGITS);
+    for (int i = hex.length(); i < HEX_DIGITS; i++) {
+      padded.append('0');
+    }
+    return padded.append(hex).toString();
+  }
+
+  private static String formatThreshold(long threshold) {
+    String hex = formatRandomValue(threshold);
+    int end = hex.length();
+    while (end > 1 && hex.charAt(end - 1) == '0') {
+      end--;
+    }
+    return hex.substring(0, end);
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -113,13 +113,17 @@ final class OtelTraceState {
       double sampleRate,
       boolean sampled,
       int samplingPriority) {
-    if (sampleRate <= 0 || sampled && samplingPriority <= 0) {
+    // `sampled` is the raw probability result; `samplingPriority` may be changed by rate limiting.
+    if (sampleRate <= 0) {
       return current == null ? null : current.removeLocalProbability();
     }
 
-    long threshold = Math.round((1 - sampleRate) * THRESHOLD_RANGE);
-    threshold = Math.max(0, Math.min(threshold, MAX_THRESHOLD));
-    long randomValue = (~(traceIdLowOrderBits * KNUTH_FACTOR)) >>> 8;
+    if (sampled && samplingPriority <= 0) {
+      return current == null ? null : current.removeForNonProbabilityDecision();
+    }
+
+    long threshold = computeThreshold(sampleRate);
+    long randomValue = computeRandomValue(traceIdLowOrderBits);
     if (sampled && randomValue < threshold) {
       randomValue = threshold;
     } else if (!sampled && randomValue >= threshold) {
@@ -236,6 +240,15 @@ final class OtelTraceState {
       }
     }
     return true;
+  }
+
+  private static long computeRandomValue(long traceIdLowOrderBits) {
+    return (~(traceIdLowOrderBits * KNUTH_FACTOR)) >>> 8;
+  }
+
+  private static long computeThreshold(double sampleRate) {
+    long threshold = Math.round((1 - sampleRate) * THRESHOLD_RANGE);
+    return Math.max(0, Math.min(threshold, MAX_THRESHOLD));
   }
 
   private static String formatRandomValue(long randomValue) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -10,6 +10,7 @@ final class OtelTraceState {
   private static final long KNUTH_FACTOR = 1111111111111111111L;
   private static final long MAX_THRESHOLD = (1L << 56) - 1;
   private static final double THRESHOLD_RANGE = 1L << 56;
+  private static final String[] EMPTY_UNKNOWN_FIELDS = new String[0];
 
   private final String value;
   private final String randomValue;
@@ -44,7 +45,7 @@ final class OtelTraceState {
       return null;
     }
     List<String> fields = new ArrayList<>();
-    List<String> unknownFields = new ArrayList<>();
+    List<String> unknownFields = null;
     String randomValue = null;
     String threshold = null;
     int randomValueCount = 0;
@@ -82,6 +83,9 @@ final class OtelTraceState {
         }
       } else if (!field.isEmpty()) {
         fields.add(field);
+        if (unknownFields == null) {
+          unknownFields = new ArrayList<>();
+        }
         unknownFields.add(field);
       } else {
         changed = true;
@@ -100,7 +104,7 @@ final class OtelTraceState {
         value,
         randomValue,
         threshold,
-        unknownFields.toArray(new String[0]),
+        unknownFields == null ? EMPTY_UNKNOWN_FIELDS : unknownFields.toArray(new String[0]),
         randomValueCount,
         changed ? 0 : originalPosition,
         originalSize,
@@ -113,13 +117,20 @@ final class OtelTraceState {
       double sampleRate,
       boolean sampled,
       int samplingPriority) {
-    // `sampled` is the raw probability result; `samplingPriority` may be changed by rate limiting.
-    if (sampleRate <= 0) {
-      return current == null ? null : current.removeLocalProbability();
-    }
+    String[] unknownFields = current == null ? EMPTY_UNKNOWN_FIELDS : current.unknownFields;
+    int originalSize = current == null ? 0 : current.originalSize;
 
+    // `sampled` is the raw probability result; `samplingPriority` may be changed by rate limiting.
     if (sampled && samplingPriority <= 0) {
-      return current == null ? null : current.removeForNonProbabilityDecision();
+      if (current != null) {
+        return current.removeThresholdForLimiterDemotion();
+      }
+      return create(
+          formatRandomValue(computeRandomValue(traceIdLowOrderBits)),
+          null,
+          unknownFields,
+          originalSize,
+          true);
     }
 
     long threshold = computeThreshold(sampleRate);
@@ -130,13 +141,10 @@ final class OtelTraceState {
       randomValue = threshold == 0 ? 0 : threshold - 1;
     }
 
-    String[] unknownFields = current == null ? new String[0] : current.unknownFields;
-    int originalSize = current == null ? 0 : current.originalSize;
     return create(
         formatRandomValue(randomValue),
         formatThreshold(threshold),
         unknownFields,
-        0,
         originalSize,
         true);
   }
@@ -146,13 +154,14 @@ final class OtelTraceState {
       return this;
     }
     String retainedRandomValue = locallyGeneratedRandomValue ? null : randomValue;
-    return create(
-        retainedRandomValue,
-        null,
-        unknownFields,
-        0,
-        originalSize,
-        false);
+    return create(retainedRandomValue, null, unknownFields, originalSize, false);
+  }
+
+  OtelTraceState removeThresholdForLimiterDemotion() {
+    if (threshold == null) {
+      return this;
+    }
+    return create(randomValue, null, unknownFields, originalSize, locallyGeneratedRandomValue);
   }
 
   String getValue() {
@@ -171,17 +180,10 @@ final class OtelTraceState {
     return originalSize;
   }
 
-  private OtelTraceState removeLocalProbability() {
-    return locallyGeneratedRandomValue
-        ? create(null, null, unknownFields, 0, originalSize, false)
-        : this;
-  }
-
   private static OtelTraceState create(
       String randomValue,
       String threshold,
       String[] unknownFields,
-      int originalPosition,
       int originalSize,
       boolean locallyGeneratedRandomValue) {
     StringBuilder value = new StringBuilder();
@@ -199,7 +201,7 @@ final class OtelTraceState {
         threshold,
         unknownFields,
         randomValue == null ? 0 : 1,
-        originalPosition,
+        0,
         originalSize,
         locallyGeneratedRandomValue);
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -1,8 +1,5 @@
 package datadog.trace.core.propagation.ptags;
 
-import java.util.ArrayList;
-import java.util.List;
-
 final class OtelTraceState {
   static final int MAX_VALUE_LENGTH = 256;
 
@@ -10,105 +7,110 @@ final class OtelTraceState {
   private static final long KNUTH_FACTOR = 1111111111111111111L;
   private static final long MAX_THRESHOLD = (1L << 56) - 1;
   private static final double THRESHOLD_RANGE = 1L << 56;
-  private static final String[] EMPTY_UNKNOWN_FIELDS = new String[0];
+  private static final long NO_VALUE = -1;
+  private static final int HAS_MULTIPLE_RANDOM_VALUES = 1;
+  private static final int HAS_LOCALLY_GENERATED_RANDOM_VALUE = 1 << 1;
+  private static final String RANDOM_VALUE_KEY = "rv:";
+  private static final String THRESHOLD_KEY = "th:";
 
   private final String value;
-  private final String randomValue;
-  private final String threshold;
-  private final String[] unknownFields;
-  private final int randomValueCount;
+  private final long randomValue;
+  private final long threshold;
   private final int originalPosition;
   private final int originalSize;
-  private final boolean locallyGeneratedRandomValue;
+  private final int flags;
 
   private OtelTraceState(
       String value,
-      String randomValue,
-      String threshold,
-      String[] unknownFields,
-      int randomValueCount,
+      long randomValue,
+      long threshold,
       int originalPosition,
       int originalSize,
-      boolean locallyGeneratedRandomValue) {
+      int flags) {
     this.value = value;
     this.randomValue = randomValue;
     this.threshold = threshold;
-    this.unknownFields = unknownFields;
-    this.randomValueCount = randomValueCount;
     this.originalPosition = originalPosition;
     this.originalSize = originalSize;
-    this.locallyGeneratedRandomValue = locallyGeneratedRandomValue;
+    this.flags = flags;
   }
 
   static OtelTraceState parse(String raw, int originalPosition, int originalSize) {
     if (raw == null || raw.isEmpty()) {
       return null;
     }
-    List<String> fields = new ArrayList<>();
-    List<String> unknownFields = null;
-    String randomValue = null;
-    String threshold = null;
-    int randomValueCount = 0;
-    boolean changed = false;
+    long randomValue = NO_VALUE;
+    long threshold = NO_VALUE;
+    int flags = 0;
+    StringBuilder normalized = null;
     int start = 0;
     while (start < raw.length()) {
       int end = raw.indexOf(';', start);
       if (end < 0) {
         end = raw.length();
       }
-      String field = raw.substring(start, end);
-      int separator = field.indexOf(':');
-      String key = separator > 0 ? field.substring(0, separator) : field;
-      String fieldValue = separator > 0 ? field.substring(separator + 1) : "";
-      if ("rv".equals(key)) {
-        if (fieldValue.length() == HEX_DIGITS && isLowercaseHex(fieldValue)) {
-          fields.add(field);
-          if (randomValue == null) {
-            randomValue = fieldValue;
+      int separator = raw.indexOf(':', start);
+      if (separator >= end) {
+        separator = -1;
+      }
+      int fieldValueStart = separator < 0 ? end : separator + 1;
+      if (hasKey(raw, start, end, separator, 'r', 'v')) {
+        long parsedRandomValue =
+            end - fieldValueStart == HEX_DIGITS
+                ? parseLowercaseHex(raw, fieldValueStart, end)
+                : NO_VALUE;
+        if (parsedRandomValue != NO_VALUE) {
+          if (randomValue == NO_VALUE) {
+            randomValue = parsedRandomValue;
+          } else {
+            flags |= HAS_MULTIPLE_RANDOM_VALUES;
           }
-          randomValueCount++;
-        } else {
-          changed = true;
-        }
-      } else if ("th".equals(key)) {
-        if (!fieldValue.isEmpty()
-            && fieldValue.length() <= HEX_DIGITS
-            && isLowercaseHex(fieldValue)) {
-          fields.add(field);
-          if (threshold == null) {
-            threshold = fieldValue;
+          if (normalized != null) {
+            appendField(normalized, raw, start, end);
           }
         } else {
-          changed = true;
+          normalized = startNormalizing(raw, normalized, start);
         }
-      } else if (!field.isEmpty()) {
-        fields.add(field);
-        if (unknownFields == null) {
-          unknownFields = new ArrayList<>();
+      } else if (hasKey(raw, start, end, separator, 't', 'h')) {
+        long parsedThreshold =
+            fieldValueStart < end && end - fieldValueStart <= HEX_DIGITS
+                ? parseLowercaseHex(raw, fieldValueStart, end)
+                : NO_VALUE;
+        if (parsedThreshold != NO_VALUE) {
+          if (threshold == NO_VALUE) {
+            threshold = parsedThreshold;
+          }
+          if (normalized != null) {
+            appendField(normalized, raw, start, end);
+          }
+        } else {
+          normalized = startNormalizing(raw, normalized, start);
         }
-        unknownFields.add(field);
+      } else if (start < end) {
+        if (normalized != null) {
+          appendField(normalized, raw, start, end);
+        }
       } else {
-        changed = true;
+        normalized = startNormalizing(raw, normalized, start);
       }
       start = end + 1;
     }
 
-    String value = join(fields);
-    if (value == null) {
-      return null;
+    if (raw.charAt(raw.length() - 1) == ';') {
+      normalized = startNormalizing(raw, normalized, raw.length());
     }
-    if (!value.equals(raw)) {
-      changed = true;
+
+    String value = normalized == null ? raw : normalized.toString();
+    if (value.isEmpty()) {
+      return null;
     }
     return new OtelTraceState(
         value,
         randomValue,
         threshold,
-        unknownFields == null ? EMPTY_UNKNOWN_FIELDS : unknownFields.toArray(new String[0]),
-        randomValueCount,
-        changed ? 0 : originalPosition,
+        normalized == null ? originalPosition : 0,
         originalSize,
-        false);
+        flags);
   }
 
   static OtelTraceState updateProbability(
@@ -117,7 +119,7 @@ final class OtelTraceState {
       double sampleRate,
       boolean sampled,
       int samplingPriority) {
-    String[] unknownFields = current == null ? EMPTY_UNKNOWN_FIELDS : current.unknownFields;
+    String currentValue = current == null ? null : current.value;
     int originalSize = current == null ? 0 : current.originalSize;
 
     // `sampled` is the raw probability result; `samplingPriority` may be changed by rate limiting.
@@ -126,9 +128,9 @@ final class OtelTraceState {
         return current.removeThresholdForLimiterDemotion();
       }
       return create(
-          formatRandomValue(computeRandomValue(traceIdLowOrderBits)),
-          null,
-          unknownFields,
+          computeRandomValue(traceIdLowOrderBits),
+          NO_VALUE,
+          currentValue,
           originalSize,
           true);
     }
@@ -141,27 +143,23 @@ final class OtelTraceState {
       randomValue = threshold == 0 ? 0 : threshold - 1;
     }
 
-    return create(
-        formatRandomValue(randomValue),
-        formatThreshold(threshold),
-        unknownFields,
-        originalSize,
-        true);
+    return create(randomValue, threshold, currentValue, originalSize, true);
   }
 
   OtelTraceState removeForNonProbabilityDecision() {
-    if (!locallyGeneratedRandomValue && threshold == null && randomValueCount <= 1) {
+    if (!hasLocallyGeneratedRandomValue() && threshold == NO_VALUE && !hasMultipleRandomValues()) {
       return this;
     }
-    String retainedRandomValue = locallyGeneratedRandomValue ? null : randomValue;
-    return create(retainedRandomValue, null, unknownFields, originalSize, false);
+    long retainedRandomValue = hasLocallyGeneratedRandomValue() ? NO_VALUE : randomValue;
+    return create(retainedRandomValue, NO_VALUE, value, originalSize, false);
   }
 
   OtelTraceState removeThresholdForLimiterDemotion() {
-    if (threshold == null) {
+    if (threshold == NO_VALUE) {
       return this;
     }
-    return create(randomValue, null, unknownFields, originalSize, locallyGeneratedRandomValue);
+    return create(
+        randomValue, NO_VALUE, value, originalSize, hasLocallyGeneratedRandomValue());
   }
 
   String getValue() {
@@ -181,16 +179,20 @@ final class OtelTraceState {
   }
 
   private static OtelTraceState create(
-      String randomValue,
-      String threshold,
-      String[] unknownFields,
+      long randomValue,
+      long threshold,
+      String previousValue,
       int originalSize,
       boolean locallyGeneratedRandomValue) {
     StringBuilder value = new StringBuilder();
-    append(value, randomValue == null ? null : "rv:" + randomValue);
-    append(value, threshold == null ? null : "th:" + threshold);
-    for (String field : unknownFields) {
-      append(value, field);
+    if (randomValue != NO_VALUE) {
+      appendRandomValue(value, randomValue);
+    }
+    if (threshold != NO_VALUE) {
+      appendThreshold(value, threshold);
+    }
+    if (previousValue != null) {
+      appendUnknownFields(value, previousValue);
     }
     if (value.length() == 0) {
       return null;
@@ -199,49 +201,111 @@ final class OtelTraceState {
         value.toString(),
         randomValue,
         threshold,
-        unknownFields,
-        randomValue == null ? 0 : 1,
         0,
         originalSize,
-        locallyGeneratedRandomValue);
+        locallyGeneratedRandomValue ? HAS_LOCALLY_GENERATED_RANDOM_VALUE : 0);
   }
 
-  private static void append(StringBuilder value, String field) {
-    if (field == null || field.isEmpty()) {
+  private static StringBuilder startNormalizing(String raw, StringBuilder normalized, int start) {
+    if (normalized != null) {
+      return normalized;
+    }
+    normalized = new StringBuilder(raw.length());
+    if (start > 0) {
+      normalized.append(raw, 0, start - 1);
+    }
+    return normalized;
+  }
+
+  private static void appendRandomValue(StringBuilder value, long randomValue) {
+    if (appendFieldPrefix(value, RANDOM_VALUE_KEY.length() + HEX_DIGITS)) {
+      value.append(RANDOM_VALUE_KEY);
+      appendHex(value, randomValue, HEX_DIGITS);
+    }
+  }
+
+  private static void appendThreshold(StringBuilder value, long threshold) {
+    int hexDigits = thresholdHexDigits(threshold);
+    if (appendFieldPrefix(value, THRESHOLD_KEY.length() + hexDigits)) {
+      value.append(THRESHOLD_KEY);
+      appendHex(value, threshold, hexDigits);
+    }
+  }
+
+  private static void appendUnknownFields(StringBuilder value, String previousValue) {
+    int start = 0;
+    while (start < previousValue.length()) {
+      int end = previousValue.indexOf(';', start);
+      if (end < 0) {
+        end = previousValue.length();
+      }
+      int separator = previousValue.indexOf(':', start);
+      if (separator >= end) {
+        separator = -1;
+      }
+      if (!hasKey(previousValue, start, end, separator, 'r', 'v')
+          && !hasKey(previousValue, start, end, separator, 't', 'h')) {
+        appendField(value, previousValue, start, end);
+      }
+      start = end + 1;
+    }
+  }
+
+  private static void appendField(StringBuilder value, String field, int start, int end) {
+    if (!appendFieldPrefix(value, end - start)) {
       return;
     }
+    value.append(field, start, end);
+  }
+
+  private static boolean appendFieldPrefix(StringBuilder value, int fieldLength) {
     int separatorSize = value.length() == 0 ? 0 : 1;
-    if (value.length() + separatorSize + field.length() > MAX_VALUE_LENGTH) {
-      return;
+    if (value.length() + separatorSize + fieldLength > MAX_VALUE_LENGTH) {
+      return false;
     }
     if (separatorSize != 0) {
       value.append(';');
     }
-    value.append(field);
-  }
-
-  private static String join(List<String> fields) {
-    if (fields.isEmpty()) {
-      return null;
-    }
-    StringBuilder value = new StringBuilder();
-    for (String field : fields) {
-      if (value.length() != 0) {
-        value.append(';');
-      }
-      value.append(field);
-    }
-    return value.toString();
-  }
-
-  private static boolean isLowercaseHex(String value) {
-    for (int i = 0; i < value.length(); i++) {
-      char character = value.charAt(i);
-      if (!((character >= '0' && character <= '9') || (character >= 'a' && character <= 'f'))) {
-        return false;
-      }
-    }
     return true;
+  }
+
+  private static boolean hasKey(
+      String value, int start, int end, int separator, char first, char second) {
+    if (separator >= 0) {
+      return separator == start + 2
+          && value.charAt(start) == first
+          && value.charAt(start + 1) == second;
+    }
+    return end == start + 2 && value.charAt(start) == first && value.charAt(start + 1) == second;
+  }
+
+  private static long parseLowercaseHex(String value, int start, int end) {
+    long parsed = 0;
+    for (int i = start; i < end; i++) {
+      char character = value.charAt(i);
+      if (character >= '0' && character <= '9') {
+        parsed = (parsed << 4) | character - '0';
+      } else if (character >= 'a' && character <= 'f') {
+        parsed = (parsed << 4) | character - 'a' + 10;
+      } else {
+        return NO_VALUE;
+      }
+    }
+    return parsed;
+  }
+
+  private boolean hasMultipleRandomValues() {
+    return (flags & HAS_MULTIPLE_RANDOM_VALUES) != 0;
+  }
+
+  private boolean hasLocallyGeneratedRandomValue() {
+    return (flags & HAS_LOCALLY_GENERATED_RANDOM_VALUE) != 0;
+  }
+
+  private static void appendHex(StringBuilder value, long number, int digits) {
+    for (int shift = (HEX_DIGITS - 1) * 4; shift >= (HEX_DIGITS - digits) * 4; shift -= 4) {
+      value.append(Character.forDigit((int) (number >>> shift) & 0xF, 16));
+    }
   }
 
   private static long computeRandomValue(long traceIdLowOrderBits) {
@@ -253,24 +317,12 @@ final class OtelTraceState {
     return Math.max(0, Math.min(threshold, MAX_THRESHOLD));
   }
 
-  private static String formatRandomValue(long randomValue) {
-    String hex = Long.toHexString(randomValue);
-    if (hex.length() == HEX_DIGITS) {
-      return hex;
+  private static int thresholdHexDigits(long threshold) {
+    int digits = HEX_DIGITS;
+    while (digits > 1 && (threshold & 0xF) == 0) {
+      digits--;
+      threshold >>>= 4;
     }
-    StringBuilder padded = new StringBuilder(HEX_DIGITS);
-    for (int i = hex.length(); i < HEX_DIGITS; i++) {
-      padded.append('0');
-    }
-    return padded.append(hex).toString();
-  }
-
-  private static String formatThreshold(long threshold) {
-    String hex = formatRandomValue(threshold);
-    int end = hex.length();
-    while (end > 1 && hex.charAt(end - 1) == '0') {
-      end--;
-    }
-    return hex.substring(0, end);
+    return digits;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/OtelTraceState.java
@@ -3,17 +3,20 @@ package datadog.trace.core.propagation.ptags;
 final class OtelTraceState {
   private final String value;
   private final int inheritedPosition;
+  private final int originalMemberContributionSize;
 
-  private OtelTraceState(String value, int inheritedPosition) {
+  private OtelTraceState(String value, int inheritedPosition, int originalMemberContributionSize) {
     this.value = value;
     this.inheritedPosition = inheritedPosition;
+    this.originalMemberContributionSize = originalMemberContributionSize;
   }
 
-  static OtelTraceState parse(String raw, int inheritedPosition) {
+  static OtelTraceState parse(
+      String raw, int inheritedPosition, int originalMemberContributionSize) {
     if (raw == null || raw.isEmpty()) {
       return null;
     }
-    return new OtelTraceState(raw, inheritedPosition);
+    return new OtelTraceState(raw, inheritedPosition, originalMemberContributionSize);
   }
 
   String getValue() {
@@ -26,5 +29,9 @@ final class OtelTraceState {
 
   int getInheritedPosition() {
     return inheritedPosition;
+  }
+
+  int getOriginalMemberContributionSize() {
+    return originalMemberContributionSize;
   }
 }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsCodec.java
@@ -24,19 +24,20 @@ abstract class PTagsCodec {
   protected static final String PROPAGATION_ERROR_INCONSISTENT_TID = "inconsistent_tid ";
   protected static final TagKey UPSTREAM_SERVICES_DEPRECATED_TAG = TagKey.from("upstream_services");
 
-  static String headerValue(PTagsCodec codec, PTags ptags) {
-    return headerValue(codec, ptags, null);
-  }
-
-  static String headerValue(PTagsCodec codec, PTags ptags, CharSequence lastParentIdOverride) {
-    int estimate = codec.estimateHeaderSize(ptags);
+  static String headerValue(
+      PTagsCodec codec,
+      PTags ptags,
+      CharSequence lastParentIdOverride,
+      OtelTraceState otelTraceState,
+      int samplingPriority) {
+    int estimate = codec.estimateHeaderSize(ptags, otelTraceState);
     if (estimate == 0) {
       return "";
     }
 
     // No encoding validation here because we don't allow arbitrary tag change
     StringBuilder sb = new StringBuilder(estimate);
-    int size = codec.appendPrefix(sb, ptags, lastParentIdOverride);
+    int size = codec.appendPrefix(sb, ptags, lastParentIdOverride, samplingPriority);
     if (!ptags.isPropagationTagsDisabled()) {
       if (ptags.getDecisionMakerTagValue() != null) {
         size = codec.appendTag(sb, DECISION_MAKER_TAG, ptags.getDecisionMakerTagValue(), size);
@@ -72,7 +73,7 @@ abstract class PTagsCodec {
         size = codec.appendTag(sb, tagKey, tagValue, size);
       }
     }
-    size = codec.appendSuffix(sb, ptags, size);
+    size = codec.appendSuffix(sb, ptags, size, otelTraceState);
     if (codec.isTooLarge(sb, size)) {
       return null;
     } else {
@@ -176,6 +177,10 @@ abstract class PTagsCodec {
 
   protected abstract int estimateHeaderSize(PTags pTags);
 
+  protected int estimateHeaderSize(PTags pTags, OtelTraceState otelTraceState) {
+    return estimateHeaderSize(pTags);
+  }
+
   protected abstract int appendPrefix(StringBuilder sb, PTags ptags);
 
   /**
@@ -186,9 +191,19 @@ abstract class PTagsCodec {
     return appendPrefix(sb, ptags);
   }
 
+  protected int appendPrefix(
+      StringBuilder sb, PTags ptags, CharSequence lastParentIdOverride, int samplingPriority) {
+    return appendPrefix(sb, ptags, lastParentIdOverride);
+  }
+
   protected abstract int appendTag(StringBuilder sb, TagElement key, TagElement value, int size);
 
   protected abstract int appendSuffix(StringBuilder sb, PTags ptags, int size);
+
+  protected int appendSuffix(
+      StringBuilder sb, PTags ptags, int size, OtelTraceState otelTraceState) {
+    return appendSuffix(sb, ptags, size);
+  }
 
   protected abstract boolean isTooLarge(StringBuilder sb, int size);
 

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
@@ -112,6 +112,8 @@ public class PTagsFactory implements PropagationTags.Factory {
 
     private volatile TagValue orgPropagationMarkerTagValue;
 
+    private volatile OtelTraceState otelTraceState;
+
     // Static cache for the most-recently-seen rate → TagValue. In steady state a service uses one
     // rate, so this eliminates the char[] + String allocation on every new PTags instance.
     // Writes are benign-racy: two threads computing the same rate produce equal TagValues.
@@ -540,7 +542,20 @@ public class PTagsFactory implements PropagationTags.Factory {
 
     @Override
     public void updateW3CTracestate(String tracestate) {
+      clearCachedHeader(W3C);
       this.tracestate = tracestate;
+      setOtelTraceState(W3CPTagsCodec.extractOtelTraceState(tracestate));
+    }
+
+    OtelTraceState getOtelTraceState() {
+      return otelTraceState;
+    }
+
+    void setOtelTraceState(OtelTraceState otelTraceState) {
+      if (this.otelTraceState != otelTraceState) {
+        this.otelTraceState = otelTraceState;
+        clearCachedHeader(W3C);
+      }
     }
 
     String getError() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
@@ -560,13 +560,16 @@ public class PTagsFactory implements PropagationTags.Factory {
     }
 
     @Override
-    public void updateW3CTracestateFrom(PropagationTags source) {
-      if (!(source instanceof PTags)) {
-        super.updateW3CTracestateFrom(source);
-        return;
+    public void updateW3CTracestateFrom(PropagationTags source, int samplingPriority) {
+      String sourceTracestate = source.getW3CTracestate();
+      OtelTraceState sourceOtelTraceState =
+          source instanceof PTags
+              ? ((PTags) source).getOtelTraceState()
+              : W3CPTagsCodec.extractOtelTraceState(sourceTracestate);
+      setW3CTracestate(sourceTracestate, sourceOtelTraceState);
+      if (samplingPriority != PrioritySampling.UNSET) {
+        this.samplingPriority = samplingPriority;
       }
-      PTags sourcePTags = (PTags) source;
-      setW3CTracestate(sourcePTags.tracestate, sourcePTags.getOtelTraceState());
     }
 
     private void setW3CTracestate(String tracestate, OtelTraceState otelTraceState) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
@@ -542,9 +542,23 @@ public class PTagsFactory implements PropagationTags.Factory {
 
     @Override
     public void updateW3CTracestate(String tracestate) {
+      setW3CTracestate(tracestate, W3CPTagsCodec.extractOtelTraceState(tracestate));
+    }
+
+    @Override
+    public void updateW3CTracestateFrom(PropagationTags source) {
+      if (!(source instanceof PTags)) {
+        super.updateW3CTracestateFrom(source);
+        return;
+      }
+      PTags sourcePTags = (PTags) source;
+      setW3CTracestate(sourcePTags.tracestate, sourcePTags.getOtelTraceState());
+    }
+
+    private void setW3CTracestate(String tracestate, OtelTraceState otelTraceState) {
       clearCachedHeader(W3C);
       this.tracestate = tracestate;
-      setOtelTraceState(W3CPTagsCodec.extractOtelTraceState(tracestate));
+      this.otelTraceState = otelTraceState;
     }
 
     OtelTraceState getOtelTraceState() {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
@@ -113,6 +113,7 @@ public class PTagsFactory implements PropagationTags.Factory {
     private volatile TagValue orgPropagationMarkerTagValue;
 
     private volatile OtelTraceState otelTraceState;
+    private volatile OtelSamplingDecision otelSamplingDecision;
 
     // Static cache for the most-recently-seen rate → TagValue. In steady state a service uses one
     // rate, so this eliminates the char[] + String allocation on every new PTags instance.
@@ -267,17 +268,15 @@ public class PTagsFactory implements PropagationTags.Factory {
         }
         decisionMakerTagValue = null;
       }
-      if (removeOtelProbability && otelTraceState != null) {
-        setOtelTraceState(otelTraceState.removeForNonProbabilityDecision());
+      if (removeOtelProbability) {
+        setOtelSamplingDecision(OtelSamplingDecision.NON_PROBABILITY);
       }
     }
 
     @Override
-    public void updateOtelTraceState(
-        long traceIdLowOrderBits, double sampleRate, boolean sampled, int samplingPriority) {
-      setOtelTraceState(
-          OtelTraceState.updateProbability(
-              otelTraceState, traceIdLowOrderBits, sampleRate, sampled, samplingPriority));
+    public void updateOtelTraceState(long traceIdLowOrderBits, double sampleRate, boolean sampled) {
+      setOtelSamplingDecision(
+          OtelSamplingDecision.probability(traceIdLowOrderBits, sampleRate, sampled));
     }
 
     @Override
@@ -442,7 +441,13 @@ public class PTagsFactory implements PropagationTags.Factory {
     public String headerValue(HeaderType headerType) {
       String header = getCachedHeader(headerType);
       if (header == null) {
-        header = PTagsCodec.headerValue(factory.getDecoderEncoder(headerType), this);
+        header =
+            PTagsCodec.headerValue(
+                factory.getDecoderEncoder(headerType),
+                this,
+                null,
+                resolveOtelTraceState(headerType, samplingPriority),
+                samplingPriority);
         if (header != null) {
           setCachedHeader(headerType, header);
         } else {
@@ -464,7 +469,28 @@ public class PTagsFactory implements PropagationTags.Factory {
       // Inject-time path: encode fresh with the override; do NOT cache — the W3C `p:` is
       // per-injecting-span and these tags may be shared across sibling spans.
       String header =
-          PTagsCodec.headerValue(factory.getDecoderEncoder(headerType), this, lastParentIdOverride);
+          PTagsCodec.headerValue(
+              factory.getDecoderEncoder(headerType),
+              this,
+              lastParentIdOverride,
+              resolveOtelTraceState(headerType, samplingPriority),
+              samplingPriority);
+      return (header == null || header.isEmpty()) ? null : header;
+    }
+
+    @Override
+    public String headerValue(
+        HeaderType headerType, CharSequence lastParentIdOverride, int samplingPriority) {
+      if (lastParentIdOverride == null && samplingPriority == this.samplingPriority) {
+        return headerValue(headerType);
+      }
+      String header =
+          PTagsCodec.headerValue(
+              factory.getDecoderEncoder(headerType),
+              this,
+              lastParentIdOverride,
+              resolveOtelTraceState(headerType, samplingPriority),
+              samplingPriority);
       return (header == null || header.isEmpty()) ? null : header;
     }
 
@@ -560,16 +586,13 @@ public class PTagsFactory implements PropagationTags.Factory {
     }
 
     @Override
-    public void updateW3CTracestateFrom(PropagationTags source, int samplingPriority) {
-      String sourceTracestate = source.getW3CTracestate();
-      OtelTraceState sourceOtelTraceState =
-          source instanceof PTags
-              ? ((PTags) source).getOtelTraceState()
-              : W3CPTagsCodec.extractOtelTraceState(sourceTracestate);
-      setW3CTracestate(sourceTracestate, sourceOtelTraceState);
-      if (samplingPriority != PrioritySampling.UNSET) {
-        this.samplingPriority = samplingPriority;
+    public void updateW3CTracestateFrom(PropagationTags source) {
+      if (!(source instanceof PTags)) {
+        super.updateW3CTracestateFrom(source);
+        return;
       }
+      PTags sourcePTags = (PTags) source;
+      setW3CTracestate(sourcePTags.tracestate, sourcePTags.getOtelTraceState());
     }
 
     private void setW3CTracestate(String tracestate, OtelTraceState otelTraceState) {
@@ -585,6 +608,26 @@ public class PTagsFactory implements PropagationTags.Factory {
     void setOtelTraceState(OtelTraceState otelTraceState) {
       if (this.otelTraceState != otelTraceState) {
         this.otelTraceState = otelTraceState;
+        clearCachedHeader(W3C);
+      }
+    }
+
+    private OtelTraceState resolveOtelTraceState(HeaderType headerType, int samplingPriority) {
+      OtelTraceState current = otelTraceState;
+      if (headerType != W3C) {
+        return current;
+      }
+      OtelSamplingDecision decision = otelSamplingDecision;
+      OtelTraceState resolved =
+          decision == null ? current : decision.resolve(current, samplingPriority);
+      return resolved == null || samplingPriority == PrioritySampling.UNSET
+          ? resolved
+          : resolved.reconcileSamplingDecision(samplingPriority > 0);
+    }
+
+    private void setOtelSamplingDecision(OtelSamplingDecision decision) {
+      if (otelSamplingDecision != decision) {
+        otelSamplingDecision = decision;
         clearCachedHeader(W3C);
       }
     }
@@ -616,6 +659,63 @@ public class PTagsFactory implements PropagationTags.Factory {
           return true;
         default:
           return false;
+      }
+    }
+
+    private static final class OtelSamplingDecision {
+      private static final OtelSamplingDecision NON_PROBABILITY =
+          new OtelSamplingDecision(0, 0, false, false);
+
+      private final long traceIdLowOrderBits;
+      private final double sampleRate;
+      private final boolean sampled;
+      private final boolean probability;
+      private volatile Resolution resolution;
+
+      private OtelSamplingDecision(
+          long traceIdLowOrderBits, double sampleRate, boolean sampled, boolean probability) {
+        this.traceIdLowOrderBits = traceIdLowOrderBits;
+        this.sampleRate = sampleRate;
+        this.sampled = sampled;
+        this.probability = probability;
+      }
+
+      private static OtelSamplingDecision probability(
+          long traceIdLowOrderBits, double sampleRate, boolean sampled) {
+        return new OtelSamplingDecision(traceIdLowOrderBits, sampleRate, sampled, true);
+      }
+
+      private OtelTraceState resolve(OtelTraceState current, int samplingPriority) {
+        Resolution cached = resolution;
+        if (cached != null
+            && cached.source == current
+            && cached.samplingPriority == samplingPriority) {
+          return cached.resolved;
+        }
+        OtelTraceState resolved;
+        if (!probability) {
+          resolved = current == null ? null : current.removeForNonProbabilityDecision();
+        } else if (current != null) {
+          resolved = current;
+        } else {
+          resolved =
+              OtelTraceState.updateProbability(
+                  null, traceIdLowOrderBits, sampleRate, sampled, samplingPriority);
+        }
+        resolution = new Resolution(current, samplingPriority, resolved);
+        return resolved;
+      }
+
+      private static final class Resolution {
+        private final OtelTraceState source;
+        private final int samplingPriority;
+        private final OtelTraceState resolved;
+
+        private Resolution(OtelTraceState source, int samplingPriority, OtelTraceState resolved) {
+          this.source = source;
+          this.samplingPriority = samplingPriority;
+          this.resolved = resolved;
+        }
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
@@ -606,7 +606,7 @@ public class PTagsFactory implements PropagationTags.Factory {
         return;
       }
       PTags sourcePTags = (PTags) source;
-      setW3CTracestate(sourcePTags.tracestate, sourcePTags.getOtelTraceState());
+      setW3CTracestate(sourcePTags.tracestate, sourcePTags.getOtelTraceStateForW3C());
     }
 
     private void setW3CTracestate(String tracestate, OtelTraceState otelTraceState) {
@@ -615,8 +615,14 @@ public class PTagsFactory implements PropagationTags.Factory {
       this.otelTraceState = otelTraceState;
     }
 
-    OtelTraceState getOtelTraceState() {
+    OtelTraceState getOtelTraceStateForW3C() {
       return otelTraceState;
+    }
+
+    @Override
+    public String getOtelTraceState() {
+      OtelTraceState state = otelTraceState;
+      return state == null ? null : state.getValue();
     }
 
     void setOtelTraceState(OtelTraceState otelTraceState) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
@@ -233,6 +233,9 @@ public class PTagsFactory implements PropagationTags.Factory {
     }
 
     private void doUpdateTraceSamplingPriority(int samplingPriority, int samplingMechanism) {
+      boolean removeOtelProbability =
+          samplingMechanism != SamplingMechanism.EXTERNAL_OVERRIDE
+              && !isProbabilitySamplingMechanism(samplingMechanism);
       if (this.samplingPriority != samplingPriority) {
         // This should invalidate any cached w3c header
         clearCachedHeader(W3C);
@@ -264,6 +267,17 @@ public class PTagsFactory implements PropagationTags.Factory {
         }
         decisionMakerTagValue = null;
       }
+      if (removeOtelProbability && otelTraceState != null) {
+        setOtelTraceState(otelTraceState.removeForNonProbabilityDecision());
+      }
+    }
+
+    @Override
+    public void updateOtelTraceState(
+        long traceIdLowOrderBits, double sampleRate, boolean sampled, int samplingPriority) {
+      setOtelTraceState(
+          OtelTraceState.updateProbability(
+              otelTraceState, traceIdLowOrderBits, sampleRate, sampled, samplingPriority));
     }
 
     @Override
@@ -585,6 +599,20 @@ public class PTagsFactory implements PropagationTags.Factory {
           clearCachedHeader(DATADOG);
           clearCachedHeader(W3C);
         }
+      }
+    }
+
+    private static boolean isProbabilitySamplingMechanism(int samplingMechanism) {
+      switch (samplingMechanism) {
+        case SamplingMechanism.AGENT_RATE:
+        case SamplingMechanism.REMOTE_AUTO_RATE:
+        case SamplingMechanism.LOCAL_USER_RULE:
+        case SamplingMechanism.REMOTE_USER_RATE:
+        case SamplingMechanism.REMOTE_USER_RULE:
+        case SamplingMechanism.REMOTE_ADAPTIVE_RULE:
+          return true;
+        default:
+          return false;
       }
     }
   }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/PTagsFactory.java
@@ -234,8 +234,12 @@ public class PTagsFactory implements PropagationTags.Factory {
     }
 
     private void doUpdateTraceSamplingPriority(int samplingPriority, int samplingMechanism) {
+      boolean initialUnknownPriority =
+          this.samplingPriority == PrioritySampling.UNSET
+              && samplingMechanism == SamplingMechanism.UNKNOWN;
       boolean removeOtelProbability =
-          samplingMechanism != SamplingMechanism.EXTERNAL_OVERRIDE
+          !initialUnknownPriority
+              && samplingMechanism != SamplingMechanism.EXTERNAL_OVERRIDE
               && !isProbabilitySamplingMechanism(samplingMechanism);
       if (this.samplingPriority != samplingPriority) {
         // This should invalidate any cached w3c header
@@ -578,6 +582,16 @@ public class PTagsFactory implements PropagationTags.Factory {
     @Override
     public String getW3CTracestate() {
       return this.tracestate;
+    }
+
+    @Override
+    public String getW3CTracestate(int samplingPriority) {
+      OtelTraceState current = otelTraceState;
+      OtelTraceState resolved = resolveOtelTraceState(W3C, samplingPriority);
+      if (current == resolved) {
+        return tracestate;
+      }
+      return W3CPTagsCodec.updateOtelTraceState(this, resolved);
     }
 
     @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -50,13 +50,19 @@ public class W3CPTagsCodec extends PTagsCodec {
     int ddMemberValueEnd = -1; // dd member value end position including OWS (exclusive)
     int memberIndex = 0;
     int ddMemberIndex = -1;
+    int otelMemberValueStart = -1;
+    int otelMemberValueEnd = -1;
+    int otelMemberPosition = 0;
+    int otherMemberPosition = 0;
     while (memberStart < len) {
       if (memberIndex == MAX_MEMBER_COUNT) {
         // TODO should we return one with an error?
         // TODO should we try to pick up the `dd` member anyway?
         return tagsFactory.empty();
       }
-      if (ddMemberIndex == -1 && value.startsWith(DATADOG_MEMBER_KEY, memberStart)) {
+      boolean datadogMember = value.startsWith(DATADOG_MEMBER_KEY, memberStart);
+      boolean otelMember = value.startsWith(OTEL_MEMBER_KEY, memberStart);
+      if (ddMemberIndex == -1 && datadogMember) {
         ddMemberStart = memberStart;
         ddMemberIndex = memberIndex;
       }
@@ -69,6 +75,7 @@ public class W3CPTagsCodec extends PTagsCodec {
       if (ddMemberValueStart == -1 && ddMemberIndex != -1) {
         ddMemberValueStart = pos;
       }
+      int memberValueStart = pos;
       pos = validateMemberValue(value, pos);
       if (pos < 0) {
         // TODO should we return one with an error?
@@ -76,6 +83,15 @@ public class W3CPTagsCodec extends PTagsCodec {
       }
       if (ddMemberValueEnd == -1 && ddMemberIndex != -1) {
         ddMemberValueEnd = pos;
+      }
+      if (otelMemberValueStart == -1) {
+        if (otelMember) {
+          otelMemberValueStart = memberValueStart;
+          otelMemberValueEnd = stripTrailingOWC(value, memberValueStart, pos);
+          otelMemberPosition = otherMemberPosition;
+        } else if (!datadogMember) {
+          otherMemberPosition++;
+        }
       }
       memberStart = findNextMember(value, pos);
       if (memberStart < 0) {
@@ -85,9 +101,15 @@ public class W3CPTagsCodec extends PTagsCodec {
       memberIndex++;
     }
 
+    OtelTraceState otelTraceState =
+        otelMemberValueStart < 0
+            ? null
+            : OtelTraceState.parse(
+                value.substring(otelMemberValueStart, otelMemberValueEnd), otelMemberPosition);
+
     if (ddMemberIndex == -1) {
       // There was no dd member, so create an empty one with the _suffix_
-      return empty(tagsFactory, value, extractOtelTraceState(value));
+      return empty(tagsFactory, value, otelTraceState);
     }
 
     List<TagElement> tagPairs = null;
@@ -159,7 +181,13 @@ public class W3CPTagsCodec extends PTagsCodec {
               if (tagKey.equals(TRACE_ID_TAG)) {
                 return tagsFactory.createInvalid(PROPAGATION_ERROR_MALFORMED_TID + tagValue);
               }
-              return empty(tagsFactory, value, firstMemberStart, ddMemberStart, ddMemberValueEnd);
+              return empty(
+                  tagsFactory,
+                  value,
+                  firstMemberStart,
+                  ddMemberStart,
+                  ddMemberValueEnd,
+                  otelTraceState);
             }
             if (tagKey.equals(DECISION_MAKER_TAG)) {
               decisionMakerTagValue = tagValue;
@@ -203,7 +231,7 @@ public class W3CPTagsCodec extends PTagsCodec {
         maxUnknownSize,
         lastParentId,
         orgPropagationMarkerTagValue,
-        extractOtelTraceState(value));
+        otelTraceState);
   }
 
   @Override
@@ -801,21 +829,6 @@ public class W3CPTagsCodec extends PTagsCodec {
   private static W3CPTags empty(
       PTagsFactory factory, String original, OtelTraceState otelTraceState) {
     return empty(factory, original, 0, -1, -1, otelTraceState);
-  }
-
-  private static W3CPTags empty(
-      PTagsFactory factory,
-      String original,
-      int firstMemberStart,
-      int ddMemberStart,
-      int ddMemberValueEnd) {
-    return empty(
-        factory,
-        original,
-        firstMemberStart,
-        ddMemberStart,
-        ddMemberValueEnd,
-        extractOtelTraceState(original));
   }
 
   private static W3CPTags empty(

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -21,6 +21,7 @@ public class W3CPTagsCodec extends PTagsCodec {
 
   private static final int MAX_HEADER_SIZE = 256;
   private static final String DATADOG_MEMBER_KEY = "dd=";
+  private static final String OTEL_MEMBER_KEY = "ot=";
   private static final int EMPTY_SIZE = DATADOG_MEMBER_KEY.length(); // 3
   private static final char MEMBER_SEPARATOR = ',';
   private static final char ELEMENT_SEPARATOR = ';';
@@ -86,7 +87,7 @@ public class W3CPTagsCodec extends PTagsCodec {
 
     if (ddMemberIndex == -1) {
       // There was no dd member, so create an empty one with the _suffix_
-      return empty(tagsFactory, value);
+      return empty(tagsFactory, value, extractOtelTraceState(value));
     }
 
     List<TagElement> tagPairs = null;
@@ -201,7 +202,8 @@ public class W3CPTagsCodec extends PTagsCodec {
         ddMemberValueEnd,
         maxUnknownSize,
         lastParentId,
-        orgPropagationMarkerTagValue);
+        orgPropagationMarkerTagValue,
+        extractOtelTraceState(value));
   }
 
   @Override
@@ -225,6 +227,10 @@ public class W3CPTagsCodec extends PTagsCodec {
     } else if (pTags.tracestate != null) {
       // We assume there is no Datadog list-member
       size += pTags.tracestate.length();
+    }
+    OtelTraceState otelTraceState = pTags.getOtelTraceState();
+    if (otelTraceState != null) {
+      size += OTEL_MEMBER_KEY.length() + otelTraceState.length() + 1;
     }
     return size;
   }
@@ -290,9 +296,8 @@ public class W3CPTagsCodec extends PTagsCodec {
       sb.setLength(0);
       size = 0;
     }
-    // Append all other non-Datadog list-members
-    int newSize = cleanUpAndAppendSuffix(sb, ptags, size);
-    if (newSize != size) {
+    // Append the managed OTel member and all other non-Datadog list-members
+    if (appendOtelAndVendorMembers(sb, ptags, size != 0)) {
       // We don't care about the total size in bytes here, but only the fact that we added something
       // that should be returned
       size = Math.max(size, EMPTY_SIZE + 1);
@@ -698,50 +703,104 @@ public class W3CPTagsCodec extends PTagsCodec {
     return size;
   }
 
-  private static int cleanUpAndAppendSuffix(StringBuilder sb, PTags ptags, int size) {
+  private static boolean appendOtelAndVendorMembers(
+      StringBuilder sb, PTags ptags, boolean hasDatadogMember) {
     String original = ptags.tracestate;
-    if (original == null) {
-      return size;
-    }
-    int ddMemberStart = (ptags instanceof W3CPTags) ? ((W3CPTags) ptags).ddMemberStart : -1;
-    int remainingMemberAllowed = size == 0 ? MAX_MEMBER_COUNT : MAX_MEMBER_COUNT - 1;
-    int len = original.length();
-    int memberStart = findNextMember(original, 0);
-    while (memberStart < len) {
+    OtelTraceState otelTraceState = ptags.getOtelTraceState();
+    int remainingMembers = MAX_MEMBER_COUNT - (hasDatadogMember ? 1 : 0);
+    int otherMemberPosition = 0;
+    boolean otelTraceStateAppended = false;
+    boolean memberAppended = false;
+    int len = original == null ? 0 : original.length();
+    int memberStart = original == null ? 0 : findNextMember(original, 0);
+    while (memberStart < len && remainingMembers > 0) {
       // Look for member end position
       int memberEnd = original.indexOf(MEMBER_SEPARATOR, memberStart);
       if (memberEnd < 0) {
         memberEnd = len;
       }
-      // Try to define Datadog member start if not already found
-      if (ddMemberStart == -1) {
-        if (original.startsWith(DATADOG_MEMBER_KEY, memberStart)) {
-          ddMemberStart = memberStart;
-        }
-      }
-      // Skip Datadog member (already added with prefix and tags)
-      if (memberStart != ddMemberStart) {
-        if (sb.length() > 0) {
-          sb.append(MEMBER_SEPARATOR);
-          size++;
+      boolean managedMember =
+          original.startsWith(DATADOG_MEMBER_KEY, memberStart)
+              || original.startsWith(OTEL_MEMBER_KEY, memberStart);
+      if (!managedMember) {
+        if (otelTraceState != null
+            && !otelTraceStateAppended
+            && otelTraceState.getInheritedPosition() == otherMemberPosition) {
+          appendMember(sb, OTEL_MEMBER_KEY, otelTraceState.getValue());
+          remainingMembers--;
+          otelTraceStateAppended = true;
+          memberAppended = true;
+          if (remainingMembers == 0) {
+            break;
+          }
         }
         int end = stripTrailingOWC(original, memberStart, memberEnd);
-        sb.append(original, memberStart, end);
-        size += (end - memberStart);
-        remainingMemberAllowed--;
+        appendMember(sb, original, memberStart, end);
+        remainingMembers--;
+        otherMemberPosition++;
+        memberAppended = true;
       }
-      // Check if remaining members are allowed
-      if (remainingMemberAllowed == 0) {
-        memberStart = len;
-      } else {
-        memberStart = findNextMember(original, memberEnd + 1);
-      }
+      memberStart = findNextMember(original, memberEnd + 1);
     }
-    return size;
+    if (otelTraceState != null
+        && !otelTraceStateAppended
+        && remainingMembers > 0
+        && otelTraceState.getInheritedPosition() == otherMemberPosition) {
+      appendMember(sb, OTEL_MEMBER_KEY, otelTraceState.getValue());
+      memberAppended = true;
+    }
+    return memberAppended;
+  }
+
+  private static void appendMember(StringBuilder sb, String member, int start, int end) {
+    if (sb.length() != 0) {
+      sb.append(MEMBER_SEPARATOR);
+    }
+    sb.append(member, start, end);
+  }
+
+  private static void appendMember(StringBuilder sb, String key, String value) {
+    if (sb.length() != 0) {
+      sb.append(MEMBER_SEPARATOR);
+    }
+    sb.append(key).append(value);
+  }
+
+  static OtelTraceState extractOtelTraceState(String tracestate) {
+    if (tracestate == null || tracestate.isEmpty()) {
+      return null;
+    }
+    int otherMemberPosition = 0;
+    int memberStart = findNextMember(tracestate, 0);
+    while (memberStart < tracestate.length()) {
+      int memberValueStart = validateMemberKey(tracestate, memberStart);
+      if (memberValueStart < 0) {
+        return null;
+      }
+      int memberValueEnd = validateMemberValue(tracestate, memberValueStart);
+      if (memberValueEnd < 0) {
+        return null;
+      }
+      if (tracestate.startsWith(OTEL_MEMBER_KEY, memberStart)) {
+        int end = stripTrailingOWC(tracestate, memberValueStart, memberValueEnd);
+        return OtelTraceState.parse(
+            tracestate.substring(memberValueStart, end), otherMemberPosition);
+      }
+      if (!tracestate.startsWith(DATADOG_MEMBER_KEY, memberStart)) {
+        otherMemberPosition++;
+      }
+      memberStart = findNextMember(tracestate, memberValueEnd);
+    }
+    return null;
   }
 
   static W3CPTags empty(PTagsFactory factory, String original) {
-    return empty(factory, original, 0, -1, -1);
+    return empty(factory, original, extractOtelTraceState(original));
+  }
+
+  private static W3CPTags empty(
+      PTagsFactory factory, String original, OtelTraceState otelTraceState) {
+    return empty(factory, original, 0, -1, -1, otelTraceState);
   }
 
   private static W3CPTags empty(
@@ -750,6 +809,22 @@ public class W3CPTagsCodec extends PTagsCodec {
       int firstMemberStart,
       int ddMemberStart,
       int ddMemberValueEnd) {
+    return empty(
+        factory,
+        original,
+        firstMemberStart,
+        ddMemberStart,
+        ddMemberValueEnd,
+        extractOtelTraceState(original));
+  }
+
+  private static W3CPTags empty(
+      PTagsFactory factory,
+      String original,
+      int firstMemberStart,
+      int ddMemberStart,
+      int ddMemberValueEnd,
+      OtelTraceState otelTraceState) {
     return new W3CPTags(
         factory,
         null,
@@ -764,7 +839,8 @@ public class W3CPTagsCodec extends PTagsCodec {
         ddMemberValueEnd,
         0,
         null,
-        null);
+        null,
+        otelTraceState);
   }
 
   private static class W3CPTags extends PTags {
@@ -799,7 +875,8 @@ public class W3CPTagsCodec extends PTagsCodec {
         int ddMemberValueEnd,
         int maxUnknownSize,
         CharSequence lastParentId,
-        TagValue orgPropagationMarkerTagValue) {
+        TagValue orgPropagationMarkerTagValue,
+        OtelTraceState otelTraceState) {
       super(
           factory,
           tagPairs,
@@ -815,6 +892,7 @@ public class W3CPTagsCodec extends PTagsCodec {
       this.ddMemberStart = ddMemberStart;
       this.ddMemberValueEnd = ddMemberValueEnd;
       this.maxUnknownSize = maxUnknownSize;
+      setOtelTraceState(otelTraceState);
     }
 
     @Override

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -229,6 +229,11 @@ public class W3CPTagsCodec extends PTagsCodec {
 
   @Override
   protected int estimateHeaderSize(PTags pTags) {
+    return estimateHeaderSize(pTags, pTags.getOtelTraceState());
+  }
+
+  @Override
+  protected int estimateHeaderSize(PTags pTags, OtelTraceState otelTraceState) {
     int size = EMPTY_SIZE + 1; // 'dd=' and delimiter;
     // Yes, this is a bit much, but better safe than sorry
     size += pTags.getXDatadogTagsSize();
@@ -252,7 +257,6 @@ public class W3CPTagsCodec extends PTagsCodec {
       size += pTags.tracestate.length();
       includesOriginalTracestate = true;
     }
-    OtelTraceState otelTraceState = pTags.getOtelTraceState();
     if (otelTraceState != null) {
       size -= includesOriginalTracestate ? otelTraceState.getOriginalSize() : 0;
       size += OTEL_MEMBER_KEY.length() + otelTraceState.length() + 1;
@@ -267,11 +271,17 @@ public class W3CPTagsCodec extends PTagsCodec {
 
   @Override
   protected int appendPrefix(StringBuilder sb, PTags ptags, CharSequence lastParentIdOverride) {
+    return appendPrefix(sb, ptags, lastParentIdOverride, ptags.getSamplingPriority());
+  }
+
+  @Override
+  protected int appendPrefix(
+      StringBuilder sb, PTags ptags, CharSequence lastParentIdOverride, int samplingPriority) {
     sb.append(DATADOG_MEMBER_KEY);
     // Append sampling priority (s)
-    if (ptags.getSamplingPriority() != PrioritySampling.UNSET) {
+    if (samplingPriority != PrioritySampling.UNSET) {
       sb.append("s:");
-      sb.append(ptags.getSamplingPriority());
+      sb.append(samplingPriority);
     }
     // Append origin (o)
     CharSequence origin = ptags.getOrigin();
@@ -310,6 +320,12 @@ public class W3CPTagsCodec extends PTagsCodec {
 
   @Override
   protected int appendSuffix(StringBuilder sb, PTags ptags, int size) {
+    return appendSuffix(sb, ptags, size, ptags.getOtelTraceState());
+  }
+
+  @Override
+  protected int appendSuffix(
+      StringBuilder sb, PTags ptags, int size, OtelTraceState otelTraceState) {
     // If there is room for appending unknown from W3CPTags
     if (size < MAX_HEADER_SIZE && ptags instanceof W3CPTags) {
       W3CPTags w3cPTags = (W3CPTags) ptags;
@@ -322,7 +338,7 @@ public class W3CPTagsCodec extends PTagsCodec {
       size = 0;
     }
     // Append the managed OTel member and all other non-Datadog list-members
-    if (appendOtelAndVendorMembers(sb, ptags, size != 0)) {
+    if (appendOtelAndVendorMembers(sb, ptags, otelTraceState, size != 0)) {
       // We don't care about the total size in bytes here, but only the fact that we added something
       // that should be returned
       size = Math.max(size, EMPTY_SIZE + 1);
@@ -729,9 +745,8 @@ public class W3CPTagsCodec extends PTagsCodec {
   }
 
   private static boolean appendOtelAndVendorMembers(
-      StringBuilder sb, PTags ptags, boolean hasDatadogMember) {
+      StringBuilder sb, PTags ptags, OtelTraceState otelTraceState, boolean hasDatadogMember) {
     String original = ptags.tracestate;
-    OtelTraceState otelTraceState = ptags.getOtelTraceState();
     int remainingMembers = MAX_MEMBER_COUNT - (hasDatadogMember ? 1 : 0);
     int otherMemberPosition = 0;
     boolean otelTraceStateAppended = false;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -50,6 +50,7 @@ public class W3CPTagsCodec extends PTagsCodec {
     int ddMemberValueEnd = -1; // dd member value end position including OWS (exclusive)
     int memberIndex = 0;
     int ddMemberIndex = -1;
+    OtelTraceState otelTraceState = null;
     while (memberStart < len) {
       if (memberIndex == MAX_MEMBER_COUNT) {
         // TODO should we return one with an error?

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -50,8 +50,10 @@ public class W3CPTagsCodec extends PTagsCodec {
     int ddMemberValueEnd = -1; // dd member value end position including OWS (exclusive)
     int memberIndex = 0;
     int ddMemberIndex = -1;
+    int otelMemberStart = -1;
     int otelMemberValueStart = -1;
     int otelMemberValueEnd = -1;
+    int otelMemberEnd = -1;
     int otelMemberPosition = 0;
     int otherMemberPosition = 0;
     while (memberStart < len) {
@@ -86,8 +88,10 @@ public class W3CPTagsCodec extends PTagsCodec {
       }
       if (otelMemberValueStart == -1) {
         if (otelMember) {
+          otelMemberStart = memberStart;
           otelMemberValueStart = memberValueStart;
           otelMemberValueEnd = stripTrailingOWC(value, memberValueStart, pos);
+          otelMemberEnd = pos;
           otelMemberPosition = otherMemberPosition;
         } else if (!datadogMember) {
           otherMemberPosition++;
@@ -105,7 +109,9 @@ public class W3CPTagsCodec extends PTagsCodec {
         otelMemberValueStart < 0
             ? null
             : OtelTraceState.parse(
-                value.substring(otelMemberValueStart, otelMemberValueEnd), otelMemberPosition);
+                value.substring(otelMemberValueStart, otelMemberValueEnd),
+                otelMemberPosition,
+                memberContributionSize(value, firstMemberStart, otelMemberStart, otelMemberEnd));
 
     if (ddMemberIndex == -1) {
       // There was no dd member, so create an empty one with the _suffix_
@@ -245,19 +251,23 @@ public class W3CPTagsCodec extends PTagsCodec {
     if (pTags.getSamplingPriority() != PrioritySampling.UNSET) {
       size += 5; // 's:-?[0-9]' + delimiter
     }
+    boolean includesOriginalTracestate = false;
     if (pTags instanceof W3CPTags) {
       W3CPTags w3CPTags = (W3CPTags) pTags;
       size += w3CPTags.maxUnknownSize;
       if (w3CPTags.ddMemberStart != -1) {
         size +=
             (w3CPTags.tracestate.length() - (w3CPTags.ddMemberValueEnd - w3CPTags.ddMemberStart));
+        includesOriginalTracestate = true;
       }
     } else if (pTags.tracestate != null) {
       // We assume there is no Datadog list-member
       size += pTags.tracestate.length();
+      includesOriginalTracestate = true;
     }
     OtelTraceState otelTraceState = pTags.getOtelTraceState();
     if (otelTraceState != null) {
+      size -= includesOriginalTracestate ? otelTraceState.getOriginalMemberContributionSize() : 0;
       size += OTEL_MEMBER_KEY.length() + otelTraceState.length() + 1;
     }
     return size;
@@ -799,7 +809,8 @@ public class W3CPTagsCodec extends PTagsCodec {
       return null;
     }
     int otherMemberPosition = 0;
-    int memberStart = findNextMember(tracestate, 0);
+    int firstMemberStart = findNextMember(tracestate, 0);
+    int memberStart = firstMemberStart;
     while (memberStart < tracestate.length()) {
       int memberValueStart = validateMemberKey(tracestate, memberStart);
       if (memberValueStart < 0) {
@@ -812,7 +823,9 @@ public class W3CPTagsCodec extends PTagsCodec {
       if (tracestate.startsWith(OTEL_MEMBER_KEY, memberStart)) {
         int end = stripTrailingOWC(tracestate, memberValueStart, memberValueEnd);
         return OtelTraceState.parse(
-            tracestate.substring(memberValueStart, end), otherMemberPosition);
+            tracestate.substring(memberValueStart, end),
+            otherMemberPosition,
+            memberContributionSize(tracestate, firstMemberStart, memberStart, memberValueEnd));
       }
       if (!tracestate.startsWith(DATADOG_MEMBER_KEY, memberStart)) {
         otherMemberPosition++;
@@ -820,6 +833,13 @@ public class W3CPTagsCodec extends PTagsCodec {
       memberStart = findNextMember(tracestate, memberValueEnd);
     }
     return null;
+  }
+
+  private static int memberContributionSize(
+      String tracestate, int firstMemberStart, int memberStart, int memberEnd) {
+    int memberSize = memberEnd - memberStart;
+    boolean isOnlyMember = memberStart == firstMemberStart && memberEnd == tracestate.length();
+    return isOnlyMember ? memberSize : memberSize + 1;
   }
 
   static W3CPTags empty(PTagsFactory factory, String original) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -57,19 +57,19 @@ public class W3CPTagsCodec extends PTagsCodec {
     int otelMemberPosition = 0;
     int otherMemberPosition = 0;
     while (memberStart < len) {
+      int currentMemberStart = memberStart;
       if (memberIndex == MAX_MEMBER_COUNT) {
         // TODO should we return one with an error?
         // TODO should we try to pick up the `dd` member anyway?
         return tagsFactory.empty();
       }
-      boolean datadogMember = value.startsWith(DATADOG_MEMBER_KEY, memberStart);
-      boolean otelMember = value.startsWith(OTEL_MEMBER_KEY, memberStart);
+      boolean datadogMember = value.startsWith(DATADOG_MEMBER_KEY, currentMemberStart);
       if (ddMemberIndex == -1 && datadogMember) {
-        ddMemberStart = memberStart;
+        ddMemberStart = currentMemberStart;
         ddMemberIndex = memberIndex;
       }
       // Validate the member key
-      int pos = validateMemberKey(value, memberStart);
+      int pos = validateMemberKey(value, currentMemberStart);
       if (pos < 0) {
         // TODO should we return one with an error?
         return tagsFactory.empty();
@@ -86,23 +86,28 @@ public class W3CPTagsCodec extends PTagsCodec {
       if (ddMemberValueEnd == -1 && ddMemberIndex != -1) {
         ddMemberValueEnd = pos;
       }
-      if (otelMemberValueStart == -1) {
-        if (otelMember) {
-          otelMemberStart = memberStart;
-          otelMemberValueStart = memberValueStart;
-          otelMemberValueEnd = stripTrailingOWC(value, memberValueStart, pos);
-          otelMemberEnd = pos;
-          otelMemberPosition = otherMemberPosition;
-        } else if (!datadogMember) {
-          otherMemberPosition++;
-        }
-      }
       memberStart = findNextMember(value, pos);
       if (memberStart < 0) {
         // TODO should we return one with an error?
         return tagsFactory.empty();
       }
       memberIndex++;
+      if (otelMemberValueStart != -1) {
+        continue;
+      }
+      if (datadogMember) {
+        continue;
+      }
+      boolean otelMember = value.startsWith(OTEL_MEMBER_KEY, currentMemberStart);
+      if (otelMember) {
+        otelMemberStart = currentMemberStart;
+        otelMemberValueStart = memberValueStart;
+        otelMemberValueEnd = stripTrailingOWC(value, memberValueStart, pos);
+        otelMemberEnd = pos;
+        otelMemberPosition = otherMemberPosition;
+      } else {
+        otherMemberPosition++;
+      }
     }
 
     OtelTraceState otelTraceState =

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -338,7 +338,7 @@ public class W3CPTagsCodec extends PTagsCodec {
       size = 0;
     }
     // Append the managed OTel member and all other non-Datadog list-members
-    if (appendOtelAndVendorMembers(sb, ptags, otelTraceState, size != 0)) {
+    if (appendOtelAndVendorMembers(sb, ptags, otelTraceState, size != 0, false)) {
       // We don't care about the total size in bytes here, but only the fact that we added something
       // that should be returned
       size = Math.max(size, EMPTY_SIZE + 1);
@@ -745,7 +745,11 @@ public class W3CPTagsCodec extends PTagsCodec {
   }
 
   private static boolean appendOtelAndVendorMembers(
-      StringBuilder sb, PTags ptags, OtelTraceState otelTraceState, boolean hasDatadogMember) {
+      StringBuilder sb,
+      PTags ptags,
+      OtelTraceState otelTraceState,
+      boolean hasDatadogMember,
+      boolean preserveDatadogMember) {
     String original = ptags.tracestate;
     int remainingMembers = MAX_MEMBER_COUNT - (hasDatadogMember ? 1 : 0);
     int otherMemberPosition = 0;
@@ -759,10 +763,14 @@ public class W3CPTagsCodec extends PTagsCodec {
       if (memberEnd < 0) {
         memberEnd = len;
       }
-      boolean managedMember =
-          original.startsWith(DATADOG_MEMBER_KEY, memberStart)
-              || original.startsWith(OTEL_MEMBER_KEY, memberStart);
-      if (!managedMember) {
+      boolean datadogMember = original.startsWith(DATADOG_MEMBER_KEY, memberStart);
+      boolean otelMember = original.startsWith(OTEL_MEMBER_KEY, memberStart);
+      if (datadogMember && preserveDatadogMember) {
+        int end = stripTrailingOWC(original, memberStart, memberEnd);
+        appendMember(sb, original, memberStart, end);
+        remainingMembers--;
+        memberAppended = true;
+      } else if (!datadogMember && !otelMember) {
         if (otelTraceState != null
             && !otelTraceStateAppended
             && otelTraceState.getOriginalPosition() == otherMemberPosition) {
@@ -790,6 +798,17 @@ public class W3CPTagsCodec extends PTagsCodec {
       memberAppended = true;
     }
     return memberAppended;
+  }
+
+  static String updateOtelTraceState(PTags ptags, OtelTraceState otelTraceState) {
+    String original = ptags.tracestate;
+    int capacity = original == null ? 0 : original.length();
+    if (otelTraceState != null) {
+      capacity += OTEL_MEMBER_KEY.length() + otelTraceState.length() + 1;
+    }
+    StringBuilder updated = new StringBuilder(capacity);
+    appendOtelAndVendorMembers(updated, ptags, otelTraceState, false, true);
+    return updated.length() == 0 ? null : updated.toString();
   }
 
   private static void appendMember(StringBuilder sb, String member, int start, int end) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -272,7 +272,7 @@ public class W3CPTagsCodec extends PTagsCodec {
     }
     OtelTraceState otelTraceState = pTags.getOtelTraceState();
     if (otelTraceState != null) {
-      size -= includesOriginalTracestate ? otelTraceState.getOriginalMemberContributionSize() : 0;
+      size -= includesOriginalTracestate ? otelTraceState.getOriginalSize() : 0;
       size += OTEL_MEMBER_KEY.length() + otelTraceState.length() + 1;
     }
     return size;
@@ -768,7 +768,7 @@ public class W3CPTagsCodec extends PTagsCodec {
       if (!managedMember) {
         if (otelTraceState != null
             && !otelTraceStateAppended
-            && otelTraceState.getInheritedPosition() == otherMemberPosition) {
+            && otelTraceState.getOriginalPosition() == otherMemberPosition) {
           appendMember(sb, OTEL_MEMBER_KEY, otelTraceState.getValue());
           remainingMembers--;
           otelTraceStateAppended = true;
@@ -788,7 +788,7 @@ public class W3CPTagsCodec extends PTagsCodec {
     if (otelTraceState != null
         && !otelTraceStateAppended
         && remainingMembers > 0
-        && otelTraceState.getInheritedPosition() == otherMemberPosition) {
+        && otelTraceState.getOriginalPosition() == otherMemberPosition) {
       appendMember(sb, OTEL_MEMBER_KEY, otelTraceState.getValue());
       memberAppended = true;
     }

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -50,8 +50,6 @@ public class W3CPTagsCodec extends PTagsCodec {
     int ddMemberValueEnd = -1; // dd member value end position including OWS (exclusive)
     int memberIndex = 0;
     int ddMemberIndex = -1;
-    OtelTraceState otelTraceState = null;
-    int otherMemberPosition = 0;
     while (memberStart < len) {
       if (memberIndex == MAX_MEMBER_COUNT) {
         // TODO should we return one with an error?
@@ -82,14 +80,15 @@ public class W3CPTagsCodec extends PTagsCodec {
         ddMemberIndex = memberIndex;
         ddMemberValueEnd = memberValueEnd;
       } else if (otelMember) {
+        // Position to retain for this member (if left unchanged)
+        // Indexing after an eventual dd= member which will be placed first
+        int memberPosition = memberIndex - (ddMemberStart >= 0 ? 1 : 0);
         otelTraceState =
             OtelTraceState.parse(
                 value.substring(
                     memberValueStart, stripTrailingOWC(value, memberValueStart, memberValueEnd)),
-                otherMemberPosition,
+                memberPosition,
                 memberContributionSize(value, firstMemberStart, memberStart, memberValueEnd));
-      } else {
-        otherMemberPosition++;
       }
 
       memberIndex++;

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -50,73 +50,55 @@ public class W3CPTagsCodec extends PTagsCodec {
     int ddMemberValueEnd = -1; // dd member value end position including OWS (exclusive)
     int memberIndex = 0;
     int ddMemberIndex = -1;
-    int otelMemberStart = -1;
-    int otelMemberValueStart = -1;
-    int otelMemberValueEnd = -1;
-    int otelMemberEnd = -1;
-    int otelMemberPosition = 0;
+    OtelTraceState otelTraceState = null;
     int otherMemberPosition = 0;
     while (memberStart < len) {
-      int currentMemberStart = memberStart;
       if (memberIndex == MAX_MEMBER_COUNT) {
         // TODO should we return one with an error?
         // TODO should we try to pick up the `dd` member anyway?
         return tagsFactory.empty();
       }
-      boolean datadogMember = value.startsWith(DATADOG_MEMBER_KEY, currentMemberStart);
-      if (ddMemberIndex == -1 && datadogMember) {
-        ddMemberStart = currentMemberStart;
-        ddMemberIndex = memberIndex;
-      }
       // Validate the member key
-      int pos = validateMemberKey(value, currentMemberStart);
-      if (pos < 0) {
+      int memberValueStart = validateMemberKey(value, memberStart);
+      if (memberValueStart < 0) {
         // TODO should we return one with an error?
         return tagsFactory.empty();
       }
-      if (ddMemberValueStart == -1 && ddMemberIndex != -1) {
-        ddMemberValueStart = pos;
-      }
-      int memberValueStart = pos;
-      pos = validateMemberValue(value, pos);
-      if (pos < 0) {
+      int memberValueEnd = validateMemberValue(value, memberValueStart);
+      if (memberValueEnd < 0) {
         // TODO should we return one with an error?
         return tagsFactory.empty();
       }
-      if (ddMemberValueEnd == -1 && ddMemberIndex != -1) {
-        ddMemberValueEnd = pos;
+
+      boolean datadogMember =
+          ddMemberIndex == -1 && value.startsWith(DATADOG_MEMBER_KEY, memberStart);
+      boolean otelMember =
+          !datadogMember
+              && otelTraceState == null
+              && value.startsWith(OTEL_MEMBER_KEY, memberStart);
+      if (datadogMember) {
+        ddMemberStart = memberStart;
+        ddMemberValueStart = memberValueStart;
+        ddMemberIndex = memberIndex;
+        ddMemberValueEnd = memberValueEnd;
+      } else if (otelMember) {
+        otelTraceState =
+            OtelTraceState.parse(
+                value.substring(
+                    memberValueStart, stripTrailingOWC(value, memberValueStart, memberValueEnd)),
+                otherMemberPosition,
+                memberContributionSize(value, firstMemberStart, memberStart, memberValueEnd));
+      } else {
+        otherMemberPosition++;
       }
-      memberStart = findNextMember(value, pos);
+
+      memberIndex++;
+      memberStart = findNextMember(value, memberValueEnd);
       if (memberStart < 0) {
         // TODO should we return one with an error?
         return tagsFactory.empty();
       }
-      memberIndex++;
-      if (otelMemberValueStart != -1) {
-        continue;
-      }
-      if (datadogMember) {
-        continue;
-      }
-      boolean otelMember = value.startsWith(OTEL_MEMBER_KEY, currentMemberStart);
-      if (otelMember) {
-        otelMemberStart = currentMemberStart;
-        otelMemberValueStart = memberValueStart;
-        otelMemberValueEnd = stripTrailingOWC(value, memberValueStart, pos);
-        otelMemberEnd = pos;
-        otelMemberPosition = otherMemberPosition;
-      } else {
-        otherMemberPosition++;
-      }
     }
-
-    OtelTraceState otelTraceState =
-        otelMemberValueStart < 0
-            ? null
-            : OtelTraceState.parse(
-                value.substring(otelMemberValueStart, otelMemberValueEnd),
-                otelMemberPosition,
-                memberContributionSize(value, firstMemberStart, otelMemberStart, otelMemberEnd));
 
     if (ddMemberIndex == -1) {
       // There was no dd member, so create an empty one with the _suffix_

--- a/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -229,7 +229,7 @@ public class W3CPTagsCodec extends PTagsCodec {
 
   @Override
   protected int estimateHeaderSize(PTags pTags) {
-    return estimateHeaderSize(pTags, pTags.getOtelTraceState());
+    return estimateHeaderSize(pTags, pTags.getOtelTraceStateForW3C());
   }
 
   @Override
@@ -320,7 +320,7 @@ public class W3CPTagsCodec extends PTagsCodec {
 
   @Override
   protected int appendSuffix(StringBuilder sb, PTags ptags, int size) {
-    return appendSuffix(sb, ptags, size, ptags.getOtelTraceState());
+    return appendSuffix(sb, ptags, size, ptags.getOtelTraceStateForW3C());
   }
 
   @Override

--- a/dd-trace-core/src/test/java/datadog/trace/common/metrics/SimpleSpan.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/metrics/SimpleSpan.java
@@ -333,17 +333,11 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
 
   @Override
   public SimpleSpan setSamplingPriority(
-      int samplingPriority, CharSequence rate, double sampleRate, int samplingMechanism) {
-    return this;
-  }
-
-  @Override
-  public SimpleSpan setSamplingPriority(
       int samplingPriority,
       CharSequence rate,
       double sampleRate,
       int samplingMechanism,
-      boolean sampled) {
+      Boolean probabilitySamplingResult) {
     return this;
   }
 

--- a/dd-trace-core/src/test/java/datadog/trace/common/metrics/SimpleSpan.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/metrics/SimpleSpan.java
@@ -338,6 +338,16 @@ class SimpleSpan implements CoreSpan<SimpleSpan> {
   }
 
   @Override
+  public SimpleSpan setSamplingPriority(
+      int samplingPriority,
+      CharSequence rate,
+      double sampleRate,
+      int samplingMechanism,
+      boolean sampled) {
+    return this;
+  }
+
+  @Override
   public SimpleSpan setSpanSamplingPriority(double rate, int limit) {
     return this;
   }

--- a/dd-trace-core/src/test/java/datadog/trace/common/sampling/DeterministicTraceSamplerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/sampling/DeterministicTraceSamplerTest.java
@@ -19,6 +19,10 @@ import org.tabletest.junit.TableTest;
 
 class DeterministicTraceSamplerTest {
 
+  private static final String SAMPLE_RATE_COLUMN = "rate       ";
+  private static final String SAMPLE_RATE_0_123456789 = "0.123456789";
+  private static final String SAMPLE_RATE_0_999999999 = "0.999999999";
+
   @TableTest({
     "scenario               | expected | traceId             ",
     "10428415896243638596 f | false    | 10428415896243638596",
@@ -357,11 +361,8 @@ class DeterministicTraceSamplerTest {
     assertTrue(sampler.sample(span));
   }
 
-  @TableTest({
-    "rate       ",
-    "0.123456789",
-    "0.999999999"
-  })
+  // These values fail if the configured rate is narrowed to a float.
+  @TableTest({SAMPLE_RATE_COLUMN, SAMPLE_RATE_0_123456789, SAMPLE_RATE_0_999999999})
   void preservesConfiguredSampleRate(double rate) {
     assertEquals(rate, new DeterministicSampler.TraceSampler(rate).getSampleRate());
   }

--- a/dd-trace-core/src/test/java/datadog/trace/common/sampling/DeterministicTraceSamplerTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/sampling/DeterministicTraceSamplerTest.java
@@ -19,10 +19,6 @@ import org.tabletest.junit.TableTest;
 
 class DeterministicTraceSamplerTest {
 
-  private static final String SAMPLE_RATE_COLUMN = "rate       ";
-  private static final String SAMPLE_RATE_0_123456789 = "0.123456789";
-  private static final String SAMPLE_RATE_0_999999999 = "0.999999999";
-
   @TableTest({
     "scenario               | expected | traceId             ",
     "10428415896243638596 f | false    | 10428415896243638596",
@@ -361,8 +357,11 @@ class DeterministicTraceSamplerTest {
     assertTrue(sampler.sample(span));
   }
 
-  // These values fail if the configured rate is narrowed to a float.
-  @TableTest({SAMPLE_RATE_COLUMN, SAMPLE_RATE_0_123456789, SAMPLE_RATE_0_999999999})
+  @TableTest({
+    "rate       ",
+    "0.123456789",
+    "0.999999999"
+  })
   void preservesConfiguredSampleRate(double rate) {
     assertEquals(rate, new DeterministicSampler.TraceSampler(rate).getSampleRate());
   }

--- a/dd-trace-core/src/test/java/datadog/trace/common/writer/TraceGenerator.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/writer/TraceGenerator.java
@@ -414,6 +414,16 @@ public class TraceGenerator {
     }
 
     @Override
+    public PojoSpan setSamplingPriority(
+        int samplingPriority,
+        CharSequence rate,
+        double sampleRate,
+        int samplingMechanism,
+        boolean sampled) {
+      return this;
+    }
+
+    @Override
     public PojoSpan setSpanSamplingPriority(double rate, int limit) {
       return this;
     }

--- a/dd-trace-core/src/test/java/datadog/trace/common/writer/TraceGenerator.java
+++ b/dd-trace-core/src/test/java/datadog/trace/common/writer/TraceGenerator.java
@@ -409,17 +409,11 @@ public class TraceGenerator {
 
     @Override
     public PojoSpan setSamplingPriority(
-        int samplingPriority, CharSequence rate, double sampleRate, int samplingMechanism) {
-      return this;
-    }
-
-    @Override
-    public PojoSpan setSamplingPriority(
         int samplingPriority,
         CharSequence rate,
         double sampleRate,
         int samplingMechanism,
-        boolean sampled) {
+        Boolean probabilitySamplingResult) {
       return this;
     }
 

--- a/dd-trace-core/src/test/java/datadog/trace/core/CoreSpanBuilderTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/CoreSpanBuilderTest.java
@@ -67,6 +67,7 @@ public class CoreSpanBuilderTest extends DDCoreJavaSpecification {
   private static final String OTEL_MEMBER = "ot=";
   private static final String THRESHOLD_0_5 = ";th:8";
   private static final double SAMPLE_RATE_0_5 = 0.5;
+  private static final String DATADOG_TRACE_STATE = "_dd.p.dm=934086a686-4,_dd.p.anytag=value";
 
   private ListWriter writer;
   private CoreTracer tracer;

--- a/dd-trace-core/src/test/java/datadog/trace/core/CoreSpanBuilderTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/CoreSpanBuilderTest.java
@@ -12,10 +12,15 @@ import static datadog.trace.api.DDTags.SCHEMA_VERSION_TAG_KEY;
 import static datadog.trace.api.DDTags.THREAD_ID;
 import static datadog.trace.api.DDTags.THREAD_NAME;
 import static datadog.trace.api.TracePropagationStyle.DATADOG;
+import static datadog.trace.api.TracePropagationStyle.TRACECONTEXT;
+import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP;
+import static datadog.trace.api.sampling.SamplingMechanism.LOCAL_USER_RULE;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.noopSpan;
+import static datadog.trace.common.sampling.RuleBasedTraceSampler.SAMPLING_RULE_RATE;
 import static datadog.trace.test.junit.utils.config.WithConfigExtension.injectSysConfig;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -363,6 +368,33 @@ public class CoreSpanBuilderTest extends DDCoreJavaSpecification {
   }
 
   @Test
+  void extractedContextShouldPreserveOtelTraceState() {
+    PropagationTags propagationTags =
+        PropagationTags.factory()
+            .fromHeaderValue(
+                PropagationTags.HeaderType.W3C, "dd=s:0,ot=rv:ef284ace7a91e1;th:e6666666666668");
+    ExtractedContext extractedContext =
+        new ExtractedContext(
+            DDTraceId.ONE,
+            2,
+            PrioritySampling.SAMPLER_DROP,
+            null,
+            0,
+            Collections.<String, String>emptyMap(),
+            Collections.<String, Object>emptyMap(),
+            null,
+            propagationTags,
+            null,
+            TRACECONTEXT);
+
+    DDSpan span = (DDSpan) tracer.buildSpan("test", "op name").asChildOf(extractedContext).start();
+
+    assertEquals(
+        "dd=s:0,ot=rv:ef284ace7a91e1;th:e6666666666668",
+        span.spanContext().getPropagationTags().headerValue(PropagationTags.HeaderType.W3C));
+  }
+
+  @Test
   @WithConfig(key = "trace.propagation.behavior.extract", value = "restart")
   void buildContextFromExtractedContextWithRestartBehavior() {
     ExtractedContext extractedContext =
@@ -375,9 +407,7 @@ public class CoreSpanBuilderTest extends DDCoreJavaSpecification {
             Collections.<String, String>emptyMap(),
             Collections.<String, Object>emptyMap(),
             null,
-            PropagationTags.factory()
-                .fromHeaderValue(
-                    PropagationTags.HeaderType.DATADOG, "_dd.p.dm=934086a686-4,_dd.p.anytag=value"),
+            propagationTagsWithOtelState(),
             null,
             DATADOG);
     DDSpan span = (DDSpan) tracer.buildSpan("test", "op name").asChildOf(extractedContext).start();
@@ -394,6 +424,16 @@ public class CoreSpanBuilderTest extends DDCoreJavaSpecification {
     assertEquals(
         extractedContext.getPropagationTags().headerValue(PropagationTags.HeaderType.W3C),
         link.traceState());
+    String initialTraceState =
+        span.spanContext().getPropagationTags().headerValue(PropagationTags.HeaderType.W3C);
+    assertTrue(initialTraceState == null || !initialTraceState.contains("ot="));
+
+    span.setSamplingPriority(USER_KEEP, SAMPLING_RULE_RATE, 0.5, LOCAL_USER_RULE, true);
+
+    String freshTraceState =
+        span.spanContext().getPropagationTags().headerValue(PropagationTags.HeaderType.W3C);
+    assertFalse(freshTraceState.contains("ef284ace7a91e1"));
+    assertTrue(freshTraceState.contains(";th:8"));
   }
 
   @Test
@@ -409,9 +449,7 @@ public class CoreSpanBuilderTest extends DDCoreJavaSpecification {
             Collections.<String, String>emptyMap(),
             Collections.<String, Object>emptyMap(),
             null,
-            PropagationTags.factory()
-                .fromHeaderValue(
-                    PropagationTags.HeaderType.DATADOG, "_dd.p.dm=934086a686-4,_dd.p.anytag=value"),
+            propagationTagsWithOtelState(),
             null,
             DATADOG);
     DDSpan span = (DDSpan) tracer.buildSpan("test", "op name").asChildOf(extractedContext).start();
@@ -420,6 +458,25 @@ public class CoreSpanBuilderTest extends DDCoreJavaSpecification {
     assertNotEquals(extractedContext.getSpanId(), span.getParentId());
     assertEquals(PrioritySampling.UNSET, span.samplingPriority());
     assertTrue(span.getLinks().isEmpty());
+    String initialTraceState =
+        span.spanContext().getPropagationTags().headerValue(PropagationTags.HeaderType.W3C);
+    assertTrue(initialTraceState == null || !initialTraceState.contains("ot="));
+
+    span.setSamplingPriority(USER_KEEP, SAMPLING_RULE_RATE, 0.5, LOCAL_USER_RULE, true);
+
+    String freshTraceState =
+        span.spanContext().getPropagationTags().headerValue(PropagationTags.HeaderType.W3C);
+    assertFalse(freshTraceState.contains("ef284ace7a91e1"));
+    assertTrue(freshTraceState.contains(";th:8"));
+  }
+
+  private static PropagationTags propagationTagsWithOtelState() {
+    PropagationTags propagationTags =
+        PropagationTags.factory()
+            .fromHeaderValue(
+                PropagationTags.HeaderType.DATADOG, "_dd.p.dm=934086a686-4,_dd.p.anytag=value");
+    propagationTags.updateW3CTracestate("dd=s:0,ot=rv:ef284ace7a91e1;th:e6666666666668");
+    return propagationTags;
   }
 
   @Test

--- a/dd-trace-core/src/test/java/datadog/trace/core/CoreSpanBuilderTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/CoreSpanBuilderTest.java
@@ -60,6 +60,14 @@ import org.tabletest.junit.TableTest;
 
 public class CoreSpanBuilderTest extends DDCoreJavaSpecification {
 
+  // Propagation fixtures preserve the raw inbound vendor values as a single test vector.
+  private static final String INHERITED_RANDOM_VALUE = "ef284ace7a91e1";
+  private static final String OTEL_TRACE_STATE =
+      "dd=s:0,ot=rv:" + INHERITED_RANDOM_VALUE + ";th:e6666666666668";
+  private static final String OTEL_MEMBER = "ot=";
+  private static final String THRESHOLD_0_5 = ";th:8";
+  private static final double SAMPLE_RATE_0_5 = 0.5;
+
   private ListWriter writer;
   private CoreTracer tracer;
 
@@ -370,9 +378,7 @@ public class CoreSpanBuilderTest extends DDCoreJavaSpecification {
   @Test
   void extractedContextShouldPreserveOtelTraceState() {
     PropagationTags propagationTags =
-        PropagationTags.factory()
-            .fromHeaderValue(
-                PropagationTags.HeaderType.W3C, "dd=s:0,ot=rv:ef284ace7a91e1;th:e6666666666668");
+        PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.W3C, OTEL_TRACE_STATE);
     ExtractedContext extractedContext =
         new ExtractedContext(
             DDTraceId.ONE,
@@ -390,7 +396,7 @@ public class CoreSpanBuilderTest extends DDCoreJavaSpecification {
     DDSpan span = (DDSpan) tracer.buildSpan("test", "op name").asChildOf(extractedContext).start();
 
     assertEquals(
-        "dd=s:0,ot=rv:ef284ace7a91e1;th:e6666666666668",
+        OTEL_TRACE_STATE,
         span.spanContext().getPropagationTags().headerValue(PropagationTags.HeaderType.W3C));
   }
 
@@ -426,14 +432,14 @@ public class CoreSpanBuilderTest extends DDCoreJavaSpecification {
         link.traceState());
     String initialTraceState =
         span.spanContext().getPropagationTags().headerValue(PropagationTags.HeaderType.W3C);
-    assertTrue(initialTraceState == null || !initialTraceState.contains("ot="));
+    assertTrue(initialTraceState == null || !initialTraceState.contains(OTEL_MEMBER));
 
-    span.setSamplingPriority(USER_KEEP, SAMPLING_RULE_RATE, 0.5, LOCAL_USER_RULE, true);
+    span.setSamplingPriority(USER_KEEP, SAMPLING_RULE_RATE, SAMPLE_RATE_0_5, LOCAL_USER_RULE, true);
 
     String freshTraceState =
         span.spanContext().getPropagationTags().headerValue(PropagationTags.HeaderType.W3C);
-    assertFalse(freshTraceState.contains("ef284ace7a91e1"));
-    assertTrue(freshTraceState.contains(";th:8"));
+    assertFalse(freshTraceState.contains(INHERITED_RANDOM_VALUE));
+    assertTrue(freshTraceState.contains(THRESHOLD_0_5));
   }
 
   @Test
@@ -460,22 +466,21 @@ public class CoreSpanBuilderTest extends DDCoreJavaSpecification {
     assertTrue(span.getLinks().isEmpty());
     String initialTraceState =
         span.spanContext().getPropagationTags().headerValue(PropagationTags.HeaderType.W3C);
-    assertTrue(initialTraceState == null || !initialTraceState.contains("ot="));
+    assertTrue(initialTraceState == null || !initialTraceState.contains(OTEL_MEMBER));
 
-    span.setSamplingPriority(USER_KEEP, SAMPLING_RULE_RATE, 0.5, LOCAL_USER_RULE, true);
+    span.setSamplingPriority(USER_KEEP, SAMPLING_RULE_RATE, SAMPLE_RATE_0_5, LOCAL_USER_RULE, true);
 
     String freshTraceState =
         span.spanContext().getPropagationTags().headerValue(PropagationTags.HeaderType.W3C);
-    assertFalse(freshTraceState.contains("ef284ace7a91e1"));
-    assertTrue(freshTraceState.contains(";th:8"));
+    assertFalse(freshTraceState.contains(INHERITED_RANDOM_VALUE));
+    assertTrue(freshTraceState.contains(THRESHOLD_0_5));
   }
 
   private static PropagationTags propagationTagsWithOtelState() {
     PropagationTags propagationTags =
         PropagationTags.factory()
-            .fromHeaderValue(
-                PropagationTags.HeaderType.DATADOG, "_dd.p.dm=934086a686-4,_dd.p.anytag=value");
-    propagationTags.updateW3CTracestate("dd=s:0,ot=rv:ef284ace7a91e1;th:e6666666666668");
+            .fromHeaderValue(PropagationTags.HeaderType.DATADOG, DATADOG_TRACE_STATE);
+    propagationTags.updateW3CTracestate(OTEL_TRACE_STATE);
     return propagationTags;
   }
 

--- a/dd-trace-core/src/test/java/datadog/trace/core/CoreSpanBuilderTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/CoreSpanBuilderTest.java
@@ -64,6 +64,8 @@ public class CoreSpanBuilderTest extends DDCoreJavaSpecification {
   private static final String INHERITED_RANDOM_VALUE = "ef284ace7a91e1";
   private static final String OTEL_TRACE_STATE =
       "dd=s:0,ot=rv:" + INHERITED_RANDOM_VALUE + ";th:e6666666666668";
+  private static final String OTEL_TRACE_STATE_WITHOUT_THRESHOLD =
+      "dd=s:0,ot=rv:" + INHERITED_RANDOM_VALUE;
   private static final String OTEL_MEMBER = "ot=";
   private static final String THRESHOLD_0_5 = ";th:8";
   private static final double SAMPLE_RATE_0_5 = 0.5;
@@ -377,9 +379,10 @@ public class CoreSpanBuilderTest extends DDCoreJavaSpecification {
   }
 
   @Test
-  void extractedContextShouldPreserveOtelTraceState() {
+  void extractedContextShouldPreserveOtelRandomnessAndAlignThreshold() {
     PropagationTags propagationTags =
         PropagationTags.factory().fromHeaderValue(PropagationTags.HeaderType.W3C, OTEL_TRACE_STATE);
+    assertEquals(OTEL_TRACE_STATE, propagationTags.getW3CTracestate());
     ExtractedContext extractedContext =
         new ExtractedContext(
             DDTraceId.ONE,
@@ -397,7 +400,7 @@ public class CoreSpanBuilderTest extends DDCoreJavaSpecification {
     DDSpan span = (DDSpan) tracer.buildSpan("test", "op name").asChildOf(extractedContext).start();
 
     assertEquals(
-        OTEL_TRACE_STATE,
+        OTEL_TRACE_STATE_WITHOUT_THRESHOLD,
         span.spanContext().getPropagationTags().headerValue(PropagationTags.HeaderType.W3C));
   }
 

--- a/dd-trace-core/src/test/java/datadog/trace/core/OtelSamplingDecisionTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/OtelSamplingDecisionTest.java
@@ -26,6 +26,20 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
 
+  private static final String AGENT_RATE_ENDPOINT = "traces";
+  private static final String INSTRUMENTATION_NAME = "datadog";
+  private static final String OPERATION_NAME = "operation";
+  private static final String SERVICE_NAME = "service";
+  private static final String OTEL_MEMBER = "ot=";
+  private static final String OTEL_RANDOM_VALUE_PREFIX = "ot=rv:";
+  private static final String HALF_THRESHOLD = ";th:8";
+  private static final double SAMPLE_RATE_0_5 = 0.5;
+  private static final String SAMPLE_RATE_0_5_RULE = "[{\"sample_rate\": 0.5}]";
+  private static final String FULL_SAMPLE_RATE_RULE = "[{\"sample_rate\": 1}]";
+  // Keeps configured-rule vectors out of the limiter path.
+  private static final String HIGH_RATE_LIMIT = "10000000";
+  private static final String ONE_PER_SECOND_RATE_LIMIT = "1";
+
   @Test
   void initialAgentRateDoesNotEstablishOtelProbabilityState() {
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
@@ -34,7 +48,7 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
 
       new RateByServiceTraceSampler().setSamplingPriority(span);
 
-      assertFalse(w3cHeader(span).contains("ot="));
+      assertFalse(w3cHeader(span).contains(OTEL_MEMBER));
     } finally {
       tracer.close();
     }
@@ -43,7 +57,7 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
   @Test
   void loadedAgentRateEstablishesOtelProbabilityState() {
     RateByServiceTraceSampler sampler = new RateByServiceTraceSampler();
-    sampler.onResponse("traces", agentRates(0.5));
+    sampler.onResponse(AGENT_RATE_ENDPOINT, agentRates(SAMPLE_RATE_0_5));
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
     try {
       DDSpan span = newRootSpan(tracer);
@@ -51,8 +65,8 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
       sampler.setSamplingPriority(span);
 
       String header = w3cHeader(span);
-      assertTrue(header.contains("ot=rv:"));
-      assertTrue(header.contains(";th:8"));
+      assertTrue(header.contains(OTEL_RANDOM_VALUE_PREFIX));
+      assertTrue(header.contains(HALF_THRESHOLD));
     } finally {
       tracer.close();
     }
@@ -61,14 +75,14 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
   @Test
   void loadedZeroAgentRateDoesNotEstablishOtelProbabilityState() {
     RateByServiceTraceSampler sampler = new RateByServiceTraceSampler();
-    sampler.onResponse("traces", agentRates(0));
+    sampler.onResponse(AGENT_RATE_ENDPOINT, agentRates(0));
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
     try {
       DDSpan span = newRootSpan(tracer);
 
       sampler.setSamplingPriority(span);
 
-      assertFalse(w3cHeader(span).contains("ot="));
+      assertFalse(w3cHeader(span).contains(OTEL_MEMBER));
     } finally {
       tracer.close();
     }
@@ -79,11 +93,11 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
   void configuredRulesEstablishOtelProbabilityState(boolean traceRule) {
     Properties properties = new Properties();
     if (traceRule) {
-      properties.setProperty(TRACE_SAMPLING_RULES, "[{\"sample_rate\": 0.5}]");
+      properties.setProperty(TRACE_SAMPLING_RULES, SAMPLE_RATE_0_5_RULE);
     } else {
-      properties.setProperty(TRACE_SAMPLE_RATE, "0.5");
+      properties.setProperty(TRACE_SAMPLE_RATE, String.valueOf(SAMPLE_RATE_0_5));
     }
-    properties.setProperty(TRACE_RATE_LIMIT, "10000000");
+    properties.setProperty(TRACE_RATE_LIMIT, HIGH_RATE_LIMIT);
     PrioritySampler sampler = (PrioritySampler) Sampler.Builder.forConfig(properties);
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
     try {
@@ -92,8 +106,8 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
       sampler.setSamplingPriority(span);
 
       String header = w3cHeader(span);
-      assertTrue(header.contains("ot=rv:"));
-      assertTrue(header.contains(";th:8"));
+      assertTrue(header.contains(OTEL_RANDOM_VALUE_PREFIX));
+      assertTrue(header.contains(HALF_THRESHOLD));
     } finally {
       tracer.close();
     }
@@ -102,8 +116,8 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
   @Test
   void limiterRejectionDoesNotTurnProbabilityKeepIntoOtelDrop() {
     Properties properties = new Properties();
-    properties.setProperty(TRACE_SAMPLING_RULES, "[{\"sample_rate\": 1}]");
-    properties.setProperty(TRACE_RATE_LIMIT, "1");
+    properties.setProperty(TRACE_SAMPLING_RULES, FULL_SAMPLE_RATE_RULE);
+    properties.setProperty(TRACE_RATE_LIMIT, ONE_PER_SECOND_RATE_LIMIT);
     PrioritySampler sampler = (PrioritySampler) Sampler.Builder.forConfig(properties);
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
     try {
@@ -113,9 +127,9 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
       sampler.setSamplingPriority(allowed);
       sampler.setSamplingPriority(rejected);
 
-      assertTrue(w3cHeader(allowed).contains("ot=rv:"));
+      assertTrue(w3cHeader(allowed).contains(OTEL_RANDOM_VALUE_PREFIX));
       assertEquals(USER_DROP, rejected.samplingPriority());
-      assertFalse(w3cHeader(rejected).contains("ot="));
+      assertFalse(w3cHeader(rejected).contains(OTEL_MEMBER));
     } finally {
       tracer.close();
     }
@@ -126,12 +140,13 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
     try {
       DDSpan span = newRootSpan(tracer);
-      span.setSamplingPriority(USER_KEEP, SAMPLING_RULE_RATE, 0.5, LOCAL_USER_RULE, true);
-      assertTrue(w3cHeader(span).contains("ot=rv:"));
+      span.setSamplingPriority(
+          USER_KEEP, SAMPLING_RULE_RATE, SAMPLE_RATE_0_5, LOCAL_USER_RULE, true);
+      assertTrue(w3cHeader(span).contains(OTEL_RANDOM_VALUE_PREFIX));
 
       span.spanContext().forceKeep();
 
-      assertFalse(w3cHeader(span).contains("ot="));
+      assertFalse(w3cHeader(span).contains(OTEL_MEMBER));
     } finally {
       tracer.close();
     }
@@ -140,8 +155,8 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
   private static DDSpan newRootSpan(CoreTracer tracer) {
     return (DDSpan)
         tracer
-            .buildSpan("datadog", "operation")
-            .withServiceName("service")
+            .buildSpan(INSTRUMENTATION_NAME, OPERATION_NAME)
+            .withServiceName(SERVICE_NAME)
             .ignoreActiveSpan()
             .start();
   }

--- a/dd-trace-core/src/test/java/datadog/trace/core/OtelSamplingDecisionTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/OtelSamplingDecisionTest.java
@@ -33,6 +33,8 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
   private static final String OTEL_MEMBER = "ot=";
   private static final String OTEL_RANDOM_VALUE_PREFIX = "ot=rv:";
   private static final String HALF_THRESHOLD = ";th:8";
+  private static final String MAX_THRESHOLD = ";th:ffffffffffffff";
+  private static final String OTEL_THRESHOLD_PREFIX = ";th:";
   private static final double SAMPLE_RATE_0_5 = 0.5;
   private static final String SAMPLE_RATE_0_5_RULE = "[{\"sample_rate\": 0.5}]";
   private static final String FULL_SAMPLE_RATE_RULE = "[{\"sample_rate\": 1}]";
@@ -73,7 +75,7 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
   }
 
   @Test
-  void loadedZeroAgentRateDoesNotEstablishOtelProbabilityState() {
+  void loadedZeroAgentRateEstablishesOtelProbabilityStateWithMaxThreshold() {
     RateByServiceTraceSampler sampler = new RateByServiceTraceSampler();
     sampler.onResponse(AGENT_RATE_ENDPOINT, agentRates(0));
     CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
@@ -82,7 +84,9 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
 
       sampler.setSamplingPriority(span);
 
-      assertFalse(w3cHeader(span).contains(OTEL_MEMBER));
+      String header = w3cHeader(span);
+      assertTrue(header.contains(OTEL_RANDOM_VALUE_PREFIX));
+      assertTrue(header.contains(MAX_THRESHOLD));
     } finally {
       tracer.close();
     }
@@ -114,7 +118,7 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
   }
 
   @Test
-  void limiterRejectionDoesNotTurnProbabilityKeepIntoOtelDrop() {
+  void limiterRejectionStripsThresholdButKeepsOtelRandomValue() {
     Properties properties = new Properties();
     properties.setProperty(TRACE_SAMPLING_RULES, FULL_SAMPLE_RATE_RULE);
     properties.setProperty(TRACE_RATE_LIMIT, ONE_PER_SECOND_RATE_LIMIT);
@@ -129,7 +133,9 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
 
       assertTrue(w3cHeader(allowed).contains(OTEL_RANDOM_VALUE_PREFIX));
       assertEquals(USER_DROP, rejected.samplingPriority());
-      assertFalse(w3cHeader(rejected).contains(OTEL_MEMBER));
+      String rejectedHeader = w3cHeader(rejected);
+      assertTrue(rejectedHeader.contains(OTEL_RANDOM_VALUE_PREFIX));
+      assertFalse(rejectedHeader.contains(OTEL_THRESHOLD_PREFIX));
     } finally {
       tracer.close();
     }

--- a/dd-trace-core/src/test/java/datadog/trace/core/OtelSamplingDecisionTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/OtelSamplingDecisionTest.java
@@ -1,0 +1,162 @@
+package datadog.trace.core;
+
+import static datadog.trace.api.config.TracerConfig.TRACE_RATE_LIMIT;
+import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLE_RATE;
+import static datadog.trace.api.config.TracerConfig.TRACE_SAMPLING_RULES;
+import static datadog.trace.api.sampling.PrioritySampling.USER_DROP;
+import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP;
+import static datadog.trace.api.sampling.SamplingMechanism.LOCAL_USER_RULE;
+import static datadog.trace.common.sampling.RuleBasedTraceSampler.SAMPLING_RULE_RATE;
+import static datadog.trace.core.propagation.PropagationTags.HeaderType.W3C;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.common.sampling.PrioritySampler;
+import datadog.trace.common.sampling.RateByServiceTraceSampler;
+import datadog.trace.common.sampling.Sampler;
+import datadog.trace.common.writer.ListWriter;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
+
+  @Test
+  void initialAgentRateDoesNotEstablishOtelProbabilityState() {
+    CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
+    try {
+      DDSpan span = newRootSpan(tracer);
+
+      new RateByServiceTraceSampler().setSamplingPriority(span);
+
+      assertFalse(w3cHeader(span).contains("ot="));
+    } finally {
+      tracer.close();
+    }
+  }
+
+  @Test
+  void loadedAgentRateEstablishesOtelProbabilityState() {
+    RateByServiceTraceSampler sampler = new RateByServiceTraceSampler();
+    sampler.onResponse("traces", agentRates(0.5));
+    CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
+    try {
+      DDSpan span = newRootSpan(tracer);
+
+      sampler.setSamplingPriority(span);
+
+      String header = w3cHeader(span);
+      assertTrue(header.contains("ot=rv:"));
+      assertTrue(header.contains(";th:8"));
+    } finally {
+      tracer.close();
+    }
+  }
+
+  @Test
+  void loadedZeroAgentRateDoesNotEstablishOtelProbabilityState() {
+    RateByServiceTraceSampler sampler = new RateByServiceTraceSampler();
+    sampler.onResponse("traces", agentRates(0));
+    CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
+    try {
+      DDSpan span = newRootSpan(tracer);
+
+      sampler.setSamplingPriority(span);
+
+      assertFalse(w3cHeader(span).contains("ot="));
+    } finally {
+      tracer.close();
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void configuredRulesEstablishOtelProbabilityState(boolean traceRule) {
+    Properties properties = new Properties();
+    if (traceRule) {
+      properties.setProperty(TRACE_SAMPLING_RULES, "[{\"sample_rate\": 0.5}]");
+    } else {
+      properties.setProperty(TRACE_SAMPLE_RATE, "0.5");
+    }
+    properties.setProperty(TRACE_RATE_LIMIT, "10000000");
+    PrioritySampler sampler = (PrioritySampler) Sampler.Builder.forConfig(properties);
+    CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
+    try {
+      DDSpan span = newRootSpan(tracer);
+
+      sampler.setSamplingPriority(span);
+
+      String header = w3cHeader(span);
+      assertTrue(header.contains("ot=rv:"));
+      assertTrue(header.contains(";th:8"));
+    } finally {
+      tracer.close();
+    }
+  }
+
+  @Test
+  void limiterRejectionDoesNotTurnProbabilityKeepIntoOtelDrop() {
+    Properties properties = new Properties();
+    properties.setProperty(TRACE_SAMPLING_RULES, "[{\"sample_rate\": 1}]");
+    properties.setProperty(TRACE_RATE_LIMIT, "1");
+    PrioritySampler sampler = (PrioritySampler) Sampler.Builder.forConfig(properties);
+    CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
+    try {
+      DDSpan allowed = newRootSpan(tracer);
+      DDSpan rejected = newRootSpan(tracer);
+
+      sampler.setSamplingPriority(allowed);
+      sampler.setSamplingPriority(rejected);
+
+      assertTrue(w3cHeader(allowed).contains("ot=rv:"));
+      assertEquals(USER_DROP, rejected.samplingPriority());
+      assertFalse(w3cHeader(rejected).contains("ot="));
+    } finally {
+      tracer.close();
+    }
+  }
+
+  @Test
+  void manualOverrideRemovesLocallyGeneratedProbabilityState() {
+    CoreTracer tracer = tracerBuilder().writer(new ListWriter()).build();
+    try {
+      DDSpan span = newRootSpan(tracer);
+      span.setSamplingPriority(USER_KEEP, SAMPLING_RULE_RATE, 0.5, LOCAL_USER_RULE, true);
+      assertTrue(w3cHeader(span).contains("ot=rv:"));
+
+      span.spanContext().forceKeep();
+
+      assertFalse(w3cHeader(span).contains("ot="));
+    } finally {
+      tracer.close();
+    }
+  }
+
+  private static DDSpan newRootSpan(CoreTracer tracer) {
+    return (DDSpan)
+        tracer
+            .buildSpan("datadog", "operation")
+            .withServiceName("service")
+            .ignoreActiveSpan()
+            .start();
+  }
+
+  private static String w3cHeader(DDSpan span) {
+    String header = span.spanContext().getPropagationTags().headerValue(W3C);
+    assertNotNull(header);
+    return header;
+  }
+
+  private static Map<String, Map<String, Number>> agentRates(double rate) {
+    Map<String, Number> rates = new HashMap<>();
+    rates.put("service:,env:", rate);
+    Map<String, Map<String, Number>> response = new HashMap<>();
+    response.put("rate_by_service", rates);
+    return response;
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/core/OtelSamplingDecisionTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/OtelSamplingDecisionTest.java
@@ -34,7 +34,6 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
   private static final String OTEL_RANDOM_VALUE_PREFIX = "ot=rv:";
   private static final String HALF_THRESHOLD = ";th:8";
   private static final String MAX_THRESHOLD = ";th:ffffffffffffff";
-  private static final String OTEL_THRESHOLD_PREFIX = ";th:";
   private static final double SAMPLE_RATE_0_5 = 0.5;
   private static final String SAMPLE_RATE_0_5_RULE = "[{\"sample_rate\": 0.5}]";
   private static final String FULL_SAMPLE_RATE_RULE = "[{\"sample_rate\": 1}]";
@@ -118,7 +117,7 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
   }
 
   @Test
-  void limiterRejectionStripsThresholdButKeepsOtelRandomValue() {
+  void limiterRejectionDoesNotEstablishOtelProbabilityState() {
     Properties properties = new Properties();
     properties.setProperty(TRACE_SAMPLING_RULES, FULL_SAMPLE_RATE_RULE);
     properties.setProperty(TRACE_RATE_LIMIT, ONE_PER_SECOND_RATE_LIMIT);
@@ -133,9 +132,7 @@ class OtelSamplingDecisionTest extends DDCoreJavaSpecification {
 
       assertTrue(w3cHeader(allowed).contains(OTEL_RANDOM_VALUE_PREFIX));
       assertEquals(USER_DROP, rejected.samplingPriority());
-      String rejectedHeader = w3cHeader(rejected);
-      assertTrue(rejectedHeader.contains(OTEL_RANDOM_VALUE_PREFIX));
-      assertFalse(rejectedHeader.contains(OTEL_THRESHOLD_PREFIX));
+      assertFalse(w3cHeader(rejected).contains(OTEL_MEMBER));
     } finally {
       tracer.close();
     }

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollectorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollectorTest.java
@@ -131,27 +131,69 @@ class OtlpTraceJsonCollectorTest {
   }
 
   @Test
-  void spanTraceStateIncludedWhenPropagated() throws IOException {
+  void spansExportFullTraceStateWithOtelMember() throws IOException {
     PropagationTags propagationTags = PropagationTags.factory().empty();
-    propagationTags.updateW3CTracestate("vendor=state");
+    propagationTags.updateW3CTracestate("vendor=state,ot=rv:abcdef12345678;th:80000000000000");
+    propagationTags.updateTraceSamplingPriority(
+        PrioritySampling.USER_KEEP, SamplingMechanism.EXTERNAL_OVERRIDE);
     ExtractedContext parent =
         new ExtractedContext(
             DDTraceId.ONE,
             0L,
-            PrioritySampling.UNSET,
+            PrioritySampling.USER_KEEP,
             null,
             propagationTags,
             TracePropagationStyle.DATADOG);
 
-    AgentSpan agentSpan = TRACER.startSpan("test", "op.tracestate", parent);
-    agentSpan.setResourceName("op.tracestate");
-    agentSpan.finish();
+    AgentSpan root = TRACER.startSpan("test", "op.tracestate.root", parent);
+    root.setResourceName("op.tracestate.root");
+    AgentSpan child = TRACER.startSpan("test", "op.tracestate.child", root.spanContext());
+    child.setResourceName("op.tracestate.child");
+    child.finish();
+    root.finish();
 
     OtlpTraceJsonCollector collector = new OtlpTraceJsonCollector();
-    collector.addTrace(asList((CoreSpan<?>) agentSpan));
-    Map<String, Object> parsedSpan = onlySpan(collector.collectTraces());
+    collector.addTrace(asList((CoreSpan<?>) root, (CoreSpan<?>) child));
+    List<Map<String, Object>> parsedSpans = allSpans(collector.collectTraces());
 
-    assertEquals("vendor=state", parsedSpan.get("traceState"));
+    assertEquals(2, parsedSpans.size());
+    for (Map<String, Object> parsedSpan : parsedSpans) {
+      assertEquals(
+          "vendor=state,ot=rv:abcdef12345678;th:80000000000000", parsedSpan.get("traceState"));
+    }
+  }
+
+  @Test
+  void spansExportOtelTraceStateWithoutW3CTraceState() throws IOException {
+    PropagationTags propagationTags = PropagationTags.factory().empty();
+    propagationTags.updateTraceSamplingPriority(
+        PrioritySampling.USER_KEEP, SamplingMechanism.EXTERNAL_OVERRIDE);
+    propagationTags.updateOtelTraceState(DDTraceId.ONE.toLong(), 0.5, true);
+    String traceState = propagationTags.getW3CTracestate(PrioritySampling.USER_KEEP);
+    ExtractedContext parent =
+        new ExtractedContext(
+            DDTraceId.ONE,
+            0L,
+            PrioritySampling.USER_KEEP,
+            null,
+            propagationTags,
+            TracePropagationStyle.DATADOG);
+
+    AgentSpan root = TRACER.startSpan("test", "op.otel.root", parent);
+    root.setResourceName("op.otel.root");
+    AgentSpan child = TRACER.startSpan("test", "op.otel.child", root.spanContext());
+    child.setResourceName("op.otel.child");
+    child.finish();
+    root.finish();
+
+    OtlpTraceJsonCollector collector = new OtlpTraceJsonCollector();
+    collector.addTrace(asList((CoreSpan<?>) root, (CoreSpan<?>) child));
+    List<Map<String, Object>> parsedSpans = allSpans(collector.collectTraces());
+
+    assertEquals(2, parsedSpans.size());
+    for (Map<String, Object> parsedSpan : parsedSpans) {
+      assertEquals(traceState, parsedSpan.get("traceState"));
+    }
   }
 
   @Test

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollectorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceJsonCollectorTest.java
@@ -2,6 +2,7 @@ package datadog.trace.core.otlp.trace;
 
 import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_SERVER;
+import static datadog.trace.common.sampling.RuleBasedTraceSampler.SAMPLING_RULE_RATE;
 import static datadog.trace.core.DDSpanContext.SPAN_SAMPLING_MECHANISM_TAG;
 import static datadog.trace.core.otlp.common.OtlpCommonJson.hexSpanId;
 import static datadog.trace.core.otlp.common.OtlpCommonJson.hexTraceId;
@@ -151,6 +152,30 @@ class OtlpTraceJsonCollectorTest {
     Map<String, Object> parsedSpan = onlySpan(collector.collectTraces());
 
     assertEquals("vendor=state", parsedSpan.get("traceState"));
+  }
+
+  @Test
+  void spanTraceStateIncludesLocalOtelSamplingState() throws IOException {
+    AgentSpan agentSpan = TRACER.startSpan("test", "op.otel-tracestate");
+    agentSpan.setResourceName("op.otel-tracestate");
+    ((DDSpan) agentSpan)
+        .setSamplingPriority(
+            PrioritySampling.USER_KEEP,
+            SAMPLING_RULE_RATE,
+            0.5,
+            SamplingMechanism.LOCAL_USER_RULE,
+            true);
+    agentSpan.finish();
+
+    OtlpTraceJsonCollector collector = new OtlpTraceJsonCollector();
+    collector.addTrace(asList((CoreSpan<?>) agentSpan));
+    Map<String, Object> parsedSpan = onlySpan(collector.collectTraces());
+
+    String traceState = (String) parsedSpan.get("traceState");
+    assertTrue(traceState.startsWith("ot=rv:"));
+    assertTrue(traceState.contains(";th:8"));
+    assertFalse(traceState.contains("dd="));
+    assertEquals(SAMPLED_TRACE_FLAG, ((Number) parsedSpan.get("flags")).intValue());
   }
 
   @Test

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceProtoTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceProtoTest.java
@@ -730,6 +730,68 @@ class OtlpTraceProtoTest {
     return null;
   }
 
+  @Test
+  void spansExportFullTraceStateWithOtelMember() throws IOException {
+    PropagationTags propagationTags = PropagationTags.factory().empty();
+    propagationTags.updateW3CTracestate("vendor=state,ot=rv:abcdef12345678;th:80000000000000");
+    propagationTags.updateTraceSamplingPriority(
+        PrioritySampling.USER_KEEP, SamplingMechanism.EXTERNAL_OVERRIDE);
+    ExtractedContext parent =
+        new ExtractedContext(
+            DDTraceId.ONE,
+            0L,
+            PrioritySampling.USER_KEEP,
+            null,
+            propagationTags,
+            TracePropagationStyle.DATADOG);
+
+    AgentSpan root = TRACER.startSpan("test", "op.tracestate.root", parent);
+    root.setResourceName("op.tracestate.root");
+    AgentSpan child = TRACER.startSpan("test", "op.tracestate.child", root.spanContext());
+    child.setResourceName("op.tracestate.child");
+    child.finish();
+    root.finish();
+
+    OtlpTraceProtoCollector collector = new OtlpTraceProtoCollector();
+    collector.addTrace(asList((DDSpan) root, (DDSpan) child));
+
+    assertEquals(
+        asList(
+            "vendor=state,ot=rv:abcdef12345678;th:80000000000000",
+            "vendor=state,ot=rv:abcdef12345678;th:80000000000000"),
+        parseSpanTraceStatesFromPayload(collector.collectTraces()));
+  }
+
+  @Test
+  void spansExportOtelTraceStateWithoutW3CTraceState() throws IOException {
+    PropagationTags propagationTags = PropagationTags.factory().empty();
+    propagationTags.updateTraceSamplingPriority(
+        PrioritySampling.USER_KEEP, SamplingMechanism.EXTERNAL_OVERRIDE);
+    propagationTags.updateOtelTraceState(DDTraceId.ONE.toLong(), 0.5, true);
+    String traceState = propagationTags.getW3CTracestate(PrioritySampling.USER_KEEP);
+    ExtractedContext parent =
+        new ExtractedContext(
+            DDTraceId.ONE,
+            0L,
+            PrioritySampling.USER_KEEP,
+            null,
+            propagationTags,
+            TracePropagationStyle.DATADOG);
+
+    AgentSpan root = TRACER.startSpan("test", "op.otel.root", parent);
+    root.setResourceName("op.otel.root");
+    AgentSpan child = TRACER.startSpan("test", "op.otel.child", root.spanContext());
+    child.setResourceName("op.otel.child");
+    child.finish();
+    root.finish();
+
+    OtlpTraceProtoCollector collector = new OtlpTraceProtoCollector();
+    collector.addTrace(asList((DDSpan) root, (DDSpan) child));
+
+    assertEquals(
+        asList(traceState, traceState), parseSpanTraceStatesFromPayload(collector.collectTraces()));
+  }
+
   private static List<String> parseSpanNamesFromPayload(OtlpPayload payload) throws IOException {
     CodedInputStream tracesData = CodedInputStream.newInstance(payload.getContent());
     tracesData.readTag(); // field 1: TracesData.resource_spans
@@ -767,6 +829,45 @@ class OtlpTraceProtoTest {
       }
     }
     return names;
+  }
+
+  private static List<String> parseSpanTraceStatesFromPayload(OtlpPayload payload)
+      throws IOException {
+    CodedInputStream tracesData = CodedInputStream.newInstance(payload.getContent());
+    tracesData.readTag();
+    CodedInputStream resourceSpans = tracesData.readBytes().newCodedInput();
+
+    CodedInputStream scopeSpans = null;
+    while (!resourceSpans.isAtEnd()) {
+      int tag = resourceSpans.readTag();
+      if (WireFormat.getTagFieldNumber(tag) == 2) {
+        scopeSpans = resourceSpans.readBytes().newCodedInput();
+      } else {
+        resourceSpans.skipField(tag);
+      }
+    }
+    assertNotNull(scopeSpans, "ScopeSpans must be present in ResourceSpans");
+
+    List<String> traceStates = new ArrayList<>();
+    while (!scopeSpans.isAtEnd()) {
+      int tag = scopeSpans.readTag();
+      if (WireFormat.getTagFieldNumber(tag) != 2) {
+        scopeSpans.skipField(tag);
+        continue;
+      }
+      CodedInputStream spanData = scopeSpans.readBytes().newCodedInput();
+      String traceState = null;
+      while (!spanData.isAtEnd()) {
+        int spanTag = spanData.readTag();
+        if (WireFormat.getTagFieldNumber(spanTag) == 3) {
+          traceState = spanData.readString();
+        } else {
+          spanData.skipField(spanTag);
+        }
+      }
+      traceStates.add(traceState);
+    }
+    return traceStates;
   }
 
   // ── span construction ─────────────────────────────────────────────────────

--- a/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceProtoTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/otlp/trace/OtlpTraceProtoTest.java
@@ -6,6 +6,7 @@ import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_CONSUME
 import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_INTERNAL;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_PRODUCER;
 import static datadog.trace.bootstrap.instrumentation.api.Tags.SPAN_KIND_SERVER;
+import static datadog.trace.common.sampling.RuleBasedTraceSampler.SAMPLING_RULE_RATE;
 import static datadog.trace.core.otlp.common.OtlpTraceFlags.SAMPLED_TRACE_FLAG;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.copyOfRange;
@@ -674,6 +675,59 @@ class OtlpTraceProtoTest {
         asList("first.span", "second.span", "third.span"),
         parseSpanNamesFromPayload(payload),
         "spans must appear in trace order in the payload");
+  }
+
+  @Test
+  void spanTraceStateIncludesLocalOtelSamplingState() throws IOException {
+    AgentSpan agentSpan = TRACER.startSpan("test", "op.otel-tracestate");
+    agentSpan.setResourceName("op.otel-tracestate");
+    ((DDSpan) agentSpan)
+        .setSamplingPriority(
+            PrioritySampling.USER_KEEP,
+            SAMPLING_RULE_RATE,
+            0.5,
+            SamplingMechanism.LOCAL_USER_RULE,
+            true);
+    agentSpan.finish();
+
+    OtlpTraceProtoCollector collector = new OtlpTraceProtoCollector();
+    collector.addTrace(asList((DDSpan) agentSpan));
+
+    String traceState = parseFirstSpanTraceState(collector.collectTraces());
+    assertTrue(traceState.startsWith("ot=rv:"));
+    assertTrue(traceState.contains(";th:8"));
+    assertFalse(traceState.contains("dd="));
+  }
+
+  private static String parseFirstSpanTraceState(OtlpPayload payload) throws IOException {
+    CodedInputStream tracesData = CodedInputStream.newInstance(payload.getContent());
+    tracesData.readTag();
+    CodedInputStream resourceSpans = tracesData.readBytes().newCodedInput();
+
+    while (!resourceSpans.isAtEnd()) {
+      int tag = resourceSpans.readTag();
+      if (WireFormat.getTagFieldNumber(tag) != 2) {
+        resourceSpans.skipField(tag);
+        continue;
+      }
+      CodedInputStream scopeSpans = resourceSpans.readBytes().newCodedInput();
+      while (!scopeSpans.isAtEnd()) {
+        int scopeTag = scopeSpans.readTag();
+        if (WireFormat.getTagFieldNumber(scopeTag) != 2) {
+          scopeSpans.skipField(scopeTag);
+          continue;
+        }
+        CodedInputStream span = scopeSpans.readBytes().newCodedInput();
+        while (!span.isAtEnd()) {
+          int spanTag = span.readTag();
+          if (WireFormat.getTagFieldNumber(spanTag) == 3) {
+            return span.readString();
+          }
+          span.skipField(spanTag);
+        }
+      }
+    }
+    return null;
   }
 
   private static List<String> parseSpanNamesFromPayload(OtlpPayload payload) throws IOException {

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/HttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/HttpExtractorTest.java
@@ -1,11 +1,14 @@
 package datadog.trace.core.propagation;
 
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH;
 import static datadog.trace.api.DDTags.PARENT_ID;
+import static datadog.trace.api.TracePropagationStyle.DATADOG;
 import static datadog.trace.api.TracePropagationStyle.TRACECONTEXT;
 import static datadog.trace.bootstrap.instrumentation.api.ContextVisitors.stringValuesMap;
 import static datadog.trace.core.propagation.B3HttpCodec.B3_SPAN_ID;
 import static datadog.trace.core.propagation.B3HttpCodec.B3_TRACE_ID;
 import static datadog.trace.core.propagation.HttpCodecTestHelper.headers;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,9 +43,15 @@ class HttpExtractorTest extends DDJavaSpecification {
   private static final String W3C_TRACE_ID = "00000000000000000000000000000001";
   private static final String W3C_SPAN_ID = "123456789abcdef0";
   private static final String W3C_TRACE_PARENT = "00-" + W3C_TRACE_ID + "-" + W3C_SPAN_ID + "-01";
+  private static final String W3C_TRACE_PARENT_DROP =
+      "00-" + W3C_TRACE_ID + "-" + W3C_SPAN_ID + "-00";
   private static final String W3C_PARENT_ID = "456789abcdef0123";
   private static final String W3C_TRACE_STATE_WITH_P = "dd=p:" + W3C_PARENT_ID;
   private static final String W3C_TRACE_STATE_NO_P = "dd=s:2,foo=1";
+  private static final String W3C_TRACE_STATE_WITH_OTEL =
+      "dd=s:0,ot=rv:ef284ace7a91e1;th:e6666666666668";
+  private static final String W3C_TRACE_STATE_WITH_OTEL_AND_DECISION_MAKER =
+      "dd=s:2;t.dm:-3,ot=rv:ef284ace7a91e1;th:e6666666666668";
   private static final String W3C_SPAN_ID_LSTR = Long.toString(DDSpanId.fromHex(W3C_SPAN_ID));
 
   @TableTest({
@@ -211,6 +220,41 @@ class HttpExtractorTest extends DDJavaSpecification {
     }
   }
 
+  @TableTest({
+    "samplingPriority | datadogTags   | traceParent             | traceState                                    ",
+    "0                |               | 'W3C_TRACE_PARENT_DROP' | 'W3C_TRACE_STATE_WITH_OTEL'                   ",
+    "2                | '_dd.p.dm=-3' | 'W3C_TRACE_PARENT'      | 'W3C_TRACE_STATE_WITH_OTEL_AND_DECISION_MAKER'"
+  })
+  void enrichesPropagationTagsWhenDatadogContextWins(
+      int samplingPriority,
+      String datadogTags,
+      @ConvertWith(W3cConstantConverter.class) String traceParent,
+      @ConvertWith(W3cConstantConverter.class) String traceState) {
+    HttpCodec.Extractor extractor = createExtractor(asList(DATADOG, TRACECONTEXT));
+    Map<String, String> headers =
+        headers(
+            DatadogHttpCodec.TRACE_ID_KEY,
+            "1",
+            DatadogHttpCodec.SPAN_ID_KEY,
+            "2",
+            DatadogHttpCodec.SAMPLING_PRIORITY_KEY,
+            String.valueOf(samplingPriority),
+            DatadogHttpCodec.DATADOG_TAGS_KEY,
+            datadogTags,
+            W3CHttpCodec.TRACE_PARENT_KEY,
+            traceParent,
+            W3CHttpCodec.TRACE_STATE_KEY,
+            traceState);
+
+    ExtractedContext context =
+        assertInstanceOf(ExtractedContext.class, extractor.extract(headers, stringValuesMap()));
+
+    assertEquals(samplingPriority, context.getSamplingPriority());
+    assertEquals(samplingPriority, context.getPropagationTags().getSamplingPriority());
+    assertEquals(
+        traceState, context.getPropagationTags().headerValue(PropagationTags.HeaderType.W3C));
+  }
+
   private static Set<TracePropagationStyle> orderedSetOf(List<TracePropagationStyle> styles) {
     return new LinkedHashSet<>(styles);
   }
@@ -224,6 +268,7 @@ class HttpExtractorTest extends DDJavaSpecification {
     Config config = mock(Config.class);
     when(config.getTracePropagationStylesToExtract()).thenReturn(orderedSetOf(styles));
     when(config.isTracePropagationExtractFirst()).thenReturn(extractFirst);
+    when(config.getxDatadogTagsMaxLength()).thenReturn(DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH);
     DynamicConfig<DynamicConfig.Snapshot> dynamicConfig =
         DynamicConfig.create().setHeaderTags(headerTags).setBaggageMapping(emptyMap()).apply();
     return HttpCodec.createExtractor(config, dynamicConfig::captureTraceConfig);
@@ -248,10 +293,16 @@ class HttpExtractorTest extends DDJavaSpecification {
       switch (source.toString()) {
         case "W3C_TRACE_PARENT":
           return W3C_TRACE_PARENT;
+        case "W3C_TRACE_PARENT_DROP":
+          return W3C_TRACE_PARENT_DROP;
         case "W3C_TRACE_STATE_WITH_P":
           return W3C_TRACE_STATE_WITH_P;
         case "W3C_TRACE_STATE_NO_P":
           return W3C_TRACE_STATE_NO_P;
+        case "W3C_TRACE_STATE_WITH_OTEL":
+          return W3C_TRACE_STATE_WITH_OTEL;
+        case "W3C_TRACE_STATE_WITH_OTEL_AND_DECISION_MAKER":
+          return W3C_TRACE_STATE_WITH_OTEL_AND_DECISION_MAKER;
         case "W3C_SPAN_ID_LSTR":
           return W3C_SPAN_ID_LSTR;
         case "W3C_PARENT_ID":

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/HttpExtractorTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/HttpExtractorTest.java
@@ -1,14 +1,11 @@
 package datadog.trace.core.propagation;
 
-import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH;
 import static datadog.trace.api.DDTags.PARENT_ID;
-import static datadog.trace.api.TracePropagationStyle.DATADOG;
 import static datadog.trace.api.TracePropagationStyle.TRACECONTEXT;
 import static datadog.trace.bootstrap.instrumentation.api.ContextVisitors.stringValuesMap;
 import static datadog.trace.core.propagation.B3HttpCodec.B3_SPAN_ID;
 import static datadog.trace.core.propagation.B3HttpCodec.B3_TRACE_ID;
 import static datadog.trace.core.propagation.HttpCodecTestHelper.headers;
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,15 +40,9 @@ class HttpExtractorTest extends DDJavaSpecification {
   private static final String W3C_TRACE_ID = "00000000000000000000000000000001";
   private static final String W3C_SPAN_ID = "123456789abcdef0";
   private static final String W3C_TRACE_PARENT = "00-" + W3C_TRACE_ID + "-" + W3C_SPAN_ID + "-01";
-  private static final String W3C_TRACE_PARENT_DROP =
-      "00-" + W3C_TRACE_ID + "-" + W3C_SPAN_ID + "-00";
   private static final String W3C_PARENT_ID = "456789abcdef0123";
   private static final String W3C_TRACE_STATE_WITH_P = "dd=p:" + W3C_PARENT_ID;
   private static final String W3C_TRACE_STATE_NO_P = "dd=s:2,foo=1";
-  private static final String W3C_TRACE_STATE_WITH_OTEL =
-      "dd=s:0,ot=rv:ef284ace7a91e1;th:e6666666666668";
-  private static final String W3C_TRACE_STATE_WITH_OTEL_AND_DECISION_MAKER =
-      "dd=s:2;t.dm:-3,ot=rv:ef284ace7a91e1;th:e6666666666668";
   private static final String W3C_SPAN_ID_LSTR = Long.toString(DDSpanId.fromHex(W3C_SPAN_ID));
 
   @TableTest({
@@ -220,41 +211,6 @@ class HttpExtractorTest extends DDJavaSpecification {
     }
   }
 
-  @TableTest({
-    "samplingPriority | datadogTags   | traceParent             | traceState                                    ",
-    "0                |               | 'W3C_TRACE_PARENT_DROP' | 'W3C_TRACE_STATE_WITH_OTEL'                   ",
-    "2                | '_dd.p.dm=-3' | 'W3C_TRACE_PARENT'      | 'W3C_TRACE_STATE_WITH_OTEL_AND_DECISION_MAKER'"
-  })
-  void enrichesPropagationTagsWhenDatadogContextWins(
-      int samplingPriority,
-      String datadogTags,
-      @ConvertWith(W3cConstantConverter.class) String traceParent,
-      @ConvertWith(W3cConstantConverter.class) String traceState) {
-    HttpCodec.Extractor extractor = createExtractor(asList(DATADOG, TRACECONTEXT));
-    Map<String, String> headers =
-        headers(
-            DatadogHttpCodec.TRACE_ID_KEY,
-            "1",
-            DatadogHttpCodec.SPAN_ID_KEY,
-            "2",
-            DatadogHttpCodec.SAMPLING_PRIORITY_KEY,
-            String.valueOf(samplingPriority),
-            DatadogHttpCodec.DATADOG_TAGS_KEY,
-            datadogTags,
-            W3CHttpCodec.TRACE_PARENT_KEY,
-            traceParent,
-            W3CHttpCodec.TRACE_STATE_KEY,
-            traceState);
-
-    ExtractedContext context =
-        assertInstanceOf(ExtractedContext.class, extractor.extract(headers, stringValuesMap()));
-
-    assertEquals(samplingPriority, context.getSamplingPriority());
-    assertEquals(samplingPriority, context.getPropagationTags().getSamplingPriority());
-    assertEquals(
-        traceState, context.getPropagationTags().headerValue(PropagationTags.HeaderType.W3C));
-  }
-
   private static Set<TracePropagationStyle> orderedSetOf(List<TracePropagationStyle> styles) {
     return new LinkedHashSet<>(styles);
   }
@@ -268,7 +224,6 @@ class HttpExtractorTest extends DDJavaSpecification {
     Config config = mock(Config.class);
     when(config.getTracePropagationStylesToExtract()).thenReturn(orderedSetOf(styles));
     when(config.isTracePropagationExtractFirst()).thenReturn(extractFirst);
-    when(config.getxDatadogTagsMaxLength()).thenReturn(DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH);
     DynamicConfig<DynamicConfig.Snapshot> dynamicConfig =
         DynamicConfig.create().setHeaderTags(headerTags).setBaggageMapping(emptyMap()).apply();
     return HttpCodec.createExtractor(config, dynamicConfig::captureTraceConfig);
@@ -293,16 +248,10 @@ class HttpExtractorTest extends DDJavaSpecification {
       switch (source.toString()) {
         case "W3C_TRACE_PARENT":
           return W3C_TRACE_PARENT;
-        case "W3C_TRACE_PARENT_DROP":
-          return W3C_TRACE_PARENT_DROP;
         case "W3C_TRACE_STATE_WITH_P":
           return W3C_TRACE_STATE_WITH_P;
         case "W3C_TRACE_STATE_NO_P":
           return W3C_TRACE_STATE_NO_P;
-        case "W3C_TRACE_STATE_WITH_OTEL":
-          return W3C_TRACE_STATE_WITH_OTEL;
-        case "W3C_TRACE_STATE_WITH_OTEL_AND_DECISION_MAKER":
-          return W3C_TRACE_STATE_WITH_OTEL_AND_DECISION_MAKER;
         case "W3C_SPAN_ID_LSTR":
           return W3C_SPAN_ID_LSTR;
         case "W3C_PARENT_ID":

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/OtelTraceStatePropagationTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/OtelTraceStatePropagationTest.java
@@ -1,0 +1,172 @@
+package datadog.trace.core.propagation;
+
+import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP;
+import static datadog.trace.api.sampling.SamplingMechanism.LOCAL_USER_RULE;
+import static datadog.trace.api.sampling.SamplingMechanism.MANUAL;
+import static datadog.trace.core.propagation.PropagationTags.HeaderType.W3C;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class OtelTraceStatePropagationTest {
+  private static final String RV = "ef284ace7a91e1";
+  private static final String TH = "e6666666666668";
+
+  @ParameterizedTest
+  @MethodSource("inboundTraceState")
+  void normalizesAndForwardsFirstOtelMember(String header, String expected) {
+    PropagationTags propagationTags = PropagationTags.factory().fromHeaderValue(W3C, header);
+
+    assertEquals(expected, propagationTags.headerValue(W3C));
+  }
+
+  static Stream<Arguments> inboundTraceState() {
+    return Stream.of(
+        arguments("ot=rv:" + RV + ";th:" + TH, "ot=rv:" + RV + ";th:" + TH),
+        arguments("ot=rv:" + RV, "ot=rv:" + RV),
+        arguments("ot=th:" + TH, "ot=th:" + TH),
+        arguments("ot=foo:bar", "ot=foo:bar"),
+        arguments(
+            "congo=state,ot=rv:invalid;th:" + TH + ";foo:bar",
+            "ot=th:" + TH + ";foo:bar,congo=state"),
+        arguments("congo=state,ot=rv:invalid;th:invalid", "congo=state"),
+        arguments("ot=rv:EF284ACE7A91E1;th:" + TH, "ot=th:" + TH),
+        arguments(
+            "ot=rv:" + RV + ";rv:1234567890abcd;th:" + TH,
+            "ot=rv:" + RV + ";rv:1234567890abcd;th:" + TH),
+        arguments(
+            "foo=bar,ot=rv:" + RV + ",ot=rv:1234567890abcd,other=state",
+            "foo=bar,ot=rv:" + RV + ",other=state"),
+        arguments("dd=s:1,dd=s:0,ot=rv:" + RV, "dd=s:1,ot=rv:" + RV));
+  }
+
+  @Test
+  void preservesUnchangedInheritedMemberPosition() {
+    PropagationTags propagationTags =
+        PropagationTags.factory()
+            .fromHeaderValue(W3C, "dd=s:1,foo=bar,ot=rv:" + RV + ",something=else");
+
+    assertEquals(
+        "dd=s:1,foo=bar,ot=rv:" + RV + ",something=else", propagationTags.headerValue(W3C));
+  }
+
+  @Test
+  void movesNormalizedMemberImmediatelyAfterDatadog() {
+    PropagationTags propagationTags =
+        PropagationTags.factory()
+            .fromHeaderValue(W3C, "dd=s:1,foo=bar,ot=rv:invalid;th:" + TH + ",something=else");
+
+    assertEquals(
+        "dd=s:1,ot=th:" + TH + ",foo=bar,something=else", propagationTags.headerValue(W3C));
+  }
+
+  @Test
+  void movesLocallyGeneratedMemberImmediatelyAfterDatadog() {
+    PropagationTags propagationTags =
+        PropagationTags.factory()
+            .fromHeaderValue(
+                W3C, "foo=bar,ot=rv:" + RV + ";th:" + TH + ";future:value,other=state");
+
+    propagationTags.updateTraceSamplingPriority(USER_KEEP, LOCAL_USER_RULE);
+    propagationTags.updateOtelTraceState(1, 0.5, true, USER_KEEP);
+
+    assertEquals(
+        "dd=s:2;t.dm:-3,ot=rv:f0948a54d43b8e;th:8;future:value,foo=bar,other=state",
+        propagationTags.headerValue(W3C));
+  }
+
+  @Test
+  void manualKeepRetainsInheritedRandomnessAndUnknownFields() {
+    PropagationTags propagationTags =
+        PropagationTags.factory()
+            .fromHeaderValue(
+                W3C, "foo=bar,ot=rv:" + RV + ";th:" + TH + ";future:value,other=state");
+
+    propagationTags.forceKeep(MANUAL);
+
+    assertEquals(
+        "dd=s:2;t.dm:-4,ot=rv:" + RV + ";future:value,foo=bar,other=state",
+        propagationTags.headerValue(W3C));
+  }
+
+  @Test
+  void manualKeepRemovesLocallyGeneratedRandomness() {
+    PropagationTags propagationTags = PropagationTags.factory().empty();
+    propagationTags.updateTraceSamplingPriority(USER_KEEP, LOCAL_USER_RULE);
+    propagationTags.updateOtelTraceState(1, 0.5, true, USER_KEEP);
+
+    propagationTags.forceKeep(MANUAL);
+
+    assertEquals("dd=s:2;t.dm:-4", propagationTags.headerValue(W3C));
+  }
+
+  @Test
+  void sampledContextWithoutOtelStateDoesNotFabricateIt() {
+    PropagationTags propagationTags =
+        PropagationTags.factory().fromHeaderValue(W3C, "dd=s:1,foo=bar");
+
+    assertEquals("dd=s:1,foo=bar", propagationTags.headerValue(W3C));
+  }
+
+  @Test
+  void updatingW3cTraceStateCapturesOtelStateForMixedHeaderExtraction() {
+    PropagationTags propagationTags =
+        PropagationTags.factory()
+            .fromHeaderValue(PropagationTags.HeaderType.DATADOG, "_dd.p.dm=-3");
+
+    propagationTags.updateW3CTracestate("foo=bar,ot=rv:" + RV + ";th:" + TH + ",other=state");
+
+    assertEquals(
+        "dd=t.dm:-3,foo=bar,ot=rv:" + RV + ";th:" + TH + ",other=state",
+        propagationTags.headerValue(W3C));
+  }
+
+  @Test
+  void emitsOnlyCompleteOtelFieldsAtMemberSizeLimit() {
+    String unknownField = "x:" + repeat("v", 254);
+    PropagationTags propagationTags =
+        PropagationTags.factory().fromHeaderValue(W3C, "ot=" + unknownField);
+
+    assertEquals("ot=" + unknownField, propagationTags.headerValue(W3C));
+
+    propagationTags.updateTraceSamplingPriority(USER_KEEP, LOCAL_USER_RULE);
+    propagationTags.updateOtelTraceState(1, 0.5, true, USER_KEEP);
+
+    String header = propagationTags.headerValue(W3C);
+    assertTrue(header.contains("ot=rv:f0948a54d43b8e;th:8"));
+    assertFalse(header.contains("x:"));
+  }
+
+  @Test
+  void generatedOtelMemberHonorsMemberCountLimit() {
+    StringBuilder original = new StringBuilder("ot=rv:").append(RV);
+    for (int i = 0; i < 31; i++) {
+      original.append(",v").append(i).append("=state");
+    }
+    PropagationTags propagationTags =
+        PropagationTags.factory().fromHeaderValue(W3C, original.toString());
+
+    propagationTags.updateTraceSamplingPriority(USER_KEEP, LOCAL_USER_RULE);
+    propagationTags.updateOtelTraceState(1, 0.5, true, USER_KEEP);
+
+    String header = propagationTags.headerValue(W3C);
+    assertEquals(32, header.split(",").length);
+    assertTrue(header.startsWith("dd=s:2;t.dm:-3,ot=rv:f0948a54d43b8e;th:8,"));
+    assertFalse(header.contains("v30=state"));
+  }
+
+  private static String repeat(String value, int count) {
+    StringBuilder repeated = new StringBuilder(value.length() * count);
+    for (int i = 0; i < count; i++) {
+      repeated.append(value);
+    }
+    return repeated.toString();
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/OtelTraceStatePropagationTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/OtelTraceStatePropagationTest.java
@@ -16,8 +16,14 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class OtelTraceStatePropagationTest {
+  private static final long TRACE_ID = 1;
+  private static final double SAMPLE_RATE_0_5 = 0.5;
   private static final String RV = "ef284ace7a91e1";
   private static final String TH = "e6666666666668";
+  private static final String GENERATED_RV = "f0948a54d43b8e";
+  private static final String THRESHOLD_0_5 = "8";
+  private static final int W3C_MEMBER_VALUE_MAX_LENGTH = 256;
+  private static final int W3C_TRACESTATE_MEMBER_LIMIT = 32;
 
   @ParameterizedTest
   @MethodSource("inboundTraceState")
@@ -28,6 +34,7 @@ class OtelTraceStatePropagationTest {
   }
 
   static Stream<Arguments> inboundTraceState() {
+    // Covers valid, invalid, duplicate, and ordered ot list-members.
     return Stream.of(
         arguments("ot=rv:" + RV + ";th:" + TH, "ot=rv:" + RV + ";th:" + TH),
         arguments("ot=rv:" + RV, "ot=rv:" + RV),
@@ -75,10 +82,14 @@ class OtelTraceStatePropagationTest {
                 W3C, "foo=bar,ot=rv:" + RV + ";th:" + TH + ";future:value,other=state");
 
     propagationTags.updateTraceSamplingPriority(USER_KEEP, LOCAL_USER_RULE);
-    propagationTags.updateOtelTraceState(1, 0.5, true, USER_KEEP);
+    propagationTags.updateOtelTraceState(TRACE_ID, SAMPLE_RATE_0_5, true, USER_KEEP);
 
     assertEquals(
-        "dd=s:2;t.dm:-3,ot=rv:f0948a54d43b8e;th:8;future:value,foo=bar,other=state",
+        "dd=s:2;t.dm:-3,ot=rv:"
+            + GENERATED_RV
+            + ";th:"
+            + THRESHOLD_0_5
+            + ";future:value,foo=bar,other=state",
         propagationTags.headerValue(W3C));
   }
 
@@ -100,7 +111,7 @@ class OtelTraceStatePropagationTest {
   void manualKeepRemovesLocallyGeneratedRandomness() {
     PropagationTags propagationTags = PropagationTags.factory().empty();
     propagationTags.updateTraceSamplingPriority(USER_KEEP, LOCAL_USER_RULE);
-    propagationTags.updateOtelTraceState(1, 0.5, true, USER_KEEP);
+    propagationTags.updateOtelTraceState(TRACE_ID, SAMPLE_RATE_0_5, true, USER_KEEP);
 
     propagationTags.forceKeep(MANUAL);
 
@@ -130,35 +141,37 @@ class OtelTraceStatePropagationTest {
 
   @Test
   void emitsOnlyCompleteOtelFieldsAtMemberSizeLimit() {
-    String unknownField = "x:" + repeat("v", 254);
+    // W3C limits an individual tracestate member value to 256 characters.
+    String unknownField = "x:" + repeat("v", W3C_MEMBER_VALUE_MAX_LENGTH - 2);
     PropagationTags propagationTags =
         PropagationTags.factory().fromHeaderValue(W3C, "ot=" + unknownField);
 
     assertEquals("ot=" + unknownField, propagationTags.headerValue(W3C));
 
     propagationTags.updateTraceSamplingPriority(USER_KEEP, LOCAL_USER_RULE);
-    propagationTags.updateOtelTraceState(1, 0.5, true, USER_KEEP);
+    propagationTags.updateOtelTraceState(TRACE_ID, SAMPLE_RATE_0_5, true, USER_KEEP);
 
     String header = propagationTags.headerValue(W3C);
-    assertTrue(header.contains("ot=rv:f0948a54d43b8e;th:8"));
+    assertTrue(header.contains("ot=rv:" + GENERATED_RV + ";th:" + THRESHOLD_0_5));
     assertFalse(header.contains("x:"));
   }
 
   @Test
   void generatedOtelMemberHonorsMemberCountLimit() {
     StringBuilder original = new StringBuilder("ot=rv:").append(RV);
-    for (int i = 0; i < 31; i++) {
+    for (int i = 0; i < W3C_TRACESTATE_MEMBER_LIMIT - 1; i++) {
       original.append(",v").append(i).append("=state");
     }
     PropagationTags propagationTags =
         PropagationTags.factory().fromHeaderValue(W3C, original.toString());
 
     propagationTags.updateTraceSamplingPriority(USER_KEEP, LOCAL_USER_RULE);
-    propagationTags.updateOtelTraceState(1, 0.5, true, USER_KEEP);
+    propagationTags.updateOtelTraceState(TRACE_ID, SAMPLE_RATE_0_5, true, USER_KEEP);
 
     String header = propagationTags.headerValue(W3C);
-    assertEquals(32, header.split(",").length);
-    assertTrue(header.startsWith("dd=s:2;t.dm:-3,ot=rv:f0948a54d43b8e;th:8,"));
+    assertEquals(W3C_TRACESTATE_MEMBER_LIMIT, header.split(",").length);
+    assertTrue(
+        header.startsWith("dd=s:2;t.dm:-3,ot=rv:" + GENERATED_RV + ";th:" + THRESHOLD_0_5 + ","));
     assertFalse(header.contains("v30=state"));
   }
 

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/OtelTraceStatePropagationTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/OtelTraceStatePropagationTest.java
@@ -1,5 +1,6 @@
 package datadog.trace.core.propagation;
 
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
 import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP;
 import static datadog.trace.api.sampling.SamplingMechanism.LOCAL_USER_RULE;
 import static datadog.trace.api.sampling.SamplingMechanism.MANUAL;
@@ -75,21 +76,17 @@ class OtelTraceStatePropagationTest {
   }
 
   @Test
-  void movesLocallyGeneratedMemberImmediatelyAfterDatadog() {
+  void preservesInheritedMemberWhenLocalProbabilitySamplingIsAttempted() {
     PropagationTags propagationTags =
         PropagationTags.factory()
             .fromHeaderValue(
                 W3C, "foo=bar,ot=rv:" + RV + ";th:" + TH + ";future:value,other=state");
 
     propagationTags.updateTraceSamplingPriority(USER_KEEP, LOCAL_USER_RULE);
-    propagationTags.updateOtelTraceState(TRACE_ID, SAMPLE_RATE_0_5, true, USER_KEEP);
+    propagationTags.updateOtelTraceState(TRACE_ID, SAMPLE_RATE_0_5, true);
 
     assertEquals(
-        "dd=s:2;t.dm:-3,ot=rv:"
-            + GENERATED_RV
-            + ";th:"
-            + THRESHOLD_0_5
-            + ";future:value,foo=bar,other=state",
+        "dd=s:2;t.dm:-3,foo=bar,ot=rv:" + RV + ";th:" + TH + ";future:value,other=state",
         propagationTags.headerValue(W3C));
   }
 
@@ -111,7 +108,7 @@ class OtelTraceStatePropagationTest {
   void manualKeepRemovesLocallyGeneratedRandomness() {
     PropagationTags propagationTags = PropagationTags.factory().empty();
     propagationTags.updateTraceSamplingPriority(USER_KEEP, LOCAL_USER_RULE);
-    propagationTags.updateOtelTraceState(TRACE_ID, SAMPLE_RATE_0_5, true, USER_KEEP);
+    propagationTags.updateOtelTraceState(TRACE_ID, SAMPLE_RATE_0_5, true);
 
     propagationTags.forceKeep(MANUAL);
 
@@ -124,6 +121,14 @@ class OtelTraceStatePropagationTest {
         PropagationTags.factory().fromHeaderValue(W3C, "dd=s:1,foo=bar");
 
     assertEquals("dd=s:1,foo=bar", propagationTags.headerValue(W3C));
+  }
+
+  @Test
+  void serializesSamplingStateFromOnePrioritySnapshot() {
+    PropagationTags propagationTags =
+        PropagationTags.factory().fromHeaderValue(W3C, "dd=s:2,ot=rv:" + RV + ";th:" + TH);
+
+    assertEquals("dd=s:0,ot=rv:" + RV, propagationTags.headerValue(W3C, null, SAMPLER_DROP));
   }
 
   @Test
@@ -140,7 +145,7 @@ class OtelTraceStatePropagationTest {
   }
 
   @Test
-  void emitsOnlyCompleteOtelFieldsAtMemberSizeLimit() {
+  void preservesInheritedOtelFieldsAtMemberSizeLimit() {
     // W3C limits an individual tracestate member value to 256 characters.
     String unknownField = "x:" + repeat("v", W3C_MEMBER_VALUE_MAX_LENGTH - 2);
     PropagationTags propagationTags =
@@ -149,24 +154,24 @@ class OtelTraceStatePropagationTest {
     assertEquals("ot=" + unknownField, propagationTags.headerValue(W3C));
 
     propagationTags.updateTraceSamplingPriority(USER_KEEP, LOCAL_USER_RULE);
-    propagationTags.updateOtelTraceState(TRACE_ID, SAMPLE_RATE_0_5, true, USER_KEEP);
+    propagationTags.updateOtelTraceState(TRACE_ID, SAMPLE_RATE_0_5, true);
 
     String header = propagationTags.headerValue(W3C);
-    assertTrue(header.contains("ot=rv:" + GENERATED_RV + ";th:" + THRESHOLD_0_5));
-    assertFalse(header.contains("x:"));
+    assertTrue(header.contains("ot=" + unknownField));
+    assertFalse(header.contains("ot=rv:"));
   }
 
   @Test
   void generatedOtelMemberHonorsMemberCountLimit() {
-    StringBuilder original = new StringBuilder("ot=rv:").append(RV);
-    for (int i = 0; i < W3C_TRACESTATE_MEMBER_LIMIT - 1; i++) {
+    StringBuilder original = new StringBuilder("v0=state");
+    for (int i = 1; i < W3C_TRACESTATE_MEMBER_LIMIT - 1; i++) {
       original.append(",v").append(i).append("=state");
     }
     PropagationTags propagationTags =
         PropagationTags.factory().fromHeaderValue(W3C, original.toString());
 
     propagationTags.updateTraceSamplingPriority(USER_KEEP, LOCAL_USER_RULE);
-    propagationTags.updateOtelTraceState(TRACE_ID, SAMPLE_RATE_0_5, true, USER_KEEP);
+    propagationTags.updateOtelTraceState(TRACE_ID, SAMPLE_RATE_0_5, true);
 
     String header = propagationTags.headerValue(W3C);
     assertEquals(W3C_TRACESTATE_MEMBER_LIMIT, header.split(",").length);

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/OtelTraceStatePropagationTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/OtelTraceStatePropagationTest.java
@@ -4,6 +4,7 @@ import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
 import static datadog.trace.api.sampling.PrioritySampling.USER_KEEP;
 import static datadog.trace.api.sampling.SamplingMechanism.LOCAL_USER_RULE;
 import static datadog.trace.api.sampling.SamplingMechanism.MANUAL;
+import static datadog.trace.api.sampling.SamplingMechanism.UNKNOWN;
 import static datadog.trace.core.propagation.PropagationTags.HeaderType.W3C;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -100,7 +101,23 @@ class OtelTraceStatePropagationTest {
     propagationTags.forceKeep(MANUAL);
 
     assertEquals(
+        "foo=bar,ot=rv:" + RV + ";th:" + TH + ";future:value,other=state",
+        propagationTags.getW3CTracestate());
+    assertEquals(
         "dd=s:2;t.dm:-4,ot=rv:" + RV + ";future:value,foo=bar,other=state",
+        propagationTags.headerValue(W3C));
+  }
+
+  @Test
+  void initialUnknownPriorityDoesNotOverrideInheritedProbabilityDecision() {
+    PropagationTags propagationTags =
+        PropagationTags.factory()
+            .fromHeaderValue(W3C, "foo=bar,ot=rv:" + RV + ";th:" + TH + ";future:value");
+
+    propagationTags.updateTraceSamplingPriority(USER_KEEP, UNKNOWN);
+
+    assertEquals(
+        "dd=s:2,foo=bar,ot=rv:" + RV + ";th:" + TH + ";future:value",
         propagationTags.headerValue(W3C));
   }
 
@@ -129,6 +146,28 @@ class OtelTraceStatePropagationTest {
         PropagationTags.factory().fromHeaderValue(W3C, "dd=s:2,ot=rv:" + RV + ";th:" + TH);
 
     assertEquals("dd=s:0,ot=rv:" + RV, propagationTags.headerValue(W3C, null, SAMPLER_DROP));
+  }
+
+  @Test
+  void effectiveTracestateOnlyUpdatesOtelMember() {
+    PropagationTags propagationTags =
+        PropagationTags.factory()
+            .fromHeaderValue(W3C, "dd=s:1;t.dm:-3,vendor=state,ot=rv:" + RV + ";th:" + TH);
+
+    assertEquals(
+        "dd=s:1;t.dm:-3,ot=rv:" + RV + ",vendor=state",
+        propagationTags.getW3CTracestate(SAMPLER_DROP));
+  }
+
+  @Test
+  void effectiveTracestateAddsOnlyLocallyGeneratedOtelMember() {
+    PropagationTags propagationTags = PropagationTags.factory().empty();
+    propagationTags.updateTraceSamplingPriority(USER_KEEP, LOCAL_USER_RULE);
+    propagationTags.updateOtelTraceState(TRACE_ID, SAMPLE_RATE_0_5, true);
+
+    assertEquals(
+        "ot=rv:" + GENERATED_RV + ";th:" + THRESHOLD_0_5,
+        propagationTags.getW3CTracestate(USER_KEEP));
   }
 
   @Test

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/W3COtelTraceStateContinuationTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/W3COtelTraceStateContinuationTest.java
@@ -1,0 +1,80 @@
+package datadog.trace.core.propagation;
+
+import static datadog.trace.bootstrap.instrumentation.api.ContextVisitors.stringValuesMap;
+import static datadog.trace.core.propagation.HttpCodecTestHelper.headers;
+import static datadog.trace.core.propagation.W3CHttpCodec.TRACE_PARENT_KEY;
+import static datadog.trace.core.propagation.W3CHttpCodec.TRACE_STATE_KEY;
+import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.api.Config;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.core.CoreTracer;
+import datadog.trace.core.DDCoreJavaSpecification;
+import datadog.trace.core.DDSpanContext;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the {@code ot=} tracestate member through the real {@link W3CHttpCodec} extractor and
+ * injector, continuing an inbound trace rather than parsing tracestate or building an {@link
+ * ExtractedContext} by hand.
+ */
+class W3COtelTraceStateContinuationTest extends DDCoreJavaSpecification {
+
+  private static final String TRACE_PARENT =
+      "00-00000000000000000000000000000001-123456789abcdef0-01";
+  private static final String OTEL_RANDOM_VALUE = "ef284ace7a91e1";
+  private static final String OTEL_THRESHOLD = "e6666666666668";
+  private static final String OTEL_MALFORMED_RANDOM_VALUE = "zz";
+  private static final String DD_MEMBER = "dd=s:2;p:123456789abcdef0";
+
+  private final HttpCodec.Injector injector = W3CHttpCodec.newInjector(emptyMap());
+
+  @Test
+  void roundTripsOtelTraceState() {
+    String inboundTracestate = DD_MEMBER + ",ot=rv:" + OTEL_RANDOM_VALUE + ";th:" + OTEL_THRESHOLD;
+    String outboundTracestate = continueTraceAndReinject(inboundTracestate);
+
+    assertTrue(outboundTracestate.contains("ot=rv:" + OTEL_RANDOM_VALUE + ";th:" + OTEL_THRESHOLD));
+  }
+
+  @Test
+  void removesMalformedOtelRandomValueButKeepsThreshold() {
+    String inboundTracestate =
+        DD_MEMBER + ",ot=rv:" + OTEL_MALFORMED_RANDOM_VALUE + ";th:" + OTEL_THRESHOLD;
+    String outboundTracestate = continueTraceAndReinject(inboundTracestate);
+
+    assertTrue(outboundTracestate.contains("ot=th:" + OTEL_THRESHOLD));
+    assertTrue(!outboundTracestate.contains("rv:" + OTEL_MALFORMED_RANDOM_VALUE));
+  }
+
+  private String continueTraceAndReinject(String inboundTracestate) {
+    Map<String, String> inboundHeaders =
+        headers(TRACE_PARENT_KEY, TRACE_PARENT, TRACE_STATE_KEY, inboundTracestate);
+
+    CoreTracer tracer = tracerBuilder().build();
+    try {
+      HttpCodec.Extractor extractor =
+          W3CHttpCodec.newExtractor(Config.get(), tracer::captureTraceConfig);
+      Object extracted = extractor.extract(inboundHeaders, stringValuesMap());
+      assertInstanceOf(ExtractedContext.class, extracted);
+      ExtractedContext extractedContext = (ExtractedContext) extracted;
+
+      AgentSpan continuedSpan =
+          tracer.buildSpan("test", "continued").asChildOf(extractedContext).start();
+      assertEquals(extractedContext.getSamplingPriority(), continuedSpan.getSamplingPriority());
+
+      Map<String, String> outboundHeaders = new HashMap<>();
+      this.injector.inject((DDSpanContext) continuedSpan.spanContext(), outboundHeaders, Map::put);
+
+      continuedSpan.finish();
+      return outboundHeaders.get(TRACE_STATE_KEY);
+    } finally {
+      tracer.close();
+    }
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/W3COtelTraceStateContinuationTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/W3COtelTraceStateContinuationTest.java
@@ -1,13 +1,20 @@
 package datadog.trace.core.propagation;
 
+import static datadog.trace.api.ConfigDefaults.DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH;
+import static datadog.trace.api.TracePropagationStyle.DATADOG;
+import static datadog.trace.api.TracePropagationStyle.TRACECONTEXT;
 import static datadog.trace.bootstrap.instrumentation.api.ContextVisitors.stringValuesMap;
 import static datadog.trace.core.propagation.HttpCodecTestHelper.headers;
 import static datadog.trace.core.propagation.W3CHttpCodec.TRACE_PARENT_KEY;
 import static datadog.trace.core.propagation.W3CHttpCodec.TRACE_STATE_KEY;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import datadog.trace.api.Config;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -15,8 +22,11 @@ import datadog.trace.core.CoreTracer;
 import datadog.trace.core.DDCoreJavaSpecification;
 import datadog.trace.core.DDSpanContext;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Exercises the {@code ot=} tracestate member through the real {@link W3CHttpCodec} extractor and
@@ -27,6 +37,8 @@ class W3COtelTraceStateContinuationTest extends DDCoreJavaSpecification {
 
   private static final String TRACE_PARENT =
       "00-00000000000000000000000000000001-123456789abcdef0-01";
+  private static final String DATADOG_TRACE_ID = "1";
+  private static final String DATADOG_PARENT_ID = "2";
   private static final String OTEL_RANDOM_VALUE = "ef284ace7a91e1";
   private static final String OTEL_THRESHOLD = "e6666666666668";
   private static final String OTEL_MALFORMED_RANDOM_VALUE = "zz";
@@ -50,6 +62,56 @@ class W3COtelTraceStateContinuationTest extends DDCoreJavaSpecification {
 
     assertTrue(outboundTracestate.contains("ot=th:" + OTEL_THRESHOLD));
     assertTrue(!outboundTracestate.contains("rv:" + OTEL_MALFORMED_RANDOM_VALUE));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"0, 01, ef284ace7a91e1, 00", "2, 00, 00000000000000, 01"})
+  void alignsOtelStateWithSampledFlagAfterCompoundExtraction(
+      int datadogSamplingPriority,
+      String inboundTraceFlags,
+      String otelRandomValue,
+      String outboundTraceFlags) {
+    String inboundTracestate = DD_MEMBER + ",ot=rv:" + otelRandomValue + ";th:" + OTEL_THRESHOLD;
+    String traceParent = TRACE_PARENT.substring(0, TRACE_PARENT.length() - 2) + inboundTraceFlags;
+    Map<String, String> inboundHeaders =
+        headers(
+            DatadogHttpCodec.TRACE_ID_KEY,
+            DATADOG_TRACE_ID,
+            DatadogHttpCodec.SPAN_ID_KEY,
+            DATADOG_PARENT_ID,
+            DatadogHttpCodec.SAMPLING_PRIORITY_KEY,
+            String.valueOf(datadogSamplingPriority),
+            TRACE_PARENT_KEY,
+            traceParent,
+            TRACE_STATE_KEY,
+            inboundTracestate);
+    Config config = mock(Config.class);
+    when(config.getTracePropagationStylesToExtract())
+        .thenReturn(new LinkedHashSet<>(asList(DATADOG, TRACECONTEXT)));
+    when(config.getxDatadogTagsMaxLength()).thenReturn(DEFAULT_TRACE_X_DATADOG_TAGS_MAX_LENGTH);
+
+    CoreTracer tracer = tracerBuilder().build();
+    try {
+      HttpCodec.Extractor extractor = HttpCodec.createExtractor(config, tracer::captureTraceConfig);
+      ExtractedContext extractedContext =
+          assertInstanceOf(
+              ExtractedContext.class, extractor.extract(inboundHeaders, stringValuesMap()));
+      assertEquals(inboundTracestate, extractedContext.getPropagationTags().getW3CTracestate());
+
+      AgentSpan continuedSpan =
+          tracer.buildSpan("test", "continued").asChildOf(extractedContext).start();
+      Map<String, String> outboundHeaders = new HashMap<>();
+      injector.inject((DDSpanContext) continuedSpan.spanContext(), outboundHeaders, Map::put);
+      continuedSpan.finish();
+
+      assertTrue(outboundHeaders.get(TRACE_PARENT_KEY).endsWith("-" + outboundTraceFlags));
+      String outboundTracestate = outboundHeaders.get(TRACE_STATE_KEY);
+      assertTrue(outboundTracestate.startsWith("dd=s:" + datadogSamplingPriority));
+      assertTrue(outboundTracestate.contains("ot=rv:" + otelRandomValue));
+      assertFalse(outboundTracestate.contains("th:" + OTEL_THRESHOLD));
+    } finally {
+      tracer.close();
+    }
   }
 
   private String continueTraceAndReinject(String inboundTracestate) {

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/W3COtelTraceStateContinuationTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/W3COtelTraceStateContinuationTest.java
@@ -10,7 +10,6 @@ import static datadog.trace.core.propagation.W3CHttpCodec.TRACE_STATE_KEY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -65,12 +64,18 @@ class W3COtelTraceStateContinuationTest extends DDCoreJavaSpecification {
   }
 
   @ParameterizedTest
-  @CsvSource({"0, 01, ef284ace7a91e1, 00", "2, 00, 00000000000000, 01"})
+  @CsvSource({
+    "0, 01, ef284ace7a91e1, 00, false",
+    "2, 00, 00000000000000, 01, false",
+    "0, 00, 00000000000000, 00, true",
+    "2, 01, ef284ace7a91e1, 01, true"
+  })
   void alignsOtelStateWithSampledFlagAfterCompoundExtraction(
       int datadogSamplingPriority,
       String inboundTraceFlags,
       String otelRandomValue,
-      String outboundTraceFlags) {
+      String outboundTraceFlags,
+      boolean thresholdExpected) {
     String inboundTracestate = DD_MEMBER + ",ot=rv:" + otelRandomValue + ";th:" + OTEL_THRESHOLD;
     String traceParent = TRACE_PARENT.substring(0, TRACE_PARENT.length() - 2) + inboundTraceFlags;
     Map<String, String> inboundHeaders =
@@ -108,7 +113,7 @@ class W3COtelTraceStateContinuationTest extends DDCoreJavaSpecification {
       String outboundTracestate = outboundHeaders.get(TRACE_STATE_KEY);
       assertTrue(outboundTracestate.startsWith("dd=s:" + datadogSamplingPriority));
       assertTrue(outboundTracestate.contains("ot=rv:" + otelRandomValue));
-      assertFalse(outboundTracestate.contains("th:" + OTEL_THRESHOLD));
+      assertEquals(thresholdExpected, outboundTracestate.contains("th:" + OTEL_THRESHOLD));
     } finally {
       tracer.close();
     }

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateParsingTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateParsingTest.java
@@ -25,7 +25,7 @@ class OtelTraceStateParsingTest {
     assertNotNull(state);
     assertEquals(VALUE, state.getValue());
     assertEquals(VALUE.length(), state.length());
-    assertEquals(INHERITED_POSITION, state.getInheritedPosition());
-    assertEquals(ORIGINAL_MEMBER_CONTRIBUTION_SIZE, state.getOriginalMemberContributionSize());
+    assertEquals(INHERITED_POSITION, state.getOriginalPosition());
+    assertEquals(ORIGINAL_MEMBER_CONTRIBUTION_SIZE, state.getOriginalSize());
   }
 }

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateParsingTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateParsingTest.java
@@ -1,0 +1,31 @@
+package datadog.trace.core.propagation.ptags;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class OtelTraceStateParsingTest {
+  private static final String VALUE = "rv:0123456789abcd";
+  private static final int INHERITED_POSITION = 2;
+  private static final int ORIGINAL_MEMBER_CONTRIBUTION_SIZE = 21;
+
+  @Test
+  void ignoresAbsentValues() {
+    assertNull(OtelTraceState.parse(null, INHERITED_POSITION, ORIGINAL_MEMBER_CONTRIBUTION_SIZE));
+    assertNull(OtelTraceState.parse("", INHERITED_POSITION, ORIGINAL_MEMBER_CONTRIBUTION_SIZE));
+  }
+
+  @Test
+  void retainsValueAndMemberMetadata() {
+    OtelTraceState state =
+        OtelTraceState.parse(VALUE, INHERITED_POSITION, ORIGINAL_MEMBER_CONTRIBUTION_SIZE);
+
+    assertNotNull(state);
+    assertEquals(VALUE, state.getValue());
+    assertEquals(VALUE.length(), state.length());
+    assertEquals(INHERITED_POSITION, state.getInheritedPosition());
+    assertEquals(ORIGINAL_MEMBER_CONTRIBUTION_SIZE, state.getOriginalMemberContributionSize());
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateTest.java
@@ -3,7 +3,6 @@ package datadog.trace.core.propagation.ptags;
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.stream.Stream;
@@ -16,6 +15,7 @@ class OtelTraceStateTest {
 
   // A stable trace ID covers sampling decisions at representative rates.
   private static final long TRACE_ID = 1;
+  private static final long OTEL_SPEC_WORKED_EXAMPLE_TRACE_ID = 0xfff972474538efffL;
   private static final String LOCAL_RANDOM_VALUE = "f0948a54d43b8e";
   private static final double SAMPLE_RATE_0_01 = 0.01;
   private static final String THRESHOLD_0_01 = "fd70a3d70a3d7";
@@ -60,8 +60,19 @@ class OtelTraceStateTest {
   }
 
   @Test
-  void omitsStateAtRateZero() {
-    assertNull(OtelTraceState.updateProbability(null, TRACE_ID, 0, false, SAMPLER_DROP));
+  void matchesOtelSpecWorkedExample() {
+    OtelTraceState state =
+        OtelTraceState.updateProbability(
+            null, OTEL_SPEC_WORKED_EXAMPLE_TRACE_ID, SAMPLE_RATE_0_1, true, SAMPLER_KEEP);
+
+    assertEquals(traceState(INHERITED_RANDOM_VALUE, THRESHOLD_0_1), state.getValue());
+  }
+
+  @Test
+  void emitsMaxThresholdAtRateZero() {
+    OtelTraceState state = OtelTraceState.updateProbability(null, TRACE_ID, 0, false, SAMPLER_DROP);
+
+    assertEquals(traceState(LOCAL_RANDOM_VALUE, TINY_POSITIVE_THRESHOLD), state.getValue());
   }
 
   @Test
@@ -94,7 +105,7 @@ class OtelTraceStateTest {
   }
 
   @Test
-  void limiterRejectionRemovesLocallyGeneratedProbability() {
+  void limiterRejectionRetainsLocallyGeneratedRandomness() {
     OtelTraceState state =
         OtelTraceState.updateProbability(
             OtelTraceState.parse(UNKNOWN_FIELD, INHERITED_POSITION),
@@ -105,7 +116,7 @@ class OtelTraceStateTest {
 
     state = OtelTraceState.updateProbability(state, TRACE_ID, SAMPLE_RATE_0_5, true, SAMPLER_DROP);
 
-    assertEquals(UNKNOWN_FIELD, state.getValue());
+    assertEquals("rv:" + LOCAL_RANDOM_VALUE + ";" + UNKNOWN_FIELD, state.getValue());
     assertEquals(0, state.getInheritedPosition());
   }
 

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateTest.java
@@ -1,0 +1,94 @@
+package datadog.trace.core.propagation.ptags;
+
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
+import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import datadog.trace.common.sampling.DeterministicSampler;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class OtelTraceStateTest {
+
+  @ParameterizedTest
+  @MethodSource("goldenSamplingVectors")
+  void createsGoldenSamplingState(double sampleRate, boolean sampled, String expectedTraceState) {
+    OtelTraceState state =
+        OtelTraceState.updateProbability(
+            null, 1, sampleRate, sampled, sampled ? SAMPLER_KEEP : SAMPLER_DROP);
+
+    assertEquals(expectedTraceState, state.getValue());
+  }
+
+  static Stream<Arguments> goldenSamplingVectors() {
+    return Stream.of(
+        arguments(0.01, false, "rv:f0948a54d43b8e;th:fd70a3d70a3d7"),
+        arguments(0.1, true, "rv:f0948a54d43b8e;th:e6666666666668"),
+        arguments(0.2, true, "rv:f0948a54d43b8e;th:ccccccccccccd"),
+        arguments(0.5, true, "rv:f0948a54d43b8e;th:8"),
+        arguments(0.99, true, "rv:f0948a54d43b8e;th:028f5c28f5c29"));
+  }
+
+  @Test
+  void omitsStateAtRateZero() {
+    assertNull(OtelTraceState.updateProbability(null, 1, 0, false, SAMPLER_DROP));
+  }
+
+  @Test
+  void clampsTinyPositiveRateThreshold() {
+    OtelTraceState state =
+        OtelTraceState.updateProbability(null, 1, Double.MIN_VALUE, false, SAMPLER_DROP);
+
+    assertEquals("rv:f0948a54d43b8e;th:ffffffffffffff", state.getValue());
+  }
+
+  @Test
+  void correctsKeepAtPrecisionBoundary() {
+    OtelTraceState state =
+        OtelTraceState.updateProbability(null, 0x03A93EE8B1999F00L, 0.1, true, SAMPLER_KEEP);
+
+    assertEquals("rv:e6666666666668;th:e6666666666668", state.getValue());
+  }
+
+  @Test
+  void correctsDropAtPrecisionBoundary() {
+    OtelTraceState state =
+        OtelTraceState.updateProbability(null, 5401449561355763072L, 0.05, false, SAMPLER_DROP);
+
+    assertEquals("rv:f333333333332f;th:f333333333333", state.getValue());
+  }
+
+  @Test
+  void limiterRejectionRemovesLocallyGeneratedProbability() {
+    OtelTraceState state =
+        OtelTraceState.updateProbability(
+            OtelTraceState.parse("foo:bar", 2), 1, 0.5, true, SAMPLER_KEEP);
+
+    state = OtelTraceState.updateProbability(state, 1, 0.5, true, SAMPLER_DROP);
+
+    assertEquals("foo:bar", state.getValue());
+    assertEquals(0, state.getInheritedPosition());
+  }
+
+  @Test
+  void nonProbabilityDecisionRetainsOnlyInheritedRandomnessAndUnknownFields() {
+    OtelTraceState state = OtelTraceState.parse("th:e6666666666668;foo:bar;rv:ef284ace7a91e1", 2);
+
+    state = state.removeForNonProbabilityDecision();
+
+    assertEquals("rv:ef284ace7a91e1;foo:bar", state.getValue());
+    assertEquals(0, state.getInheritedPosition());
+  }
+
+  @Test
+  void deterministicSamplerRetainsDoublePrecisionRate() {
+    double rate = 0.123456789012345;
+
+    assertEquals(rate, new DeterministicSampler.TraceSampler(rate).getSampleRate());
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import datadog.trace.common.sampling.DeterministicSampler;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -15,91 +14,128 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class OtelTraceStateTest {
 
+  // A stable trace ID covers sampling decisions at representative rates.
+  private static final long TRACE_ID = 1;
+  private static final String LOCAL_RANDOM_VALUE = "f0948a54d43b8e";
+  private static final double SAMPLE_RATE_0_01 = 0.01;
+  private static final String THRESHOLD_0_01 = "fd70a3d70a3d7";
+  private static final double SAMPLE_RATE_0_1 = 0.1;
+  private static final String THRESHOLD_0_1 = "e6666666666668";
+  private static final double SAMPLE_RATE_0_2 = 0.2;
+  private static final String THRESHOLD_0_2 = "ccccccccccccd";
+  private static final double SAMPLE_RATE_0_5 = 0.5;
+  private static final String THRESHOLD_0_5 = "8";
+  private static final double SAMPLE_RATE_0_99 = 0.99;
+  private static final String THRESHOLD_0_99 = "028f5c28f5c29";
+  private static final double SAMPLE_RATE_0_05 = 0.05;
+
+  // These IDs straddle thresholds that would otherwise lose precision when rounded.
+  private static final long KEEP_PRECISION_BOUNDARY_TRACE_ID = 0x03A93EE8B1999F00L;
+  private static final String KEEP_PRECISION_BOUNDARY_VALUE = "e6666666666668";
+  private static final long DROP_PRECISION_BOUNDARY_TRACE_ID = 5401449561355763072L;
+  private static final String DROP_PRECISION_BOUNDARY_RANDOM_VALUE = "f333333333332f";
+  private static final String DROP_PRECISION_BOUNDARY_THRESHOLD = "f333333333333";
+  private static final String INHERITED_RANDOM_VALUE = "ef284ace7a91e1";
+  private static final String UNKNOWN_FIELD = "foo:bar";
+  private static final int INHERITED_POSITION = 2;
+  private static final String TINY_POSITIVE_THRESHOLD = "ffffffffffffff";
+
   @ParameterizedTest
   @MethodSource("goldenSamplingVectors")
   void createsGoldenSamplingState(double sampleRate, boolean sampled, String expectedTraceState) {
     OtelTraceState state =
         OtelTraceState.updateProbability(
-            null, 1, sampleRate, sampled, sampled ? SAMPLER_KEEP : SAMPLER_DROP);
+            null, TRACE_ID, sampleRate, sampled, sampled ? SAMPLER_KEEP : SAMPLER_DROP);
 
     assertEquals(expectedTraceState, state.getValue());
   }
 
   static Stream<Arguments> goldenSamplingVectors() {
     return Stream.of(
-        arguments(0.01, false, "rv:f0948a54d43b8e;th:fd70a3d70a3d7"),
-        arguments(0.1, true, "rv:f0948a54d43b8e;th:e6666666666668"),
-        arguments(0.2, true, "rv:f0948a54d43b8e;th:ccccccccccccd"),
-        arguments(0.5, true, "rv:f0948a54d43b8e;th:8"),
-        arguments(0.99, true, "rv:f0948a54d43b8e;th:028f5c28f5c29"));
+        arguments(SAMPLE_RATE_0_01, false, traceState(LOCAL_RANDOM_VALUE, THRESHOLD_0_01)),
+        arguments(SAMPLE_RATE_0_1, true, traceState(LOCAL_RANDOM_VALUE, THRESHOLD_0_1)),
+        arguments(SAMPLE_RATE_0_2, true, traceState(LOCAL_RANDOM_VALUE, THRESHOLD_0_2)),
+        arguments(SAMPLE_RATE_0_5, true, traceState(LOCAL_RANDOM_VALUE, THRESHOLD_0_5)),
+        arguments(SAMPLE_RATE_0_99, true, traceState(LOCAL_RANDOM_VALUE, THRESHOLD_0_99)));
   }
 
   @Test
   void omitsStateAtRateZero() {
-    assertNull(OtelTraceState.updateProbability(null, 1, 0, false, SAMPLER_DROP));
+    assertNull(OtelTraceState.updateProbability(null, TRACE_ID, 0, false, SAMPLER_DROP));
   }
 
   @Test
   void clampsTinyPositiveRateThreshold() {
     OtelTraceState state =
-        OtelTraceState.updateProbability(null, 1, Double.MIN_VALUE, false, SAMPLER_DROP);
+        OtelTraceState.updateProbability(null, TRACE_ID, Double.MIN_VALUE, false, SAMPLER_DROP);
 
-    assertEquals("rv:f0948a54d43b8e;th:ffffffffffffff", state.getValue());
+    assertEquals(traceState(LOCAL_RANDOM_VALUE, TINY_POSITIVE_THRESHOLD), state.getValue());
   }
 
   @Test
   void correctsKeepAtPrecisionBoundary() {
     OtelTraceState state =
-        OtelTraceState.updateProbability(null, 0x03A93EE8B1999F00L, 0.1, true, SAMPLER_KEEP);
+        OtelTraceState.updateProbability(
+            null, KEEP_PRECISION_BOUNDARY_TRACE_ID, SAMPLE_RATE_0_1, true, SAMPLER_KEEP);
 
-    assertEquals("rv:e6666666666668;th:e6666666666668", state.getValue());
+    assertEquals(
+        traceState(KEEP_PRECISION_BOUNDARY_VALUE, KEEP_PRECISION_BOUNDARY_VALUE), state.getValue());
   }
 
   @Test
   void correctsDropAtPrecisionBoundary() {
     OtelTraceState state =
-        OtelTraceState.updateProbability(null, 5401449561355763072L, 0.05, false, SAMPLER_DROP);
+        OtelTraceState.updateProbability(
+            null, DROP_PRECISION_BOUNDARY_TRACE_ID, SAMPLE_RATE_0_05, false, SAMPLER_DROP);
 
-    assertEquals("rv:f333333333332f;th:f333333333333", state.getValue());
+    assertEquals(
+        traceState(DROP_PRECISION_BOUNDARY_RANDOM_VALUE, DROP_PRECISION_BOUNDARY_THRESHOLD),
+        state.getValue());
   }
 
   @Test
   void limiterRejectionRemovesLocallyGeneratedProbability() {
     OtelTraceState state =
         OtelTraceState.updateProbability(
-            OtelTraceState.parse("foo:bar", 2), 1, 0.5, true, SAMPLER_KEEP);
+            OtelTraceState.parse(UNKNOWN_FIELD, INHERITED_POSITION),
+            TRACE_ID,
+            SAMPLE_RATE_0_5,
+            true,
+            SAMPLER_KEEP);
 
-    state = OtelTraceState.updateProbability(state, 1, 0.5, true, SAMPLER_DROP);
+    state = OtelTraceState.updateProbability(state, TRACE_ID, SAMPLE_RATE_0_5, true, SAMPLER_DROP);
 
-    assertEquals("foo:bar", state.getValue());
+    assertEquals(UNKNOWN_FIELD, state.getValue());
     assertEquals(0, state.getInheritedPosition());
   }
 
   @Test
   void limiterRejectionRetainsInheritedRandomness() {
     OtelTraceState state =
-        OtelTraceState.parse("rv:ef284ace7a91e1;th:8;foo:bar", 2);
+        OtelTraceState.parse(
+            traceState(INHERITED_RANDOM_VALUE, THRESHOLD_0_5) + ";" + UNKNOWN_FIELD,
+            INHERITED_POSITION);
 
-    state = OtelTraceState.updateProbability(state, 1, 0.5, true, SAMPLER_DROP);
+    state = OtelTraceState.updateProbability(state, TRACE_ID, SAMPLE_RATE_0_5, true, SAMPLER_DROP);
 
-    assertEquals("rv:ef284ace7a91e1;foo:bar", state.getValue());
+    assertEquals("rv:" + INHERITED_RANDOM_VALUE + ";" + UNKNOWN_FIELD, state.getValue());
     assertEquals(0, state.getInheritedPosition());
   }
 
   @Test
   void nonProbabilityDecisionRetainsOnlyInheritedRandomnessAndUnknownFields() {
-    OtelTraceState state = OtelTraceState.parse("th:e6666666666668;foo:bar;rv:ef284ace7a91e1", 2);
+    OtelTraceState state =
+        OtelTraceState.parse(
+            "th:" + THRESHOLD_0_1 + ";" + UNKNOWN_FIELD + ";rv:" + INHERITED_RANDOM_VALUE,
+            INHERITED_POSITION);
 
     state = state.removeForNonProbabilityDecision();
 
-    assertEquals("rv:ef284ace7a91e1;foo:bar", state.getValue());
+    assertEquals("rv:" + INHERITED_RANDOM_VALUE + ";" + UNKNOWN_FIELD, state.getValue());
     assertEquals(0, state.getInheritedPosition());
   }
 
-  @Test
-  void deterministicSamplerRetainsDoublePrecisionRate() {
-    double rate = 0.123456789012345;
-
-    assertEquals(rate, new DeterministicSampler.TraceSampler(rate).getSampleRate());
+  private static String traceState(String randomValue, String threshold) {
+    return "rv:" + randomValue + ";th:" + threshold;
   }
 }

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateTest.java
@@ -76,6 +76,17 @@ class OtelTraceStateTest {
   }
 
   @Test
+  void limiterRejectionRetainsInheritedRandomness() {
+    OtelTraceState state =
+        OtelTraceState.parse("rv:ef284ace7a91e1;th:8;foo:bar", 2);
+
+    state = OtelTraceState.updateProbability(state, 1, 0.5, true, SAMPLER_DROP);
+
+    assertEquals("rv:ef284ace7a91e1;foo:bar", state.getValue());
+    assertEquals(0, state.getInheritedPosition());
+  }
+
+  @Test
   void nonProbabilityDecisionRetainsOnlyInheritedRandomnessAndUnknownFields() {
     OtelTraceState state = OtelTraceState.parse("th:e6666666666668;foo:bar;rv:ef284ace7a91e1", 2);
 

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateTest.java
@@ -124,7 +124,7 @@ class OtelTraceStateTest {
     state = OtelTraceState.updateProbability(state, TRACE_ID, SAMPLE_RATE_0_5, true, SAMPLER_DROP);
 
     assertEquals("rv:" + LOCAL_RANDOM_VALUE + ";" + UNKNOWN_FIELD, state.getValue());
-    assertEquals(0, state.getInheritedPosition());
+    assertEquals(0, state.getOriginalPosition());
   }
 
   @Test
@@ -144,7 +144,7 @@ class OtelTraceStateTest {
     state = OtelTraceState.updateProbability(state, TRACE_ID, SAMPLE_RATE_0_5, true, SAMPLER_DROP);
 
     assertEquals("rv:" + INHERITED_RANDOM_VALUE + ";" + UNKNOWN_FIELD, state.getValue());
-    assertEquals(0, state.getInheritedPosition());
+    assertEquals(0, state.getOriginalPosition());
   }
 
   @Test
@@ -158,7 +158,7 @@ class OtelTraceStateTest {
     state = state.removeForNonProbabilityDecision();
 
     assertEquals("rv:" + INHERITED_RANDOM_VALUE + ";" + UNKNOWN_FIELD, state.getValue());
-    assertEquals(0, state.getInheritedPosition());
+    assertEquals(0, state.getOriginalPosition());
   }
 
   private static String traceState(String randomValue, String threshold) {

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateTest.java
@@ -38,7 +38,12 @@ class OtelTraceStateTest {
   private static final String INHERITED_RANDOM_VALUE = "ef284ace7a91e1";
   private static final String UNKNOWN_FIELD = "foo:bar";
   private static final int INHERITED_POSITION = 2;
+  private static final int OTEL_MEMBER_OVERHEAD = 4;
   private static final String TINY_POSITIVE_THRESHOLD = "ffffffffffffff";
+  private static final String INHERITED_TRACE_STATE =
+      traceState(INHERITED_RANDOM_VALUE, THRESHOLD_0_5) + ";" + UNKNOWN_FIELD;
+  private static final String INHERITED_TRACE_STATE_WITH_RANDOMNESS_LAST =
+      "th:" + THRESHOLD_0_1 + ";" + UNKNOWN_FIELD + ";rv:" + INHERITED_RANDOM_VALUE;
 
   @ParameterizedTest
   @MethodSource("goldenSamplingVectors")
@@ -108,7 +113,8 @@ class OtelTraceStateTest {
   void limiterRejectionRetainsLocallyGeneratedRandomness() {
     OtelTraceState state =
         OtelTraceState.updateProbability(
-            OtelTraceState.parse(UNKNOWN_FIELD, INHERITED_POSITION),
+            OtelTraceState.parse(
+                UNKNOWN_FIELD, INHERITED_POSITION, UNKNOWN_FIELD.length() + OTEL_MEMBER_OVERHEAD),
             TRACE_ID,
             SAMPLE_RATE_0_5,
             true,
@@ -124,8 +130,9 @@ class OtelTraceStateTest {
   void limiterRejectionRetainsInheritedRandomness() {
     OtelTraceState state =
         OtelTraceState.parse(
-            traceState(INHERITED_RANDOM_VALUE, THRESHOLD_0_5) + ";" + UNKNOWN_FIELD,
-            INHERITED_POSITION);
+            INHERITED_TRACE_STATE,
+            INHERITED_POSITION,
+            INHERITED_TRACE_STATE.length() + OTEL_MEMBER_OVERHEAD);
 
     state = OtelTraceState.updateProbability(state, TRACE_ID, SAMPLE_RATE_0_5, true, SAMPLER_DROP);
 
@@ -137,8 +144,9 @@ class OtelTraceStateTest {
   void nonProbabilityDecisionRetainsOnlyInheritedRandomnessAndUnknownFields() {
     OtelTraceState state =
         OtelTraceState.parse(
-            "th:" + THRESHOLD_0_1 + ";" + UNKNOWN_FIELD + ";rv:" + INHERITED_RANDOM_VALUE,
-            INHERITED_POSITION);
+            INHERITED_TRACE_STATE_WITH_RANDOMNESS_LAST,
+            INHERITED_POSITION,
+            INHERITED_TRACE_STATE_WITH_RANDOMNESS_LAST.length() + OTEL_MEMBER_OVERHEAD);
 
     state = state.removeForNonProbabilityDecision();
 

--- a/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/propagation/ptags/OtelTraceStateTest.java
@@ -3,6 +3,7 @@ package datadog.trace.core.propagation.ptags;
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_DROP;
 import static datadog.trace.api.sampling.PrioritySampling.SAMPLER_KEEP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.util.stream.Stream;
@@ -124,6 +125,12 @@ class OtelTraceStateTest {
 
     assertEquals("rv:" + LOCAL_RANDOM_VALUE + ";" + UNKNOWN_FIELD, state.getValue());
     assertEquals(0, state.getInheritedPosition());
+  }
+
+  @Test
+  void limiterRejectionWithoutTraceStateDoesNotGenerateRandomness() {
+    assertNull(
+        OtelTraceState.updateProbability(null, TRACE_ID, SAMPLE_RATE_0_5, true, SAMPLER_DROP));
   }
 
   @Test

--- a/dd-trace-core/src/traceAgentTest/java/TraceGenerator.java
+++ b/dd-trace-core/src/traceAgentTest/java/TraceGenerator.java
@@ -359,17 +359,11 @@ class TraceGenerator {
 
     @Override
     public PojoSpan setSamplingPriority(
-        int samplingPriority, CharSequence rate, double sampleRate, int samplingMechanism) {
-      return this;
-    }
-
-    @Override
-    public PojoSpan setSamplingPriority(
         int samplingPriority,
         CharSequence rate,
         double sampleRate,
         int samplingMechanism,
-        boolean sampled) {
+        Boolean probabilitySamplingResult) {
       return this;
     }
 

--- a/dd-trace-core/src/traceAgentTest/java/TraceGenerator.java
+++ b/dd-trace-core/src/traceAgentTest/java/TraceGenerator.java
@@ -364,6 +364,16 @@ class TraceGenerator {
     }
 
     @Override
+    public PojoSpan setSamplingPriority(
+        int samplingPriority,
+        CharSequence rate,
+        double sampleRate,
+        int samplingMechanism,
+        boolean sampled) {
+      return this;
+    }
+
+    @Override
     public PojoSpan setSpanSamplingPriority(double rate, int limit) {
       return this;
     }


### PR DESCRIPTION
# What Does This Do

Exports the full existing W3C tracestate through OTLP. When no full W3C tracestate exists, the JSON and protobuf exporters reuse a cached `ot=` member for every local span in the trace chunk.

# Motivation

Preserves the existing OTLP tracestate contract while exporting locally generated OpenTelemetry sampling state without per-span `ot=` allocation.

# Additional Notes

Validated with focused OTLP JSON/protobuf tests and `:dd-trace-core:spotlessCheck`.

# Contributor Checklist

- [x] Title and labels follow repository conventions
- [x] Tests and formatting checks pass

Jira ticket: [APMAPI-2172]

[APMAPI-2172]: https://datadoghq.atlassian.net/browse/APMAPI-2172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ