### PR TITLE
Send the split serial id on feature flag exposure events

### DIFF
--- a/products/feature-flagging/feature-flagging-api/build.gradle.kts
+++ b/products/feature-flagging/feature-flagging-api/build.gradle.kts
@@ -47,6 +47,10 @@ dependencies {
   compileOnly("io.opentelemetry:opentelemetry-api:1.47.0")
 
   testImplementation(project(":products:feature-flagging:feature-flagging-bootstrap"))
+  // SpanEnrichmentGate resolves FeatureFlaggingConfig at runtime. Without it on the test
+  // classpath the gate swallows a NoClassDefFoundError and reads as off, so the enrichment
+  // branch cannot be driven.
+  testImplementation(project(":products:feature-flagging:feature-flagging-config"))
   testImplementation(project(":utils:config-utils"))
   testImplementation("io.opentelemetry:opentelemetry-api:1.47.0")
   testImplementation(libs.bundles.junit5)

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -576,7 +576,9 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
             .build();
     final boolean doLog = allocation.doLog != null && allocation.doLog;
     if (doLog) {
-      dispatchExposure(key, result, context);
+      // Read from the split rather than from evaluation metadata: METADATA_SPLIT_SERIAL_ID is only
+      // attached when span enrichment is enabled, and exposures need the serial id either way.
+      dispatchExposure(key, result, context, split.serialId);
     }
     return result;
   }
@@ -649,7 +651,10 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
   }
 
   private static <T> void dispatchExposure(
-      final String flag, final ProviderEvaluation<T> evaluation, final EvaluationContext context) {
+      final String flag,
+      final ProviderEvaluation<T> evaluation,
+      final EvaluationContext context,
+      final Integer serialId) {
     final String allocationKey = allocationKey(evaluation);
     final String variantKey = evaluation.getVariant();
     if (allocationKey == null || variantKey == null) {
@@ -661,7 +666,8 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
             new datadog.trace.api.featureflag.exposure.Allocation(allocationKey),
             new datadog.trace.api.featureflag.exposure.Flag(flag),
             new datadog.trace.api.featureflag.exposure.Variant(variantKey),
-            new Subject(context.getTargetingKey(), flattenContext(context)));
+            new Subject(context.getTargetingKey(), flattenContext(context)),
+            serialId);
 
     FeatureFlaggingGateway.dispatch(event);
   }

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -55,7 +55,35 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
   private static final Logger log = LoggerFactory.getLogger(DDEvaluator.class);
   private static final Set<Class<?>> SUPPORTED_RESOLUTION_TYPES =
       new HashSet<>(asList(String.class, Boolean.class, Integer.class, Double.class, Value.class));
-  static final AtomicBoolean USE_LEGACY_EXPOSURE_API = new AtomicBoolean();
+
+  static final AtomicBoolean USE_LEGACY_EXPOSURE_API =
+      new AtomicBoolean(!serialIdSupported(Split.class, ExposureEvent.class));
+
+  static boolean serialIdSupported(final Class<?> splitClass, final Class<?> eventClass) {
+    try {
+      if (splitClass.getField("serialId").getType() != Integer.class) {
+        return false;
+      }
+      eventClass.getConstructor(
+          long.class,
+          datadog.trace.api.featureflag.exposure.Allocation.class,
+          datadog.trace.api.featureflag.exposure.Flag.class,
+          datadog.trace.api.featureflag.exposure.Variant.class,
+          Subject.class,
+          Integer.class);
+      return true;
+    } catch (final NoSuchFieldException
+        | NoSuchMethodException
+        | LinkageError
+        | RuntimeException e) {
+      log.warn(
+          "Feature flag exposure serial ID reporting is unavailable with the installed "
+              + "Datadog Java agent. Exposures are still reported, without the serial id. "
+              + "Upgrade dd-java-agent to enable holdout attribution.",
+          e);
+      return false;
+    }
+  }
 
   /**
    * Maximum evaluation-context nesting depth captured on the hot path. Recursion runs on the
@@ -562,7 +590,7 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
     // present (when enrichment is on) so the span-enrichment hook can decide whether to record the
     // subject.
     if (SPAN_ENRICHMENT_ENABLED) {
-      if (split.serialId != null) {
+      if (!USE_LEGACY_EXPOSURE_API.get() && split.serialId != null) {
         metadataBuilder.addInteger(METADATA_SPLIT_SERIAL_ID, split.serialId);
       }
       metadataBuilder.addBoolean(METADATA_DO_LOG, allocation.doLog != null && allocation.doLog);
@@ -672,24 +700,11 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
         new datadog.trace.api.featureflag.exposure.Variant(variantKey);
     final Subject subject = new Subject(context.getTargetingKey(), flattenContext(context));
 
-    ExposureEvent event = null;
-    if (!USE_LEGACY_EXPOSURE_API.get()) {
-      try {
-        event =
-            new ExposureEvent(
+    final ExposureEvent event =
+        USE_LEGACY_EXPOSURE_API.get()
+            ? new ExposureEvent(timestamp, allocation, exposureFlag, variant, subject)
+            : new ExposureEvent(
                 timestamp, allocation, exposureFlag, variant, subject, split.serialId);
-      } catch (NoSuchFieldError | NoSuchMethodError ignored) {
-        if (USE_LEGACY_EXPOSURE_API.compareAndSet(false, true)) {
-          log.warn(
-              "Feature flag exposure serial ID reporting is unavailable with the installed "
-                  + "Datadog Java agent. Legacy exposures will continue; upgrade dd-java-agent "
-                  + "to enable holdout attribution.");
-        }
-      }
-    }
-    if (event == null) {
-      event = new ExposureEvent(timestamp, allocation, exposureFlag, variant, subject);
-    }
     FeatureFlaggingGateway.dispatch(event);
   }
 

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -43,14 +43,19 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
 
+  private static final Logger log = LoggerFactory.getLogger(DDEvaluator.class);
   private static final Set<Class<?>> SUPPORTED_RESOLUTION_TYPES =
       new HashSet<>(asList(String.class, Boolean.class, Integer.class, Double.class, Value.class));
+  static final AtomicBoolean USE_LEGACY_EXPOSURE_API = new AtomicBoolean();
 
   /**
    * Maximum evaluation-context nesting depth captured on the hot path. Recursion runs on the
@@ -576,7 +581,7 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
             .build();
     final boolean doLog = allocation.doLog != null && allocation.doLog;
     if (doLog) {
-      dispatchExposure(key, result, context, split.serialId);
+      dispatchExposure(key, result, context, split);
     }
     return result;
   }
@@ -652,23 +657,40 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
       final String flag,
       final ProviderEvaluation<T> evaluation,
       final EvaluationContext context,
-      final Integer serialId) {
+      final Split split) {
     final String allocationKey = allocationKey(evaluation);
     final String variantKey = evaluation.getVariant();
     if (allocationKey == null || variantKey == null) {
       return;
     }
-    try {
-      FeatureFlaggingGateway.dispatch(
-          new ExposureEvent(
-              System.currentTimeMillis(),
-              new datadog.trace.api.featureflag.exposure.Allocation(allocationKey),
-              new datadog.trace.api.featureflag.exposure.Flag(flag),
-              new datadog.trace.api.featureflag.exposure.Variant(variantKey),
-              new Subject(context.getTargetingKey(), flattenContext(context)),
-              serialId));
-    } catch (LinkageError e) {
+    final long timestamp = System.currentTimeMillis();
+    final datadog.trace.api.featureflag.exposure.Allocation allocation =
+        new datadog.trace.api.featureflag.exposure.Allocation(allocationKey);
+    final datadog.trace.api.featureflag.exposure.Flag exposureFlag =
+        new datadog.trace.api.featureflag.exposure.Flag(flag);
+    final datadog.trace.api.featureflag.exposure.Variant variant =
+        new datadog.trace.api.featureflag.exposure.Variant(variantKey);
+    final Subject subject = new Subject(context.getTargetingKey(), flattenContext(context));
+
+    ExposureEvent event = null;
+    if (!USE_LEGACY_EXPOSURE_API.get()) {
+      try {
+        event =
+            new ExposureEvent(
+                timestamp, allocation, exposureFlag, variant, subject, split.serialId);
+      } catch (NoSuchFieldError | NoSuchMethodError ignored) {
+        if (USE_LEGACY_EXPOSURE_API.compareAndSet(false, true)) {
+          log.warn(
+              "Feature flag exposure serial ID reporting is unavailable with the installed "
+                  + "Datadog Java agent. Legacy exposures will continue; upgrade dd-java-agent "
+                  + "to enable holdout attribution.");
+        }
+      }
     }
+    if (event == null) {
+      event = new ExposureEvent(timestamp, allocation, exposureFlag, variant, subject);
+    }
+    FeatureFlaggingGateway.dispatch(event);
   }
 
   private static <T> String allocationKey(final ProviderEvaluation<T> resolution) {

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -56,14 +56,28 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
   private static final Set<Class<?>> SUPPORTED_RESOLUTION_TYPES =
       new HashSet<>(asList(String.class, Boolean.class, Integer.class, Double.class, Value.class));
 
-  static final AtomicBoolean USE_LEGACY_EXPOSURE_API =
-      new AtomicBoolean(!serialIdSupported(Split.class, ExposureEvent.class));
+  static final AtomicBoolean SPLIT_SERIAL_ID_SUPPORTED =
+      new AtomicBoolean(splitSerialIdSupported(Split.class));
 
-  static boolean serialIdSupported(final Class<?> splitClass, final Class<?> eventClass) {
+  static final AtomicBoolean USE_LEGACY_EXPOSURE_API =
+      new AtomicBoolean(
+          !(SPLIT_SERIAL_ID_SUPPORTED.get() && exposureSerialIdSupported(ExposureEvent.class)));
+
+  static boolean splitSerialIdSupported(final Class<?> splitClass) {
     try {
-      if (splitClass.getField("serialId").getType() != Integer.class) {
-        return false;
-      }
+      return splitClass.getField("serialId").getType() == Integer.class;
+    } catch (final NoSuchFieldException | LinkageError | RuntimeException e) {
+      log.warn(
+          "Feature flag serial ID reporting is unavailable with the installed Datadog Java "
+              + "agent, which does not carry a serial id on the flag configuration. Upgrade "
+              + "dd-java-agent to enable holdout attribution.",
+          e);
+      return false;
+    }
+  }
+
+  static boolean exposureSerialIdSupported(final Class<?> eventClass) {
+    try {
       eventClass.getConstructor(
           long.class,
           datadog.trace.api.featureflag.exposure.Allocation.class,
@@ -72,14 +86,12 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
           Subject.class,
           Integer.class);
       return true;
-    } catch (final NoSuchFieldException
-        | NoSuchMethodException
-        | LinkageError
-        | RuntimeException e) {
+    } catch (final NoSuchMethodException | LinkageError | RuntimeException e) {
       log.warn(
           "Feature flag exposure serial ID reporting is unavailable with the installed "
-              + "Datadog Java agent. Exposures are still reported, without the serial id. "
-              + "Upgrade dd-java-agent to enable holdout attribution.",
+              + "Datadog Java agent. Exposures are still reported, without the serial id, and "
+              + "span enrichment is unaffected. Upgrade dd-java-agent to enable holdout "
+              + "attribution on exposures.",
           e);
       return false;
     }
@@ -590,7 +602,7 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
     // present (when enrichment is on) so the span-enrichment hook can decide whether to record the
     // subject.
     if (SPAN_ENRICHMENT_ENABLED) {
-      if (!USE_LEGACY_EXPOSURE_API.get() && split.serialId != null) {
+      if (SPLIT_SERIAL_ID_SUPPORTED.get() && split.serialId != null) {
         metadataBuilder.addInteger(METADATA_SPLIT_SERIAL_ID, split.serialId);
       }
       metadataBuilder.addBoolean(METADATA_DO_LOG, allocation.doLog != null && allocation.doLog);

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -576,8 +576,6 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
             .build();
     final boolean doLog = allocation.doLog != null && allocation.doLog;
     if (doLog) {
-      // Read from the split rather than from evaluation metadata: METADATA_SPLIT_SERIAL_ID is only
-      // attached when span enrichment is enabled, and exposures need the serial id either way.
       dispatchExposure(key, result, context, split.serialId);
     }
     return result;
@@ -670,8 +668,6 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
               new Subject(context.getTargetingKey(), flattenContext(context)),
               serialId));
     } catch (LinkageError e) {
-      // Never let exposure recording break flag evaluation. The serial id constructor resolves
-      // against the agent's bootstrap class, which can predate this provider.
     }
   }
 

--- a/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
+++ b/products/feature-flagging/feature-flagging-api/src/main/java/datadog/trace/api/openfeature/DDEvaluator.java
@@ -660,16 +660,19 @@ class DDEvaluator implements Evaluator, FeatureFlaggingGateway.ConfigListener {
     if (allocationKey == null || variantKey == null) {
       return;
     }
-    final ExposureEvent event =
-        new ExposureEvent(
-            System.currentTimeMillis(),
-            new datadog.trace.api.featureflag.exposure.Allocation(allocationKey),
-            new datadog.trace.api.featureflag.exposure.Flag(flag),
-            new datadog.trace.api.featureflag.exposure.Variant(variantKey),
-            new Subject(context.getTargetingKey(), flattenContext(context)),
-            serialId);
-
-    FeatureFlaggingGateway.dispatch(event);
+    try {
+      FeatureFlaggingGateway.dispatch(
+          new ExposureEvent(
+              System.currentTimeMillis(),
+              new datadog.trace.api.featureflag.exposure.Allocation(allocationKey),
+              new datadog.trace.api.featureflag.exposure.Flag(flag),
+              new datadog.trace.api.featureflag.exposure.Variant(variantKey),
+              new Subject(context.getTargetingKey(), flattenContext(context)),
+              serialId));
+    } catch (LinkageError e) {
+      // Never let exposure recording break flag evaluation. The serial id constructor resolves
+      // against the agent's bootstrap class, which can predate this provider.
+    }
   }
 
   private static <T> String allocationKey(final ProviderEvaluation<T> resolution) {

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorSpanEnrichmentForkedTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorSpanEnrichmentForkedTest.java
@@ -1,0 +1,99 @@
+package datadog.trace.api.openfeature;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+
+import datadog.trace.api.featureflag.ufc.v1.Allocation;
+import datadog.trace.api.featureflag.ufc.v1.Flag;
+import datadog.trace.api.featureflag.ufc.v1.ServerConfiguration;
+import datadog.trace.api.featureflag.ufc.v1.Split;
+import datadog.trace.api.featureflag.ufc.v1.ValueType;
+import datadog.trace.api.featureflag.ufc.v1.Variant;
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.MutableContext;
+import dev.openfeature.sdk.ProviderEvaluation;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Drives the span-enrichment branch of {@link DDEvaluator}, which the ordinary test task cannot
+ * reach: the gate is read once into a static final field at class load. The property is set here
+ * rather than through {@code @WithConfig} because that extension rewrites {@code Config.INSTANCE},
+ * which this module does not use, and the forked task gives this class its own JVM where nothing
+ * has loaded the evaluator yet.
+ */
+class DDEvaluatorSpanEnrichmentForkedTest {
+
+  static {
+    System.setProperty("dd.experimental.flagging.provider.span.enrichment.enabled", "true");
+  }
+
+  @Test
+  void enrichmentMetadataCarriesTheSplitSerialId() {
+    final ProviderEvaluation<?> result = evaluate(340132);
+
+    assertNotNull(
+        result.getFlagMetadata().getBoolean(DDEvaluator.METADATA_DO_LOG),
+        "span enrichment must be on, or the assertions below pass vacuously");
+    assertEquals(
+        Integer.valueOf(340132),
+        result.getFlagMetadata().getInteger(DDEvaluator.METADATA_SPLIT_SERIAL_ID));
+  }
+
+  /**
+   * Agents 1.65 and 1.66 carry Split.serialId but not the six-argument event constructor. Only the
+   * exposure path may fall back on those agents; the enrichment metadata they already support must
+   * keep reporting the serial id.
+   */
+  @Test
+  void enrichmentMetadataSurvivesAnAgentWithoutTheExposureConstructor() {
+    final boolean previous = DDEvaluator.USE_LEGACY_EXPOSURE_API.getAndSet(true);
+    try {
+      assertEquals(
+          Integer.valueOf(340132),
+          evaluate(340132).getFlagMetadata().getInteger(DDEvaluator.METADATA_SPLIT_SERIAL_ID));
+    } finally {
+      DDEvaluator.USE_LEGACY_EXPOSURE_API.set(previous);
+    }
+  }
+
+  @Test
+  void enrichmentMetadataOmitsTheSerialIdWhenTheAgentSplitHasNoField() {
+    final boolean previous = DDEvaluator.SPLIT_SERIAL_ID_SUPPORTED.getAndSet(false);
+    try {
+      assertNull(
+          evaluate(340132).getFlagMetadata().getInteger(DDEvaluator.METADATA_SPLIT_SERIAL_ID));
+    } finally {
+      DDEvaluator.SPLIT_SERIAL_ID_SUPPORTED.set(previous);
+    }
+  }
+
+  @Test
+  void enrichmentMetadataOmitsTheSerialIdWhenTheSplitHasNone() {
+    assertNull(evaluate(null).getFlagMetadata().getInteger(DDEvaluator.METADATA_SPLIT_SERIAL_ID));
+  }
+
+  private static ProviderEvaluation<?> evaluate(final Integer serialId) {
+    final Map<String, Variant> variations = new HashMap<>();
+    variations.put("on", new Variant("on", 1));
+    final Split split = new Split(emptyList(), "on", emptyMap(), serialId);
+    final Allocation allocation =
+        new Allocation("alloc-1", null, null, null, singletonList(split), Boolean.FALSE);
+    final Map<String, Flag> flags = new HashMap<>();
+    flags.put(
+        "target",
+        new Flag("target", true, ValueType.INTEGER, variations, singletonList(allocation)));
+
+    final DDEvaluator evaluator = new DDEvaluator(mock(Runnable.class));
+    evaluator.accept(new ServerConfiguration("", "", true, null, flags));
+
+    final EvaluationContext ctx = new MutableContext("target").setTargetingKey("user-1");
+    return evaluator.evaluate(Integer.class, "target", 23, ctx);
+  }
+}

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -421,6 +422,52 @@ public class DDEvaluatorTest {
     } finally {
       DDEvaluator.USE_LEGACY_EXPOSURE_API.set(previous);
     }
+  }
+
+  // ---- old-agent bootstrap probe ----
+
+  /** A Split from an agent that predates the serial id: the field does not exist. */
+  static final class SplitWithoutSerialId {}
+
+  /** A Split whose serialId is not the Integer the dispatch site reads. */
+  static final class SplitWithWrongSerialIdType {
+    public long serialId;
+  }
+
+  /** An ExposureEvent from an agent that predates the serial id: only the five-arg constructor. */
+  static final class LegacyExposureEvent {
+    LegacyExposureEvent(
+        final long timestamp,
+        final datadog.trace.api.featureflag.exposure.Allocation allocation,
+        final datadog.trace.api.featureflag.exposure.Flag flag,
+        final datadog.trace.api.featureflag.exposure.Variant variant,
+        final datadog.trace.api.featureflag.exposure.Subject subject) {}
+  }
+
+  /**
+   * Positive control. The probe must agree with the bootstrap actually on the classpath, or the
+   * negative cases below would pass for the wrong reason and the feature would ship switched off.
+   */
+  @Test
+  public void probeAcceptsTheBootstrapOnTheClasspath() {
+    assertTrue(DDEvaluator.serialIdSupported(Split.class, ExposureEvent.class));
+    assertFalse(DDEvaluator.USE_LEGACY_EXPOSURE_API.get());
+  }
+
+  @Test
+  public void probeRejectsAnAgentWhoseSplitHasNoSerialId() {
+    assertFalse(DDEvaluator.serialIdSupported(SplitWithoutSerialId.class, ExposureEvent.class));
+  }
+
+  @Test
+  public void probeRejectsAnAgentWhoseSerialIdIsNotAnInteger() {
+    assertFalse(
+        DDEvaluator.serialIdSupported(SplitWithWrongSerialIdType.class, ExposureEvent.class));
+  }
+
+  @Test
+  public void probeRejectsAnAgentWithoutTheSerialIdConstructor() {
+    assertFalse(DDEvaluator.serialIdSupported(Split.class, LegacyExposureEvent.class));
   }
 
   /**

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -26,6 +27,7 @@ import com.squareup.moshi.JsonWriter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
 import datadog.trace.api.featureflag.FeatureFlaggingGateway;
+import datadog.trace.api.featureflag.exposure.ExposureEvent;
 import datadog.trace.api.featureflag.ufc.v1.Allocation;
 import datadog.trace.api.featureflag.ufc.v1.ConditionConfiguration;
 import datadog.trace.api.featureflag.ufc.v1.ConditionOperator;
@@ -392,6 +394,47 @@ public class DDEvaluatorTest {
     assertThat(
         details.getFlagMetadata().getBoolean(DDEvaluator.METADATA_OBSERVE_FULL_EVALUATION_DATA),
         equalTo(false));
+  }
+
+  // ---- exposure events carry the split's serial id ----
+
+  @Test
+  public void exposureCarriesTheSplitSerialId() {
+    assertEquals(Integer.valueOf(340132), exposureFor(340132).serial_id);
+  }
+
+  @Test
+  public void exposureCarriesSerialIdZero() {
+    assertEquals(Integer.valueOf(0), exposureFor(0).serial_id);
+  }
+
+  @Test
+  public void exposureOmitsSerialIdWhenTheSplitHasNone() {
+    assertNull(exposureFor(null).serial_id);
+  }
+
+  /**
+   * Evaluates a logging allocation whose split carries the given serial id and returns the single
+   * dispatched exposure. Span enrichment is off here, as it is by default, so this also pins that
+   * the serial id does not travel via the enrichment-gated evaluation metadata.
+   */
+  private static ExposureEvent exposureFor(final Integer serialId) {
+    final List<ExposureEvent> dispatched = new ArrayList<>();
+    final FeatureFlaggingGateway.ExposureListener listener = dispatched::add;
+    FeatureFlaggingGateway.addExposureListener(listener);
+    try {
+      final Map<String, Variant> variations = new HashMap<>();
+      variations.put("on", new Variant("on", 1));
+      final Split split = new Split(emptyList(), "on", emptyMap(), serialId);
+      final Allocation allocation =
+          new Allocation("alloc-1", null, null, null, singletonList(split), Boolean.TRUE);
+      evaluateFlag(
+          new Flag("target", true, ValueType.INTEGER, variations, singletonList(allocation)), true);
+    } finally {
+      FeatureFlaggingGateway.removeExposureListener(listener);
+    }
+    assertEquals(1, dispatched.size());
+    return dispatched.get(0);
   }
 
   // Builds a flag that reaches resolveVariant: enabled, one allocation with no rules, one split

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -414,6 +414,37 @@ public class DDEvaluatorTest {
   }
 
   /**
+   * A provider from this release can run against an agent whose bootstrap ExposureEvent predates
+   * the serial id, which makes the constructor unresolvable. The evaluation must still return its
+   * value rather than propagate the linkage failure to the caller.
+   */
+  @Test
+  public void linkageFailureWhileDispatchingAnExposureDoesNotBreakEvaluation() {
+    final FeatureFlaggingGateway.ExposureListener listener =
+        event -> {
+          throw new NoSuchMethodError(
+              "datadog.trace.api.featureflag.exposure.ExposureEvent.<init>");
+        };
+    FeatureFlaggingGateway.addExposureListener(listener);
+    try {
+      final Map<String, Variant> variations = new HashMap<>();
+      variations.put("on", new Variant("on", 1));
+      final Split split = new Split(emptyList(), "on", emptyMap(), 7);
+      final Allocation allocation =
+          new Allocation("alloc-1", null, null, null, singletonList(split), Boolean.TRUE);
+      final ProviderEvaluation<?> result =
+          evaluateFlag(
+              new Flag("target", true, ValueType.INTEGER, variations, singletonList(allocation)),
+              true);
+
+      assertThat(result.getValue(), equalTo(1));
+      assertThat(result.getVariant(), equalTo("on"));
+    } finally {
+      FeatureFlaggingGateway.removeExposureListener(listener);
+    }
+  }
+
+  /**
    * Evaluates a logging allocation whose split carries the given serial id and returns the single
    * dispatched exposure. Span enrichment is off here, as it is by default, so this also pins that
    * the serial id does not travel via the enrichment-gated evaluation metadata.

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -413,34 +413,13 @@ public class DDEvaluatorTest {
     assertNull(exposureFor(null).serial_id);
   }
 
-  /**
-   * A provider from this release can run against an agent whose bootstrap ExposureEvent predates
-   * the serial id, which makes the constructor unresolvable. The evaluation must still return its
-   * value rather than propagate the linkage failure to the caller.
-   */
   @Test
-  public void linkageFailureWhileDispatchingAnExposureDoesNotBreakEvaluation() {
-    final FeatureFlaggingGateway.ExposureListener listener =
-        event -> {
-          throw new NoSuchMethodError(
-              "datadog.trace.api.featureflag.exposure.ExposureEvent.<init>");
-        };
-    FeatureFlaggingGateway.addExposureListener(listener);
+  public void legacyExposureApiDispatchesAnExposureWithoutSerialId() {
+    final boolean previous = DDEvaluator.USE_LEGACY_EXPOSURE_API.getAndSet(true);
     try {
-      final Map<String, Variant> variations = new HashMap<>();
-      variations.put("on", new Variant("on", 1));
-      final Split split = new Split(emptyList(), "on", emptyMap(), 7);
-      final Allocation allocation =
-          new Allocation("alloc-1", null, null, null, singletonList(split), Boolean.TRUE);
-      final ProviderEvaluation<?> result =
-          evaluateFlag(
-              new Flag("target", true, ValueType.INTEGER, variations, singletonList(allocation)),
-              true);
-
-      assertThat(result.getValue(), equalTo(1));
-      assertThat(result.getVariant(), equalTo("on"));
+      assertNull(exposureFor(7).serial_id);
     } finally {
-      FeatureFlaggingGateway.removeExposureListener(listener);
+      DDEvaluator.USE_LEGACY_EXPOSURE_API.set(previous);
     }
   }
 

--- a/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
+++ b/products/feature-flagging/feature-flagging-api/src/test/java/datadog/trace/api/openfeature/DDEvaluatorTest.java
@@ -450,24 +450,35 @@ public class DDEvaluatorTest {
    */
   @Test
   public void probeAcceptsTheBootstrapOnTheClasspath() {
-    assertTrue(DDEvaluator.serialIdSupported(Split.class, ExposureEvent.class));
+    assertTrue(DDEvaluator.splitSerialIdSupported(Split.class));
+    assertTrue(DDEvaluator.exposureSerialIdSupported(ExposureEvent.class));
+    assertTrue(DDEvaluator.SPLIT_SERIAL_ID_SUPPORTED.get());
     assertFalse(DDEvaluator.USE_LEGACY_EXPOSURE_API.get());
   }
 
   @Test
   public void probeRejectsAnAgentWhoseSplitHasNoSerialId() {
-    assertFalse(DDEvaluator.serialIdSupported(SplitWithoutSerialId.class, ExposureEvent.class));
+    assertFalse(DDEvaluator.splitSerialIdSupported(SplitWithoutSerialId.class));
   }
 
   @Test
   public void probeRejectsAnAgentWhoseSerialIdIsNotAnInteger() {
-    assertFalse(
-        DDEvaluator.serialIdSupported(SplitWithWrongSerialIdType.class, ExposureEvent.class));
+    assertFalse(DDEvaluator.splitSerialIdSupported(SplitWithWrongSerialIdType.class));
   }
 
   @Test
   public void probeRejectsAnAgentWithoutTheSerialIdConstructor() {
-    assertFalse(DDEvaluator.serialIdSupported(Split.class, LegacyExposureEvent.class));
+    assertFalse(DDEvaluator.exposureSerialIdSupported(LegacyExposureEvent.class));
+  }
+
+  /**
+   * Agents 1.65 and 1.66 carry Split.serialId but only the five-argument event constructor. Span
+   * enrichment works on those agents, so only the exposure path may fall back.
+   */
+  @Test
+  public void probeKeepsSplitSupportWhenOnlyTheEventConstructorIsMissing() {
+    assertTrue(DDEvaluator.splitSerialIdSupported(Split.class));
+    assertFalse(DDEvaluator.exposureSerialIdSupported(LegacyExposureEvent.class));
   }
 
   /**

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/exposure/ExposureEvent.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/exposure/ExposureEvent.java
@@ -15,6 +15,20 @@ public class ExposureEvent {
    */
   public final Integer serial_id;
 
+  /**
+   * Convenience constructor; the serial id defaults to absent. Retained so a provider compiled
+   * against an earlier release keeps linking against this class, which ships in the agent while the
+   * provider that constructs it ships as the separate dd-openfeature artifact.
+   */
+  public ExposureEvent(
+      final long timestamp,
+      final Allocation allocation,
+      final Flag flag,
+      final Variant variant,
+      final Subject subject) {
+    this(timestamp, allocation, flag, variant, subject, null);
+  }
+
   public ExposureEvent(
       final long timestamp,
       final Allocation allocation,

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/exposure/ExposureEvent.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/exposure/ExposureEvent.java
@@ -8,16 +8,25 @@ public class ExposureEvent {
   public final Variant variant;
   public final Subject subject;
 
+  /**
+   * Serial id of the UFC split this exposure resolved to, or null when the split carries none. The
+   * field name is the intake's wire key: Moshi serializes these events reflectively, so renaming it
+   * to serialId would silently change the payload and the intake would drop the whole event.
+   */
+  public final Integer serial_id;
+
   public ExposureEvent(
       final long timestamp,
       final Allocation allocation,
       final Flag flag,
       final Variant variant,
-      final Subject subject) {
+      final Subject subject,
+      final Integer serialId) {
     this.timestamp = timestamp;
     this.allocation = allocation;
     this.flag = flag;
     this.variant = variant;
     this.subject = subject;
+    this.serial_id = serialId;
   }
 }

--- a/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/exposure/ExposureEvent.java
+++ b/products/feature-flagging/feature-flagging-bootstrap/src/main/java/datadog/trace/api/featureflag/exposure/ExposureEvent.java
@@ -8,18 +8,8 @@ public class ExposureEvent {
   public final Variant variant;
   public final Subject subject;
 
-  /**
-   * Serial id of the UFC split this exposure resolved to, or null when the split carries none. The
-   * field name is the intake's wire key: Moshi serializes these events reflectively, so renaming it
-   * to serialId would silently change the payload and the intake would drop the whole event.
-   */
   public final Integer serial_id;
 
-  /**
-   * Convenience constructor; the serial id defaults to absent. Retained so a provider compiled
-   * against an earlier release keeps linking against this class, which ships in the agent while the
-   * provider that constructs it ships as the separate dd-openfeature artifact.
-   */
   public ExposureEvent(
       final long timestamp,
       final Allocation allocation,

--- a/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/ExposureCache.java
+++ b/products/feature-flagging/feature-flagging-lib/src/main/java/com/datadog/featureflag/ExposureCache.java
@@ -38,10 +38,12 @@ public interface ExposureCache {
   final class Value {
     public final String variant;
     public final String allocation;
+    public final Integer serialId;
 
     public Value(final ExposureEvent event) {
       this.variant = event.variant == null ? null : event.variant.key;
       this.allocation = event.allocation == null ? null : event.allocation.key;
+      this.serialId = event.serial_id;
     }
 
     @Override
@@ -50,12 +52,14 @@ public interface ExposureCache {
         return false;
       }
       final Value value = (Value) o;
-      return Objects.equals(variant, value.variant) && Objects.equals(allocation, value.allocation);
+      return Objects.equals(variant, value.variant)
+          && Objects.equals(allocation, value.allocation)
+          && Objects.equals(serialId, value.serialId);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(variant, allocation);
+      return Objects.hash(variant, allocation, serialId);
     }
   }
 }

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/ExposureWriterTests.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/ExposureWriterTests.java
@@ -541,7 +541,6 @@ class ExposureWriterTests {
         new Allocation("Allocation_" + id),
         new Flag("Flag_" + id),
         new Variant("Variant_" + id),
-        new Subject("Subject_" + id, attributes),
-        null);
+        new Subject("Subject_" + id, attributes));
   }
 }

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/ExposureWriterTests.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/ExposureWriterTests.java
@@ -541,6 +541,7 @@ class ExposureWriterTests {
         new Allocation("Allocation_" + id),
         new Flag("Flag_" + id),
         new Variant("Variant_" + id),
-        new Subject("Subject_" + id, attributes));
+        new Subject("Subject_" + id, attributes),
+        null);
   }
 }

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/FeatureFlagEvpPublisherTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/FeatureFlagEvpPublisherTest.java
@@ -1,7 +1,10 @@
 package com.datadog.featureflag;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -12,7 +15,14 @@ import static org.mockito.Mockito.when;
 
 import datadog.communication.BackendApi;
 import datadog.communication.BackendApiFactory;
+import datadog.trace.api.featureflag.exposure.Allocation;
+import datadog.trace.api.featureflag.exposure.ExposureEvent;
+import datadog.trace.api.featureflag.exposure.ExposuresRequest;
+import datadog.trace.api.featureflag.exposure.Flag;
+import datadog.trace.api.featureflag.exposure.Subject;
+import datadog.trace.api.featureflag.exposure.Variant;
 import datadog.trace.api.intake.Intake;
+import java.nio.charset.StandardCharsets;
 import okhttp3.RequestBody;
 import org.junit.jupiter.api.Test;
 
@@ -59,6 +69,37 @@ class FeatureFlagEvpPublisherTest {
     assertThrows(
         IllegalStateException.class,
         () -> publisher.post("flagevaluation", FeatureFlagEvpPublisher.utf8Bytes("{}")));
+  }
+
+  @Test
+  void serializesSerialIdUnderTheIntakeWireKey() {
+    assertTrue(exposureJson(340132).contains("\"serial_id\":340132"));
+  }
+
+  @Test
+  void serializesSerialIdZeroRatherThanOmittingIt() {
+    assertTrue(exposureJson(0).contains("\"serial_id\":0"));
+  }
+
+  @Test
+  void omitsSerialIdKeyWhenAbsent() {
+    assertFalse(exposureJson(null).contains("serial_id"));
+  }
+
+  private static String exposureJson(final Integer serialId) {
+    final ExposureEvent event =
+        new ExposureEvent(
+            1234L,
+            new Allocation("allocation"),
+            new Flag("flag"),
+            new Variant("variant"),
+            new Subject("subject", emptyMap()),
+            serialId);
+    final FeatureFlagEvpPublisher<ExposuresRequest> publisher =
+        new FeatureFlagEvpPublisher<>(mock(BackendApiFactory.class), ExposuresRequest.class);
+    return new String(
+        publisher.serialize(new ExposuresRequest(emptyMap(), singletonList(event))),
+        StandardCharsets.UTF_8);
   }
 
   static class TestRequest {

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/FeatureFlagEvpPublisherTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/FeatureFlagEvpPublisherTest.java
@@ -86,15 +86,31 @@ class FeatureFlagEvpPublisherTest {
     assertFalse(exposureJson(null).contains("serial_id"));
   }
 
-  private static String exposureJson(final Integer serialId) {
+  @Test
+  void omitsSerialIdKeyForAnEventBuiltWithoutOne() {
     final ExposureEvent event =
         new ExposureEvent(
             1234L,
             new Allocation("allocation"),
             new Flag("flag"),
             new Variant("variant"),
+            new Subject("subject", emptyMap()));
+
+    assertFalse(exposureJsonOf(event).contains("serial_id"));
+  }
+
+  private static String exposureJson(final Integer serialId) {
+    return exposureJsonOf(
+        new ExposureEvent(
+            1234L,
+            new Allocation("allocation"),
+            new Flag("flag"),
+            new Variant("variant"),
             new Subject("subject", emptyMap()),
-            serialId);
+            serialId));
+  }
+
+  private static String exposureJsonOf(final ExposureEvent event) {
     final FeatureFlagEvpPublisher<ExposuresRequest> publisher =
         new FeatureFlagEvpPublisher<>(mock(BackendApiFactory.class), ExposuresRequest.class);
     return new String(

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/LRUExposureCacheTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/LRUExposureCacheTest.java
@@ -60,6 +60,52 @@ class LRUExposureCacheTest {
   }
 
   @Test
+  void testSerialIdAppearingEmitsANewExposure() {
+    assertEquals(2, emissions(null, 7));
+  }
+
+  @Test
+  void testSerialIdDisappearingEmitsANewExposure() {
+    assertEquals(2, emissions(7, null));
+  }
+
+  @Test
+  void testSerialIdChangingEmitsANewExposure() {
+    assertEquals(2, emissions(7, 8));
+  }
+
+  @Test
+  void testSerialIdCycleEmitsAnExposurePerTransition() {
+    assertEquals(3, emissions(7, 8, 7));
+  }
+
+  @Test
+  void testUnchangedSerialIdIsDeduplicated() {
+    assertEquals(1, emissions(7, 7));
+  }
+
+  @Test
+  void testUnchangedAbsentSerialIdIsDeduplicated() {
+    assertEquals(1, emissions(null, null));
+  }
+
+  @Test
+  void testSerialIdZeroIsDistinguishedFromAbsent() {
+    assertEquals(2, emissions(null, 0));
+    assertEquals(2, emissions(0, null));
+  }
+
+  @Test
+  void testSerialIdIsRetainedOnTheCachedValue() {
+    LRUExposureCache cache = new LRUExposureCache(5);
+    ExposureEvent event = createEvent("flag", "subject", "variant", "allocation", 0);
+
+    cache.add(event);
+
+    assertEquals(Integer.valueOf(0), cache.get(new ExposureCache.Key(event)).serialId);
+  }
+
+  @Test
   void testLruEvictionWhenCapacityExceeded() {
     LRUExposureCache cache = new LRUExposureCache(2);
     ExposureEvent event1 = createEvent("flag1", "subject1", "variant1", "allocation1");
@@ -148,14 +194,16 @@ class LRUExposureCacheTest {
             new Allocation("allocation"),
             new Flag(null),
             new Variant("variant"),
-            new Subject(null, emptyMap()));
+            new Subject(null, emptyMap()),
+            null);
     ExposureEvent event2 =
         new ExposureEvent(
             System.currentTimeMillis(),
             new Allocation("allocation"),
             new Flag(null),
             new Variant("variant"),
-            new Subject(null, emptyMap()));
+            new Subject(null, emptyMap()),
+            null);
 
     cache.add(event1);
     boolean duplicateAdded = cache.add(event2);
@@ -234,11 +282,32 @@ class LRUExposureCacheTest {
 
   private static ExposureEvent createEvent(
       String flag, String subject, String variant, String allocation) {
+    return createEvent(flag, subject, variant, allocation, null);
+  }
+
+  private static ExposureEvent createEvent(
+      String flag, String subject, String variant, String allocation, Integer serialId) {
     return new ExposureEvent(
         System.currentTimeMillis(),
         new Allocation(allocation),
         new Flag(flag),
         new Variant(variant),
-        new Subject(subject, emptyMap()));
+        new Subject(subject, emptyMap()),
+        serialId);
+  }
+
+  /**
+   * Number of exposures a run of same-flag, same-subject evaluations emits: the cache reports true
+   * only for the ones it does not suppress as duplicates.
+   */
+  private static int emissions(final Integer... serialIds) {
+    LRUExposureCache cache = new LRUExposureCache(5);
+    int emitted = 0;
+    for (Integer serialId : serialIds) {
+      if (cache.add(createEvent("flag", "subject", "variant", "allocation", serialId))) {
+        emitted++;
+      }
+    }
+    return emitted;
   }
 }

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/LRUExposureCacheTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/LRUExposureCacheTest.java
@@ -194,16 +194,14 @@ class LRUExposureCacheTest {
             new Allocation("allocation"),
             new Flag(null),
             new Variant("variant"),
-            new Subject(null, emptyMap()),
-            null);
+            new Subject(null, emptyMap()));
     ExposureEvent event2 =
         new ExposureEvent(
             System.currentTimeMillis(),
             new Allocation("allocation"),
             new Flag(null),
             new Variant("variant"),
-            new Subject(null, emptyMap()),
-            null);
+            new Subject(null, emptyMap()));
 
     cache.add(event1);
     boolean duplicateAdded = cache.add(event2);

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/RemoteConfigServiceImplTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/RemoteConfigServiceImplTest.java
@@ -184,63 +184,56 @@ class RemoteConfigServiceImplTest {
   }
 
   private static String configWithSerialId(final String serialIdJson) {
-    return "{"
-        + "\"createdAt\":\"2024-04-17T19:40:53.716Z\","
-        + "\"format\":\"SERVER\","
-        + "\"environment\":{\"name\":\"Test\"},"
-        + "\"flags\":{"
-        + "\"valid-flag\":{"
-        + "\"key\":\"valid-flag\","
-        + "\"enabled\":true,"
-        + "\"variationType\":\"STRING\","
-        + "\"variations\":{\"expected\":{\"key\":\"expected\",\"value\":\"expected\"}},"
-        + "\"allocations\":[{"
-        + "\"key\":\"default-allocation\","
-        + "\"rules\":[],"
-        + "\"splits\":[{\"variationKey\":\"expected\",\"shards\":[]"
-        + (serialIdJson == null ? "" : ",\"serialId\":" + serialIdJson)
-        + "}],"
-        + "\"doLog\":true"
-        + "}]"
-        + "}"
-        + "}"
-        + "}";
+    return configWithFlags(flagWithSerialId("valid-flag", "expected", serialIdJson));
   }
 
   /** A malformed serial id must bind to its own flag and leave the sibling flag intact. */
   private static String configWithSiblingSerialIds(final String malformedSerialIdJson) {
+    return configWithFlags(
+        flagWithSerialId("malformed-flag", "on", malformedSerialIdJson)
+            + ","
+            + flagWithSerialId("valid-flag", "expected", "7"));
+  }
+
+  private static String configWithFlags(final String flagsJson) {
     return "{"
         + "\"createdAt\":\"2024-04-17T19:40:53.716Z\","
         + "\"format\":\"SERVER\","
         + "\"environment\":{\"name\":\"Test\"},"
         + "\"flags\":{"
-        + "\"malformed-flag\":{"
-        + "\"key\":\"malformed-flag\","
+        + flagsJson
+        + "}"
+        + "}";
+  }
+
+  /** A single enabled string flag with one logging allocation. A null serial id omits the key. */
+  private static String flagWithSerialId(
+      final String flagKey, final String variationKey, final String serialIdJson) {
+    return "\""
+        + flagKey
+        + "\":{"
+        + "\"key\":\""
+        + flagKey
+        + "\","
         + "\"enabled\":true,"
         + "\"variationType\":\"STRING\","
-        + "\"variations\":{\"on\":{\"key\":\"on\",\"value\":\"on\"}},"
+        + "\"variations\":{\""
+        + variationKey
+        + "\":{\"key\":\""
+        + variationKey
+        + "\",\"value\":\""
+        + variationKey
+        + "\"}},"
         + "\"allocations\":[{"
         + "\"key\":\"default-allocation\","
         + "\"rules\":[],"
-        + "\"splits\":[{\"variationKey\":\"on\",\"shards\":[],\"serialId\":"
-        + malformedSerialIdJson
+        + "\"splits\":[{\"variationKey\":\""
+        + variationKey
+        + "\",\"shards\":[]"
+        + (serialIdJson == null ? "" : ",\"serialId\":" + serialIdJson)
         + "}],"
         + "\"doLog\":true"
         + "}]"
-        + "},"
-        + "\"valid-flag\":{"
-        + "\"key\":\"valid-flag\","
-        + "\"enabled\":true,"
-        + "\"variationType\":\"STRING\","
-        + "\"variations\":{\"expected\":{\"key\":\"expected\",\"value\":\"expected\"}},"
-        + "\"allocations\":[{"
-        + "\"key\":\"default-allocation\","
-        + "\"rules\":[],"
-        + "\"splits\":[{\"variationKey\":\"expected\",\"shards\":[],\"serialId\":7}],"
-        + "\"doLog\":true"
-        + "}]"
-        + "}"
-        + "}"
         + "}";
   }
 

--- a/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/RemoteConfigServiceImplTest.java
+++ b/products/feature-flagging/feature-flagging-lib/src/test/java/com/datadog/featureflag/RemoteConfigServiceImplTest.java
@@ -41,6 +41,8 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -117,6 +119,129 @@ class RemoteConfigServiceImplTest {
     assertFalse(config.flags.containsKey("malformed-flag"));
     assertTrue(config.flags.containsKey("valid-flag"));
     assertEquals("expected", config.flags.get("valid-flag").variations.get("expected").value);
+  }
+
+  @Test
+  void parsesSplitSerialId() throws Exception {
+    final ServerConfiguration config = deserialize(configWithSerialId("340132"));
+
+    assertNotNull(config);
+    assertEquals(Integer.valueOf(340132), serialIdOf(config));
+  }
+
+  @Test
+  void parsesSplitSerialIdZero() throws Exception {
+    final ServerConfiguration config = deserialize(configWithSerialId("0"));
+
+    assertNotNull(config);
+    assertEquals(Integer.valueOf(0), serialIdOf(config));
+  }
+
+  @Test
+  void parsesAbsentSplitSerialIdAsNull() throws Exception {
+    final ServerConfiguration config = deserialize(configWithSerialId(null));
+
+    assertNotNull(config);
+    assertNull(serialIdOf(config));
+  }
+
+  @Test
+  void parsesNullSplitSerialIdAsNull() throws Exception {
+    final ServerConfiguration config = deserialize(configWithSerialId("null"));
+
+    assertNotNull(config);
+    assertNull(serialIdOf(config));
+  }
+
+  @Test
+  void skipsFlagWithUncoercibleSerialIdAndKeepsSiblingFlag() throws Exception {
+    final ServerConfiguration config = deserialize(configWithSiblingSerialIds("true"));
+
+    assertNotNull(config);
+    assertFalse(config.flags.containsKey("malformed-flag"));
+    assertEquals("invalid_flag", config.invalidFlags.get("malformed-flag"));
+    assertTrue(config.flags.containsKey("valid-flag"));
+    assertEquals(Integer.valueOf(7), serialIdOf(config));
+  }
+
+  /**
+   * Records how leniently the per-flag value reader coerces a serial id, so a future change to the
+   * parse path is visible here. The values come from the compiler-validated UFC, so the SDK adds no
+   * validation of its own; what matters is that a bad one never rejects the sibling flag.
+   */
+  @ParameterizedTest
+  @CsvSource({"\"340132\", 340132", "1.5, 1", "-1, -1", "2147483648, 2147483647"})
+  void coercesSerialIdWithoutRejectingTheFlag(final String wireValue, final int expected)
+      throws Exception {
+    final ServerConfiguration config = deserialize(configWithSerialId(wireValue));
+
+    assertNotNull(config);
+    assertEquals(Integer.valueOf(expected), serialIdOf(config));
+  }
+
+  private static Integer serialIdOf(final ServerConfiguration config) {
+    return config.flags.get("valid-flag").allocations.get(0).splits.get(0).serialId;
+  }
+
+  private static String configWithSerialId(final String serialIdJson) {
+    return "{"
+        + "\"createdAt\":\"2024-04-17T19:40:53.716Z\","
+        + "\"format\":\"SERVER\","
+        + "\"environment\":{\"name\":\"Test\"},"
+        + "\"flags\":{"
+        + "\"valid-flag\":{"
+        + "\"key\":\"valid-flag\","
+        + "\"enabled\":true,"
+        + "\"variationType\":\"STRING\","
+        + "\"variations\":{\"expected\":{\"key\":\"expected\",\"value\":\"expected\"}},"
+        + "\"allocations\":[{"
+        + "\"key\":\"default-allocation\","
+        + "\"rules\":[],"
+        + "\"splits\":[{\"variationKey\":\"expected\",\"shards\":[]"
+        + (serialIdJson == null ? "" : ",\"serialId\":" + serialIdJson)
+        + "}],"
+        + "\"doLog\":true"
+        + "}]"
+        + "}"
+        + "}"
+        + "}";
+  }
+
+  /** A malformed serial id must bind to its own flag and leave the sibling flag intact. */
+  private static String configWithSiblingSerialIds(final String malformedSerialIdJson) {
+    return "{"
+        + "\"createdAt\":\"2024-04-17T19:40:53.716Z\","
+        + "\"format\":\"SERVER\","
+        + "\"environment\":{\"name\":\"Test\"},"
+        + "\"flags\":{"
+        + "\"malformed-flag\":{"
+        + "\"key\":\"malformed-flag\","
+        + "\"enabled\":true,"
+        + "\"variationType\":\"STRING\","
+        + "\"variations\":{\"on\":{\"key\":\"on\",\"value\":\"on\"}},"
+        + "\"allocations\":[{"
+        + "\"key\":\"default-allocation\","
+        + "\"rules\":[],"
+        + "\"splits\":[{\"variationKey\":\"on\",\"shards\":[],\"serialId\":"
+        + malformedSerialIdJson
+        + "}],"
+        + "\"doLog\":true"
+        + "}]"
+        + "},"
+        + "\"valid-flag\":{"
+        + "\"key\":\"valid-flag\","
+        + "\"enabled\":true,"
+        + "\"variationType\":\"STRING\","
+        + "\"variations\":{\"expected\":{\"key\":\"expected\",\"value\":\"expected\"}},"
+        + "\"allocations\":[{"
+        + "\"key\":\"default-allocation\","
+        + "\"rules\":[],"
+        + "\"splits\":[{\"variationKey\":\"expected\",\"shards\":[],\"serialId\":7}],"
+        + "\"doLog\":true"
+        + "}]"
+        + "}"
+        + "}"
+        + "}";
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do

This change sends a `serial_id` field on each feature flag exposure event.

The serial id identifies the UFC split that the subject was assigned to. The intake uses it to find the holdout that the allocation comes from.

| File | Change |
|---|---|
| `exposure/ExposureEvent.java` | Add the field. The field name is the wire key. Retain the five-argument constructor so a provider built against an earlier release still links. |
| `openfeature/DDEvaluator.java` | Pass the split's serial id to the exposure dispatch. Probe the agent bootstrap once at class load, and fall back to the five-argument event when the installed agent predates the field. |
| `ExposureCache.java` | Compare the serial id when the cache looks for a duplicate. |

The evaluator reads the value from the UFC split. It does not read the value from the evaluation metadata. The metadata carries the serial id only when span enrichment is on. Exposures need the value in both cases.

The SDK does not validate the value. The flag configuration layer validates it. An absent serial id sends no field.

# Motivation

The compiler turns a holdout into an ordinary allocation before an SDK receives the configuration. An exposure event therefore records no holdout. The serial id is the only link back to it.

# Additional Notes

The cache stores the allocation key and the variant key for each flag and subject. A serial id that appears or changes while both keys stay the same was suppressed. The new value then never reached the intake. The cache now compares the serial id as well.

`ExposureEvent` and `Split` ship in the agent. This provider ships as the separate `dd-openfeature` artifact, so the installed agent can be older. A single probe at class load decides whether either serial id read is safe.

Four `Test_FFE_Exposure_*_Serial_Id` classes in `DataDog/system-tests` are gated `missing_feature (EX-3415)` for Java. Those rows need a version gate after a release contains this change.

## Testing

Twenty-six new test methods, twenty-nine executed cases, covering the wire format, the cache transitions, the dispatch, the configuration parse, and the old-agent probe.

```
./gradlew spotlessCheck \
  :products:feature-flagging:feature-flagging-bootstrap:test \
  :products:feature-flagging:feature-flagging-lib:test \
  :products:feature-flagging:feature-flagging-api:test
```

The wire tests assert on the serialized bytes. An omitted key and a null property differ in the payload but not on the object.

Mutation runs confirm that each production line is load-bearing. Each mutation fails only its intended tests. One line is not covered: the span-enrichment read gate. `SPAN_ENRICHMENT_ENABLED` is frozen at class load and `feature-flagging-config` is absent from the test runtime classpath, so no unit test drives that branch, and deleting the gate leaves the suite green.

System-tests results are in a comment below.

## Risks

Low. The field is optional. An exposure event without a serial id does not change.

The cache change adds exposures. A subject reports one more exposure when its serial id appears or changes. This is the intended fix.

This change creates the path that carries a serial id to the exposures intake. On the base branch the field does not exist on the event, and the only egress for `Split.serialId` is the span-enrichment metadata, behind a gate that is off by default. So the following exposure is new, not pre-existing. The flag configuration parser coerces a serial id rather than rejecting it, and a negative value reaches the intake, which then drops the whole payload. The SDK does not validate the value because the flag configuration layer does: the remote-config schema constrains `serialId` to a non-negative integer, so the value should never arrive.

# Contributor Checklist

- [x] Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue
- [x] Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- [x] Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors

Jira ticket: [EX-3415]

*This description was generated by Claude.*


[EX-3415]: https://datadoghq.atlassian.net/browse/EX-3415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ