### PR TITLE
Disable Exception Replay for JDK < 11

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DefaultDebuggerConfigUpdater.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/agent/DefaultDebuggerConfigUpdater.java
@@ -2,6 +2,7 @@ package com.datadog.debugger.agent;
 
 import static datadog.trace.api.Config.isExplicitlyDisabled;
 
+import datadog.environment.JavaVirtualMachine;
 import datadog.trace.api.Config;
 import datadog.trace.api.config.DebuggerConfig;
 import datadog.trace.api.config.TraceInstrumentationConfig;
@@ -29,12 +30,17 @@ class DefaultDebuggerConfigUpdater implements DebuggerConfigUpdater {
         update.getDynamicInstrumentationEnabled(),
         DebuggerAgent::startDynamicInstrumentation,
         DebuggerAgent::stopDynamicInstrumentation);
-    startOrStopFeature(
-        config,
-        DebuggerConfig.EXCEPTION_REPLAY_ENABLED,
-        update.getExceptionReplayEnabled(),
-        DebuggerAgent::startExceptionReplay,
-        DebuggerAgent::stopExceptionReplay);
+    if (JavaVirtualMachine.isJavaVersionAtLeast(11)) {
+      // Cannot remotely enable Exception Replay for JDK < 11 (JVM 8 bug)
+      startOrStopFeature(
+          config,
+          DebuggerConfig.EXCEPTION_REPLAY_ENABLED,
+          update.getExceptionReplayEnabled(),
+          DebuggerAgent::startExceptionReplay,
+          DebuggerAgent::stopExceptionReplay);
+    } else {
+      LOGGER.debug("Cannot start Exception Replay on JDK version < 11");
+    }
     startOrStopFeature(
         config,
         TraceInstrumentationConfig.CODE_ORIGIN_FOR_SPANS_ENABLED,

--- a/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DefaultDebuggerConfigUpdaterTest.java
+++ b/dd-java-agent/agent-debugger/src/test/java/com/datadog/debugger/agent/DefaultDebuggerConfigUpdaterTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import datadog.communication.ddagent.DDAgentFeaturesDiscovery;
 import datadog.communication.ddagent.SharedCommunicationObjects;
+import datadog.environment.JavaVirtualMachine;
 import datadog.remoteconfig.ConfigurationPoller;
 import datadog.trace.api.Config;
 import datadog.trace.api.debugger.DebuggerConfigUpdate;
@@ -27,12 +28,20 @@ class DefaultDebuggerConfigUpdaterTest {
     productConfigUpdater.updateConfig(new DebuggerConfigUpdate());
     productConfigUpdater.updateConfig(new DebuggerConfigUpdate(true, true, true, true));
     assertTrue(productConfigUpdater.isDynamicInstrumentationEnabled());
-    assertTrue(productConfigUpdater.isExceptionReplayEnabled());
+    if (JavaVirtualMachine.isJavaVersionAtLeast(11)) {
+      assertTrue(productConfigUpdater.isExceptionReplayEnabled());
+    } else {
+      assertFalse(productConfigUpdater.isExceptionReplayEnabled());
+    }
     assertTrue(productConfigUpdater.isCodeOriginEnabled());
     assertTrue(productConfigUpdater.isDistributedDebuggerEnabled());
     productConfigUpdater.updateConfig(new DebuggerConfigUpdate());
     assertTrue(productConfigUpdater.isDynamicInstrumentationEnabled());
-    assertTrue(productConfigUpdater.isExceptionReplayEnabled());
+    if (JavaVirtualMachine.isJavaVersionAtLeast(11)) {
+      assertTrue(productConfigUpdater.isExceptionReplayEnabled());
+    } else {
+      assertFalse(productConfigUpdater.isExceptionReplayEnabled());
+    }
     assertTrue(productConfigUpdater.isCodeOriginEnabled());
     assertTrue(productConfigUpdater.isDistributedDebuggerEnabled());
     productConfigUpdater.updateConfig(new DebuggerConfigUpdate(false, false, false, false));

--- a/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
+++ b/dd-smoke-tests/debugger-integration-tests/src/test/java/datadog/smoketest/InProductEnablementIntegrationTest.java
@@ -11,6 +11,8 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 @NonRetryable
 public class InProductEnablementIntegrationTest extends ServerAppDebuggerIntegrationTest {
@@ -81,6 +83,7 @@ public class InProductEnablementIntegrationTest extends ServerAppDebuggerIntegra
 
   @Test
   @DisplayName("testExceptionReplayEnablement")
+  @EnabledForJreRange(min = JRE.JAVA_11)
   void testExceptionReplayEnablement() throws Exception {
     additionalJvmArgs.add("-Ddd.third.party.excludes=datadog.smoketest");
     appUrl = startAppAndAndGetUrl();
@@ -100,6 +103,7 @@ public class InProductEnablementIntegrationTest extends ServerAppDebuggerIntegra
   @Flaky
   @Test
   @DisplayName("testExceptionReplayEnablementFailure")
+  @EnabledForJreRange(min = JRE.JAVA_11)
   void testExceptionReplayEnablementFailure() throws Exception {
     additionalJvmArgs.add("-Ddd.exception.replay.enabled=true");
     additionalJvmArgs.add("-Ddd.third.party.excludes=datadog.smoketest");

--- a/dd-smoke-tests/junit-console/src/test/java/datadog/smoketest/JUnitConsoleSmokeTest.java
+++ b/dd-smoke-tests/junit-console/src/test/java/datadog/smoketest/JUnitConsoleSmokeTest.java
@@ -30,6 +30,8 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,6 +61,8 @@ class JUnitConsoleSmokeTest extends CiVisibilitySmokeTest {
   }
 
   @Test
+  // Exception Replay is disabled by default on JDK8 due to JVM bug
+  @EnabledForJreRange(min = JRE.JAVA_11)
   void testHeadlessFailedTestReplay() throws Exception {
     String projectName = "test_junit_console_failed_test_replay";
     givenProjectFiles(projectName);

--- a/dd-smoke-tests/maven/src/test/java/datadog/smoketest/MavenSmokeTest.java
+++ b/dd-smoke-tests/maven/src/test/java/datadog/smoketest/MavenSmokeTest.java
@@ -41,6 +41,8 @@ import org.apache.maven.wrapper.MavenWrapperMain;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.slf4j.Logger;
@@ -312,6 +314,8 @@ class MavenSmokeTest extends CiVisibilitySmokeTest {
     "failed-test-replay | test_failed_maven_failed_test_replay | 3.9.9       "
   })
   @ParameterizedTest
+  // Exception Replay is disabled by default on JDK8 due to JVM bug
+  @EnabledForJreRange(min = JRE.JAVA_11)
   void testFailedTestReplay(String projectName, String mavenVersion) throws Exception {
     givenWrapperPropertiesFile(mavenVersion);
     givenMavenProjectFiles(projectName);


### PR DESCRIPTION
# What Does This Do
Due to elusive JVM bug in JDK 8 we are preventing to enable remotely Exception Replay to avoid having crashes or NegativeArraySizeException

# Motivation

# Additional Notes
see also https://github.com/DataDog/dd-trace-java/issues/10017

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [DEBUG-6166]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-6166]: https://datadoghq.atlassian.net/browse/DEBUG-6166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ