### PR TITLE
Route OpenLineage over the Agent's Unix Domain Socket URL

### DIFF
--- a/dd-java-agent/instrumentation/spark/spark-common/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
+++ b/dd-java-agent/instrumentation/spark/spark-common/src/main/java/datadog/trace/instrumentation/spark/AbstractDatadogSparkListener.java
@@ -1564,6 +1564,15 @@ public abstract class AbstractDatadogSparkListener extends SparkListener {
   }
 
   private static String getAgentHttpUrl() {
+    // When the Agent is reachable over a Unix Domain Socket, its URL uses the unix:// scheme.
+    // Pass it through so the OpenLineage HTTP transport sends lineage over the socket (requires
+    // OpenLineage 1.54+). Any other configuration keeps the original http://host:port behavior,
+    // so existing http(s) setups are unaffected.
+    String agentUrl = Config.get().getAgentUrl();
+    if (agentUrl != null && agentUrl.startsWith("unix:")) {
+      return agentUrl;
+    }
+
     StringBuilder sb =
         new StringBuilder("http://")
             .append(Config.get().getAgentHost())


### PR DESCRIPTION
# What Does This Do

Adds a socket-only code path to `AbstractDatadogSparkListener.getAgentHttpUrl()`: when the resolved Agent URL uses the `unix://` scheme, it is passed through unchanged so the OpenLineage HTTP transport sends lineage over the Unix Domain Socket. Every other configuration keeps the existing `http://host:port` behavior, so `http(s)` setups are unaffected.

```java
String agentUrl = Config.get().getAgentUrl();
if (agentUrl != null && agentUrl.startsWith("unix:")) {
  return agentUrl;
}
// ...unchanged http://host:port fallback
```

# Motivation

The Spark DJM integration derives the OpenLineage transport URL from the Agent host/port (`http://host:port`). In deployments where the Agent is reachable **only** over a Unix Domain Socket — e.g. Spark on Kubernetes / EMR-on-EKS, where the node Agent exposes `unix:///var/run/datadog/apm.socket` — that TCP URL is unreachable, so OpenLineage delivery fails with connection-refused while APM traces (which already use the socket) succeed. This routes OpenLineage over the same socket.

# Additional Notes

- Requires **OpenLineage 1.54+**, which adds `unix://` support to its Java HTTP transport — see OpenLineage/OpenLineage#4920 (https://github.com/OpenLineage/OpenLineage/pull/4920).
- The change is intentionally minimal and gated on the `unix:` scheme so no existing (TCP) code path changes behavior.

Jira ticket: [SDO-169]


[SDO-169]: https://datadoghq.atlassian.net/browse/SDO-169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ