### PR TITLE
Read agent jar resources through the retained jar handle

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
@@ -69,6 +69,44 @@ public final class DatadogClassLoader extends SecureClassLoader {
   }
 
   @Override
+  public InputStream getResourceAsStream(final String name) {
+    // Resources we ship are read straight from the jar handle opened at construction time, the
+    // same source class loading reads from. Going through the "jar:" URL returned by
+    // findResource() instead would resolve the agent jar by pathname on every read: once a
+    // deployment has replaced or removed that jar the read either fails - and
+    // ClassLoader.getResourceAsStream() turns the IOException into a silent null, see
+    // APPSEC-69906 - or silently serves content belonging to a different build of the agent.
+    InputStream is = findResourceAsStream(name);
+    if (null == is) {
+      is = super.getResourceAsStream(name);
+    }
+    return is;
+  }
+
+  /**
+   * Reads a resource we ship from the agent jar, or returns {@code null} if the agent jar does not
+   * contain it. Note {@link BootstrapProxy} is backed by the very same jar, so consulting this
+   * before delegating cannot shadow a different resource of the same name.
+   */
+  private InputStream findResourceAsStream(String name) {
+    if (null == agentJarFile) {
+      return null;
+    }
+    String entryName = agentJarIndex.resourceEntryName(name);
+    if (null != entryName) {
+      JarEntry jarEntry = agentJarFile.getJarEntry(entryName);
+      if (null != jarEntry) {
+        try {
+          return agentJarFile.getInputStream(jarEntry);
+        } catch (IOException e) {
+          log.warn("Problem reading resource data at {}", jarEntry, e);
+        }
+      }
+    }
+    return null;
+  }
+
+  @Override
   protected URL findResource(String name) {
     String entryName = agentJarIndex.resourceEntryName(name);
     if (null != entryName) {

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/DatadogClassLoader.java
@@ -76,48 +76,47 @@ public final class DatadogClassLoader extends SecureClassLoader {
     // deployment has replaced or removed that jar the read either fails - and
     // ClassLoader.getResourceAsStream() turns the IOException into a silent null, see
     // APPSEC-69906 - or silently serves content belonging to a different build of the agent.
-    InputStream is = findResourceAsStream(name);
-    if (null == is) {
-      is = super.getResourceAsStream(name);
+    JarEntry jarEntry = findResourceEntry(name);
+    if (null == jarEntry) {
+      return super.getResourceAsStream(name);
     }
-    return is;
+    try {
+      return agentJarFile.getInputStream(jarEntry);
+    } catch (IOException e) {
+      // The retained jar owns this resource, so do not fall back to a pathname-based lookup that
+      // could serve the same entry from a replacement jar.
+      log.warn("Problem reading resource data at {}", jarEntry, e);
+      return null;
+    }
   }
 
   /**
-   * Reads a resource we ship from the agent jar, or returns {@code null} if the agent jar does not
-   * contain it. Note {@link BootstrapProxy} is backed by the very same jar, so consulting this
-   * before delegating cannot shadow a different resource of the same name.
+   * Finds a resource we ship in the retained agent jar. Indexed agent resources intentionally take
+   * precedence over delegated resources so their contents stay consistent with classes loaded from
+   * this handle. Resources not owned by this jar, including the manifest which is excluded from the
+   * index, continue through the existing delegation path. In production {@link BootstrapProxy} is
+   * initially registered with the same agent jar URL, but it can hold additional URLs.
    */
-  private InputStream findResourceAsStream(String name) {
+  private JarEntry findResourceEntry(String name) {
     if (null == agentJarFile) {
       return null;
     }
     String entryName = agentJarIndex.resourceEntryName(name);
     if (null != entryName) {
-      JarEntry jarEntry = agentJarFile.getJarEntry(entryName);
-      if (null != jarEntry) {
-        try {
-          return agentJarFile.getInputStream(jarEntry);
-        } catch (IOException e) {
-          log.warn("Problem reading resource data at {}", jarEntry, e);
-        }
-      }
+      return agentJarFile.getJarEntry(entryName);
     }
     return null;
   }
 
   @Override
   protected URL findResource(String name) {
-    String entryName = agentJarIndex.resourceEntryName(name);
-    if (null != entryName) {
-      JarEntry jarEntry = agentJarFile.getJarEntry(entryName);
-      if (null != jarEntry) {
-        String location = agentResourcePrefix + entryName;
-        try {
-          return new URL(location);
-        } catch (Exception e) {
-          log.warn("Malformed location {}", location);
-        }
+    JarEntry jarEntry = findResourceEntry(name);
+    if (null != jarEntry) {
+      String location = agentResourcePrefix + jarEntry.getName();
+      try {
+        return new URL(location);
+      } catch (Exception e) {
+        log.warn("Malformed location {}", location);
       }
     }
     return null;

--- a/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/DatadogClassLoaderTest.java
+++ b/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/DatadogClassLoaderTest.java
@@ -1,19 +1,31 @@
 package datadog.trace.bootstrap;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.Phaser;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -167,5 +179,100 @@ class DatadogClassLoaderTest {
                 + expectedPrefix
                 + ") — pre-fix code derives the prefix from JarFile.getName(),"
                 + " which leaves the space unencoded and on Windows produces a malformed URL.");
+  }
+
+  /**
+   * Regression test for APPSEC-69906. Deployments that upgrade the agent replace its jar on disk
+   * while the JVM keeps running. Class loading survives that, because it reads through the {@link
+   * java.util.jar.JarFile} handle opened at construction time, but resource loading used to go
+   * through a {@code jar:} URL that can no longer be opened — and {@link
+   * ClassLoader#getResourceAsStream} turns the resulting {@link java.io.IOException} into a silent
+   * {@code null}. AppSec surfaced that as a bogus "Resource default_config.json not found".
+   */
+  @Test
+  void getResourceAsStreamSurvivesAgentJarRemoval(@org.junit.jupiter.api.io.TempDir File tempDir)
+      throws Exception {
+    // deleting a file that is still open is rejected on Windows, so the scenario cannot arise there
+    assumeFalse(System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win"));
+
+    File jar = new File(tempDir, "testjar-jdk8");
+    Files.copy(
+        new File("src/test/resources/classloader-test-jar/testjar-jdk8").toPath(), jar.toPath());
+    DatadogClassLoader ddLoader = new DatadogClassLoader(jar.toURI().toURL(), null);
+
+    // the jar goes away from under the running JVM; the handle opened above still refers to it
+    Files.delete(jar.toPath());
+
+    // the URL is still resolved, but is now unreadable — this is what used to yield a silent null
+    URL resource = ddLoader.findResource("a/A.class");
+    assertNotNull(resource, "findResource should still resolve a/A.class from the jar index");
+    assertThrows(IOException.class, resource::openStream);
+
+    assertArrayEquals(
+        originalEntryBytes(),
+        readFully(ddLoader, "a/A.class"),
+        "getResourceAsStream should read through the retained jar handle");
+  }
+
+  /**
+   * Companion to {@link #getResourceAsStreamSurvivesAgentJarRemoval}, covering what an agent
+   * upgrade actually does: the pathname is replaced by a <em>readable</em> jar of a different
+   * build. Opening the {@code jar:} URL would then succeed and hand back the new jar's copy of the
+   * resource, while classes keep coming from the retained handle — mixing two builds. Resources
+   * must come from the same jar the classes do.
+   */
+  @Test
+  void getResourceAsStreamIgnoresAJarThatReplacedTheAgentJar(
+      @org.junit.jupiter.api.io.TempDir File tempDir) throws Exception {
+    // replacing a file that is still open is rejected on Windows, so the scenario cannot arise
+    assumeFalse(System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win"));
+
+    File jar = new File(tempDir, "testjar-jdk8");
+    Files.copy(
+        new File("src/test/resources/classloader-test-jar/testjar-jdk8").toPath(), jar.toPath());
+    DatadogClassLoader ddLoader = new DatadogClassLoader(jar.toURI().toURL(), null);
+
+    // an upgrade swaps in a different build holding a different copy of the same entry
+    byte[] replacementContents = "a different build of a/A.class".getBytes(StandardCharsets.UTF_8);
+    File replacement = new File(tempDir, "replacement");
+    try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(replacement.toPath()))) {
+      out.putNextEntry(new JarEntry("parent/a/A.classdata"));
+      out.write(replacementContents);
+      out.closeEntry();
+    }
+    // REPLACE_EXISTING alone: combining it with ATOMIC_MOVE is not portable, and the move must
+    // swap the pathname rather than write through it, so the handle keeps seeing the old jar
+    Files.move(replacement.toPath(), jar.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+    assertArrayEquals(
+        originalEntryBytes(),
+        readFully(ddLoader, "a/A.class"),
+        "getResourceAsStream should serve the jar the loader was built on, not its replacement");
+  }
+
+  private static byte[] originalEntryBytes() throws Exception {
+    try (JarFile jarFile =
+        new JarFile(new File("src/test/resources/classloader-test-jar/testjar-jdk8"))) {
+      try (InputStream is = jarFile.getInputStream(new JarEntry("parent/a/A.classdata"))) {
+        return readAllBytes(is);
+      }
+    }
+  }
+
+  private static byte[] readFully(ClassLoader loader, String name) throws Exception {
+    try (InputStream is = loader.getResourceAsStream(name)) {
+      assertNotNull(is, () -> "getResourceAsStream should have found " + name);
+      return readAllBytes(is);
+    }
+  }
+
+  private static byte[] readAllBytes(InputStream is) throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    byte[] buf = new byte[4096];
+    int read;
+    while ((read = is.read(buf)) != -1) {
+      out.write(buf, 0, read);
+    }
+    return out.toByteArray();
   }
 }

--- a/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/DatadogClassLoaderTest.java
+++ b/dd-java-agent/agent-bootstrap/src/test/java/datadog/trace/bootstrap/DatadogClassLoaderTest.java
@@ -3,6 +3,7 @@ package datadog.trace.bootstrap;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -13,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
@@ -181,13 +183,47 @@ class DatadogClassLoaderTest {
                 + " which leaves the space unencoded and on Windows produces a malformed URL.");
   }
 
+  @Test
+  void getResourceAsStreamFallsBackForResourcesExcludedFromTheIndex() throws Exception {
+    String manifestName = "META-INF/MANIFEST.MF";
+    try (URLClassLoader parent = new URLClassLoader(new URL[] {testJarLocation}, null)) {
+      DatadogClassLoader ddLoader = new DatadogClassLoader(testJarLocation, parent);
+
+      assertNull(
+          ddLoader.findResource(manifestName),
+          "the manifest should remain excluded from the agent jar index");
+      assertArrayEquals(
+          readFully(parent, manifestName),
+          readFully(ddLoader, manifestName),
+          "resources excluded from the index should retain the existing delegation path");
+    }
+  }
+
+  @Test
+  void getResourceAsStreamPrefersIndexedAgentResourceOverParent(
+      @org.junit.jupiter.api.io.TempDir File tempDir) throws Exception {
+    byte[] parentContents = "the parent's a/A.class".getBytes(StandardCharsets.UTF_8);
+    File parentJar = new File(tempDir, "parent.jar");
+    writeJarEntry(parentJar, "a/A.class", parentContents);
+
+    try (URLClassLoader parent = new URLClassLoader(new URL[] {parentJar.toURI().toURL()}, null)) {
+      DatadogClassLoader ddLoader = new DatadogClassLoader(testJarLocation, parent);
+
+      assertArrayEquals(parentContents, readFully(parent, "a/A.class"));
+      assertArrayEquals(
+          originalEntryBytes(),
+          readFully(ddLoader, "a/A.class"),
+          "indexed agent resources should take precedence over delegated resources");
+    }
+  }
+
   /**
-   * Regression test for APPSEC-69906. Deployments that upgrade the agent replace its jar on disk
-   * while the JVM keeps running. Class loading survives that, because it reads through the {@link
-   * java.util.jar.JarFile} handle opened at construction time, but resource loading used to go
-   * through a {@code jar:} URL that can no longer be opened — and {@link
-   * ClassLoader#getResourceAsStream} turns the resulting {@link java.io.IOException} into a silent
-   * {@code null}. AppSec surfaced that as a bogus "Resource default_config.json not found".
+   * Regression coverage for agent jar removal. Class loading survives an on-disk replacement,
+   * because it reads through the {@link java.util.jar.JarFile} handle opened at construction time,
+   * but resource loading used to go through a {@code jar:} URL that can no longer be opened — and
+   * {@link ClassLoader#getResourceAsStream} turns the resulting {@link java.io.IOException} into a
+   * silent {@code null}. APPSEC-69906 reported the same externally visible "Resource
+   * default_config.json not found" symptom, although its underlying cause is unconfirmed.
    */
   @Test
   void getResourceAsStreamSurvivesAgentJarRemoval(@org.junit.jupiter.api.io.TempDir File tempDir)
@@ -235,11 +271,7 @@ class DatadogClassLoaderTest {
     // an upgrade swaps in a different build holding a different copy of the same entry
     byte[] replacementContents = "a different build of a/A.class".getBytes(StandardCharsets.UTF_8);
     File replacement = new File(tempDir, "replacement");
-    try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(replacement.toPath()))) {
-      out.putNextEntry(new JarEntry("parent/a/A.classdata"));
-      out.write(replacementContents);
-      out.closeEntry();
-    }
+    writeJarEntry(replacement, "parent/a/A.classdata", replacementContents);
     // REPLACE_EXISTING alone: combining it with ATOMIC_MOVE is not portable, and the move must
     // swap the pathname rather than write through it, so the handle keeps seeing the old jar
     Files.move(replacement.toPath(), jar.toPath(), StandardCopyOption.REPLACE_EXISTING);
@@ -256,6 +288,14 @@ class DatadogClassLoaderTest {
       try (InputStream is = jarFile.getInputStream(new JarEntry("parent/a/A.classdata"))) {
         return readAllBytes(is);
       }
+    }
+  }
+
+  private static void writeJarEntry(File jar, String entryName, byte[] contents) throws Exception {
+    try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jar.toPath()))) {
+      out.putNextEntry(new JarEntry(entryName));
+      out.write(contents);
+      out.closeEntry();
     }
   }
 


### PR DESCRIPTION
# What Does This Do

`DatadogClassLoader` now reads indexed agent resources from the `JarFile` handle it opened at construction time — the same source class loading already reads from — instead of resolving the agent jar by pathname on every read. Resources not owned by the retained jar, including the manifest which is deliberately excluded from the index, continue through the previous delegation path unchanged.

If the retained jar owns an entry but opening it fails, the lookup is not delegated: doing so could serve the same entry from a different agent jar now present at the original pathname.

# Motivation

A JVM can outlive the `dd-java-agent.jar` pathname it started with. For example, package upgrades and configuration management commonly replace the jar on disk while the JVM keeps running. Class loading continues through the retained jar handle, but resource loading went through the `jar:file:...!/entry` URL returned by `findResource()`, which re-resolves the pathname on every read.

Once the jar at that pathname has been replaced or removed, that read can either:

- **fail** — and `ClassLoader.getResourceAsStream()` turns the `IOException` into a silent `null`, so an unreadable resource is indistinguishable from an absent one; or
- **succeed** — and serve a resource belonging to a *different build* of the agent, while classes keep coming from the old handle. The worst case is `appsec/native_libs/.../libddwaf.so`, where a native library could be loaded against JNI bindings from another build.

APPSEC-69906 recorded the same symptom for `default_config.json`: AppSec received `null` and reported `java.io.IOException: Resource default_config.json not found`, leaving the WAF with no ruleset and no signal that it was unprotected. The available evidence does not establish that live jar replacement caused that incident; this change hardens the classloader against that concrete failure mode and enforces that indexed resource streams come from the same jar handle as agent classes.

Resources whose first read happens late are the most exposed to pathname changes. Most agent resources (`InstrumenterIndex`, `KnownTypesIndex`, `ClassFileLocators`, and the system-classloader reads) resolve during startup. Two late readers are AppSec's default ruleset and the WAF native library, both deferred to the remote-config poller thread under `ENABLED_INACTIVE`.

# Additional Notes

For indexed agent resources, `getResourceAsStream()` now intentionally gives the retained agent jar precedence over `BootstrapProxy` and the parent loader. In normal agent wiring, `BootstrapProxy` is initially registered with the same agent jar URL and the parent is the bootstrap or platform loader. In CLI wiring the parent may be an application loader, so an application resource with the same logical name as an indexed agent resource will no longer take precedence.

Across a built shadow jar's 17528 entries there are 15 cases where a module-prefixed entry also has a literal copy at the un-prefixed path. All are `META-INF/MANIFEST.MF`, which `AgentJarIndex.IndexGenerator` excludes from the index, so they take the unchanged fallback path. Every product resource (`default_config.json`, `native_libs/**`, `third_party_libraries.json`, `metricconfigs.txt`, `appsec.version`, and the blocking templates) resolves to exactly the entry `findResource()` would have built a URL for.

Fallback is preserved when the retained jar does not own the requested resource or the index maps it to an entry the retained jar does not contain. It is deliberately not used after an `IOException` opening an entry that the retained jar does contain, because the fallback could serve that entry from a replacement build.

Deliberately out of scope, since each needs a jar swap inside the startup window and all three want the same `URLStreamHandler` work:

- `getResource()`/`getResources()` still return pathname-resolved URLs, so a caller that opens the URL itself can still read a replaced jar.
- `ClassFileLocators` reads class bytes via `BootstrapProxy` without going through `DatadogClassLoader`.
- `components/native-loader` locates via `getResource()` then `openStream()`; it has no non-test consumers today.

A resource present only in the *new* jar can still fall through to `BootstrapProxy` and be served from the replacement. The guarantee is that an entry present in the retained jar is never read from the replacement, not that the replacement can never be consulted.

Follow-up worth doing independently of this change: `AppSecConfigServiceImpl.init()` failing on the post-startup remote-config path throws `AbortStartupException`, which is caught as a plain `RuntimeException` and rate-limit-logged hours after startup, leaving `defaultConfigActivated` false. Any cause of that failure is currently silent.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [APPSEC-69906]

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APPSEC-69906]: https://datadoghq.atlassian.net/browse/APPSEC-69906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
