### PR TITLE
Use Palantir Java Format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,13 +51,13 @@ docs/                     Developer documentation (see below)
 ./gradlew :dd-java-agent:shadowJar        # Build agent jar only (dd-java-agent/build/libs/)
 ./gradlew :path:to:module:test            # Run tests for a specific module
 ./gradlew :path:to:module:test -PtestJvm=11  # Test on a specific JVM version
-./gradlew spotlessApply                   # Auto-format code (Palantir Java Format)
+./gradlew spotlessApply                   # Auto-format code (Palantir Java Format, GOOGLE style)
 ./gradlew spotlessCheck                   # Verify formatting
 ```
 
 ## Code conventions
 
-- **Formatting**: Palantir Java Format enforced via Spotless. Run `./gradlew spotlessApply` before committing.
+- **Formatting**: Palantir Java Format with `GOOGLE` style enforced via Spotless. Run `./gradlew spotlessApply` before committing.
 - **Static imports**: Prefer static imports over class-qualified calls for call-style helpers, in both test (Assertions.assertEquals, Mockito.mock) and production code (Collections.emptyList). Wildcard imports disallowed — see CONTRIBUTING.md.
 - **Documentation**: Use concise Javadoc comments (`/** ... */`) for class, method, and field documentation.
 - **Instrumentation layout**: `dd-java-agent/instrumentation/{framework}/{framework}-{minVersion}/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,13 +51,13 @@ docs/                     Developer documentation (see below)
 ./gradlew :dd-java-agent:shadowJar        # Build agent jar only (dd-java-agent/build/libs/)
 ./gradlew :path:to:module:test            # Run tests for a specific module
 ./gradlew :path:to:module:test -PtestJvm=11  # Test on a specific JVM version
-./gradlew spotlessApply                   # Auto-format code (google-java-format)
+./gradlew spotlessApply                   # Auto-format code (Palantir Java Format)
 ./gradlew spotlessCheck                   # Verify formatting
 ```
 
 ## Code conventions
 
-- **Formatting**: google-java-format enforced via Spotless. Run `./gradlew spotlessApply` before committing.
+- **Formatting**: Palantir Java Format enforced via Spotless. Run `./gradlew spotlessApply` before committing.
 - **Static imports**: Prefer static imports over class-qualified calls for call-style helpers, in both test (Assertions.assertEquals, Mockito.mock) and production code (Collections.emptyList). Wildcard imports disallowed — see CONTRIBUTING.md.
 - **Documentation**: Use concise Javadoc comments (`/** ... */`) for class, method, and field documentation.
 - **Instrumentation layout**: `dd-java-agent/instrumentation/{framework}/{framework}-{minVersion}/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,9 @@ We have automatic code formatting enabled in Gradle configuration using [Spotles
 Our main goal is to avoid extensive reformatting caused by different IDEs with different opinions about how things should
 be formatted by establishing a single _point of truth_.
 
+Java sources use [Palantir Java Format](https://github.com/palantir/palantir-java-format) with its default `PALANTIR`
+style: four-space indentation and a 120-character line width.
+
 To reformat all the files that need reformatting:
 
 ```bash
@@ -55,13 +58,14 @@ For IntelliJ IDEA, we suggest the following settings and plugin.
     * `Use single class import`: checked
     * `Class count to use import with '*'`: `9999` (some number sufficiently large that is unlikely to matter)
     * `Names count to use static import with '*'`: `9999`
-    * Use the following import layout to ensure consistency with google-java-format:
+    * Use the following import layout:
       ![import layout](https://user-images.githubusercontent.com/734411/43430811-28442636-94ae-11e8-86f1-f270ddcba023.png)
   * top right Settings icon -> `Settings...` ->`Editor` > `Code Style` > `Groovy` > `Imports`
     * `Class count to use import with '*'`: `9999` (some number sufficiently large that is unlikely to matter)
     * `Names count to use static import with '*'`: `9999`
 * To run test in a specific JDK use the `testJvm` property, e.g. `-PtestJvm=11`
-* Install the [Google Java Format](https://plugins.jetbrains.com/plugin/8527-google-java-format) plugin
+* Install the [Palantir Java Format](https://plugins.jetbrains.com/plugin/13180-palantir-java-format) plugin
+  * In IntelliJ IDEA settings, search for `palantir-java-format` and enable it for the current project
 
 ### Static imports
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,8 @@ We have automatic code formatting enabled in Gradle configuration using [Spotles
 Our main goal is to avoid extensive reformatting caused by different IDEs with different opinions about how things should
 be formatted by establishing a single _point of truth_.
 
-Java sources use [Palantir Java Format](https://github.com/palantir/palantir-java-format) with its default `PALANTIR`
-style: four-space indentation and a 120-character line width.
+Java sources use [Palantir Java Format](https://github.com/palantir/palantir-java-format) with its `GOOGLE` style:
+two-space indentation and a 100-character line width.
 
 To reformat all the files that need reformatting:
 
@@ -64,8 +64,9 @@ For IntelliJ IDEA, we suggest the following settings and plugin.
     * `Class count to use import with '*'`: `9999` (some number sufficiently large that is unlikely to matter)
     * `Names count to use static import with '*'`: `9999`
 * To run test in a specific JDK use the `testJvm` property, e.g. `-PtestJvm=11`
-* Install the [Palantir Java Format](https://plugins.jetbrains.com/plugin/13180-palantir-java-format) plugin
-  * In IntelliJ IDEA settings, search for `palantir-java-format` and enable it for the current project
+* Format Java sources with the Spotless Gradle tasks above. Do not enable the
+  [Palantir Java Format](https://plugins.jetbrains.com/plugin/13180-palantir-java-format) plugin for this project: it
+  currently exposes only the default `PALANTIR` style, while this project uses `GOOGLE`.
 
 ### Static imports
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ with(extensions["spotlessPredeclare"] as SpotlessExtension) {
     removeUnusedImports()
     forbidWildcardImports()
 
-    palantirJavaFormat(libs.versions.palantir.java.format.get())
+    palantirJavaFormat(libs.versions.palantir.java.format.get()).style("GOOGLE")
     tableTestFormatter(libs.versions.tabletest.formatter.get())
   }
   groovyGradle {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,7 @@ with(extensions["spotlessPredeclare"] as SpotlessExtension) {
     removeUnusedImports()
     forbidWildcardImports()
 
-    googleJavaFormat(libs.versions.google.java.format.get())
+    palantirJavaFormat(libs.versions.palantir.java.format.get())
     tableTestFormatter(libs.versions.tabletest.formatter.get())
   }
   groovyGradle {

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -22,7 +22,7 @@ spotless {
     targetExclude("src/test/resources/**")
     removeUnusedImports()
     forbidWildcardImports()
-    googleJavaFormat(libs.versions.google.java.format.get())
+    palantirJavaFormat(libs.versions.palantir.java.format.get())
   }
 }
 

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -22,7 +22,7 @@ spotless {
     targetExclude("src/test/resources/**")
     removeUnusedImports()
     forbidWildcardImports()
-    palantirJavaFormat(libs.versions.palantir.java.format.get())
+    palantirJavaFormat(libs.versions.palantir.java.format.get()).style("GOOGLE")
   }
 }
 

--- a/buildSrc/modifiable-config-agent/build.gradle.kts
+++ b/buildSrc/modifiable-config-agent/build.gradle.kts
@@ -18,7 +18,7 @@ spotless {
     targetExclude("src/test/resources/**")
     removeUnusedImports()
     forbidWildcardImports()
-    palantirJavaFormat(libs.versions.palantir.java.format.get())
+    palantirJavaFormat(libs.versions.palantir.java.format.get()).style("GOOGLE")
   }
 }
 

--- a/buildSrc/modifiable-config-agent/build.gradle.kts
+++ b/buildSrc/modifiable-config-agent/build.gradle.kts
@@ -18,7 +18,7 @@ spotless {
     targetExclude("src/test/resources/**")
     removeUnusedImports()
     forbidWildcardImports()
-    googleJavaFormat(libs.versions.google.java.format.get())
+    palantirJavaFormat(libs.versions.palantir.java.format.get())
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ shadow = "9.4.2"
 spotbugs_annotations = "4.10.3"
 
 # Source code formatters
-google-java-format = "1.36.1"
+palantir-java-format = "2.97.0"
 greclipse = "4.27" # Pinned. See: https://github.com/diffplug/spotless/issues/3013
 ktlint = "1.8.0"
 scalafmt = "3.11.5"

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -49,7 +49,7 @@ spotless {
       targetExclude('src/test/resources/**', buildDirectory)
       removeUnusedImports()
       forbidWildcardImports()
-      googleJavaFormat(libs.versions.google.java.format.get())
+      palantirJavaFormat(libs.versions.palantir.java.format.get())
       tableTestFormatter(libs.versions.tabletest.formatter.get())
     }
   }

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -49,7 +49,7 @@ spotless {
       targetExclude('src/test/resources/**', buildDirectory)
       removeUnusedImports()
       forbidWildcardImports()
-      palantirJavaFormat(libs.versions.palantir.java.format.get())
+      palantirJavaFormat(libs.versions.palantir.java.format.get()).style("GOOGLE")
       tableTestFormatter(libs.versions.tabletest.formatter.get())
     }
   }

--- a/test-published-dependencies/build.gradle.kts
+++ b/test-published-dependencies/build.gradle.kts
@@ -37,7 +37,7 @@ allprojects {
         target("src/**/*.java")
         removeUnusedImports()
         forbidWildcardImports()
-        googleJavaFormat(libs.versions.google.java.format.get())
+        palantirJavaFormat(libs.versions.palantir.java.format.get())
       }
     }
   }

--- a/test-published-dependencies/build.gradle.kts
+++ b/test-published-dependencies/build.gradle.kts
@@ -37,7 +37,7 @@ allprojects {
         target("src/**/*.java")
         removeUnusedImports()
         forbidWildcardImports()
-        palantirJavaFormat(libs.versions.palantir.java.format.get())
+        palantirJavaFormat(libs.versions.palantir.java.format.get()).style("GOOGLE")
       }
     }
   }


### PR DESCRIPTION
# What Does This Do

Switches every Spotless Java configuration from google-java-format 1.36.1 to palantir-java-format 2.97.0 and explicitly selects `.style("GOOGLE")`.
It also updates the contributor and agent guides, including the IntelliJ setup.

## Representative Formatting Changes

These examples come from the repository sources reformatted in #12422.

### Compact Lambda Pipelines

[`PluginApplication.java`](https://github.com/DataDog/dd-trace-java/blob/bdu/reformat-with-palantir-java-format/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/PluginApplication.java)

```diff
-        Extension.EXTENSIONS.stream()
-            .filter(ext -> ext.appliesTo(spec))
-            .forEach(
-                ext -> {
+        Extension.EXTENSIONS.stream().filter(ext -> ext.appliesTo(spec)).forEach(ext -> {
```

### Vertically Aligned Fluent Calls

[`AdviceGeneratorImpl.java`](https://github.com/DataDog/dd-trace-java/blob/bdu/reformat-with-palantir-java-format/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/impl/AdviceGeneratorImpl.java)

```diff
-      final List<Expression> helperTypes =
-          Arrays.stream(helpers)
-              .map(type -> new StringLiteralExpr(type.getClassName()))
-              .collect(Collectors.toList());
+      final List<Expression> helperTypes = Arrays.stream(helpers)
+          .map(type -> new StringLiteralExpr(type.getClassName()))
+          .collect(Collectors.toList());
```

### Nested Callbacks Without an Indentation Pyramid

[`CoreTracer.java`](https://github.com/DataDog/dd-trace-java/blob/bdu/reformat-with-palantir-java-format/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java)

```diff
-    sharedCommunicationObjects.whenReady(
-        () ->
-            AgentTaskScheduler.get()
-                .execute(
-                    () -> {
-                      startMetricsAggregation(config, sco);
-                      maybeStartLogsExport(config);
-                    }));
+    sharedCommunicationObjects.whenReady(() -> AgentTaskScheduler.get().execute(() -> {
+      startMetricsAggregation(config, sco);
+      maybeStartLogsExport(config);
+    }));
```

### Nested Lambda Pipelines Without Stair-Step Indentation

[`AssertBuilder.java`](https://github.com/DataDog/dd-trace-java/blob/bdu/reformat-with-palantir-java-format/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/assertion/AssertBuilder.java)

```diff
     return type.getAnnotationByName("AutoService")
-        .<Set<Class<?>>>map(
-            annotation ->
-                annotation.asNormalAnnotationExpr().getPairs().stream()
-                    .filter(pair -> pair.getNameAsString().equals("value"))
-                    .flatMap(
-                        pair ->
-                            pair.getValue().asArrayInitializerExpr().getValues().stream()
-                                .map(
-                                    value ->
-                                        value
-                                            .asClassExpr()
-                                            .getType()
-                                            .resolve()
-                                            .asReferenceType()
-                                            .getTypeDeclaration()
-                                            .get()
-                                            .getQualifiedName()))
-                    .map(AssertBuilder::loadClass)
-                    .collect(Collectors.toSet()))
+        .<Set<Class<?>>>map(annotation -> annotation.asNormalAnnotationExpr().getPairs().stream()
+            .filter(pair -> pair.getNameAsString().equals("value"))
+            .flatMap(pair -> pair.getValue().asArrayInitializerExpr().getValues().stream()
+                .map(value -> value
+                    .asClassExpr()
+                    .getType()
+                    .resolve()
+                    .asReferenceType()
+                    .getTypeDeclaration()
+                    .get()
+                    .getQualifiedName()))
+            .map(AssertBuilder::loadClass)
+            .collect(Collectors.toSet()))
         .orElse(Collections.emptySet());
```

### Switch Blocks Attached to Their Labels

[`JsonToExpressionConverter.java`](https://github.com/DataDog/dd-trace-java/blob/bdu/reformat-with-palantir-java-format/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java)

```diff
-      case "not":
-        {
-          JsonReader.Token token = reader.peek();
-          if (token == BEGIN_ARRAY || token == STRING || token == NUMBER) {
-            throw new UnsupportedOperationException(
-                "Operation 'not' expects a predicate as its argument");
-          }
-          return DSL.not(createPredicate(reader));
-        }
+      case "not": {
+        JsonReader.Token token = reader.peek();
+        if (token == BEGIN_ARRAY || token == STRING || token == NUMBER) {
+          throw new UnsupportedOperationException(
+              "Operation 'not' expects a predicate as its argument");
+        }
+        return DSL.not(createPredicate(reader));
+      }
```

# Motivation

The experiment deliberately selects `GOOGLE` style to preserve the repository's existing two-space indentation and 100-character line width. This keeps the evaluation focused on Palantir's lambda and fluent-chain layout instead of combining it with a repository-wide indentation and line-width change. It also reduces the stacked reformat from 6,133 files with the default `PALANTIR` style to 1,855 files.

# Additional Notes

This is the base of a two-PR experiment. `spotlessCheck` is expected to report Java format violations on this PR alone; the stacked reformatting PR #12422 makes the new formatter idempotent.

The Palantir IntelliJ plugin currently exposes only the default `PALANTIR` style, so the contributor guide keeps the Spotless Gradle tasks as the formatting source of truth for this `GOOGLE`-style experiment.

Palantir 2.97.0 with `GOOGLE` style keeps the closing parenthesis beside the final parameter:

```java
private static Function<CallSiteSpecification, CallSiteResult> generateAdviceClosure(
    final Configuration configuration) {
```

Spotless exposes Palantir style and Javadoc options, but no independent indentation or closing-parenthesis option.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR
