### PR TITLE
Fix NullPointerException in Exception Replay

### DIFF
--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/AbstractExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/AbstractExceptionDebugger.java
@@ -93,9 +93,12 @@ public abstract class AbstractExceptionDebugger implements DebuggerContext.Excep
       Throwable throwable;
       int chainedExceptionIdx = 0;
       while ((throwable = chainedExceptions.pollFirst()) != null) {
+        StackTraceElement[] stackTrace = throwable.getStackTrace();
+        if (stackTrace == null || stackTrace.length == 0) {
+          continue;
+        }
         ExceptionProbeManager.CreationResult creationResult =
-            exceptionProbeManager.createProbesForException(
-                throwable.getStackTrace(), chainedExceptionIdx);
+            exceptionProbeManager.createProbesForException(stackTrace, chainedExceptionIdx);
         if (creationResult.probesCreated > 0) {
           if (!applyConfigAsync) {
             applyExceptionConfiguration(fingerprint);

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -54,7 +54,7 @@ public class DefaultExceptionDebugger extends AbstractExceptionDebugger {
     }
     // do not handle exception with no stacktrace. cannot capture anything for it.
     // includes also FastThrow ones
-    if (t.getStackTrace().length == 0) {
+    if (t.getStackTrace() == null || t.getStackTrace().length == 0) {
       return false;
     }
     return circuitBreaker.trip();

--- a/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
+++ b/dd-java-agent/agent-debugger/src/main/java/com/datadog/debugger/exception/DefaultExceptionDebugger.java
@@ -54,7 +54,8 @@ public class DefaultExceptionDebugger extends AbstractExceptionDebugger {
     }
     // do not handle exception with no stacktrace. cannot capture anything for it.
     // includes also FastThrow ones
-    if (t.getStackTrace() == null || t.getStackTrace().length == 0) {
+    StackTraceElement[] stackTrace = t.getStackTrace();
+    if (stackTrace == null || stackTrace.length == 0) {
       return false;
     }
     return circuitBreaker.trip();


### PR DESCRIPTION
# What Does This Do
For FastThrow, getStackTrace can return null instead of empty StackTraceElement array

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [DEBUG-6173]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[DEBUG-6173]: https://datadoghq.atlassian.net/browse/DEBUG-6173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ