### PR TITLE
[EVAL] AI-generated Gson serialization instrumentation

### DIFF
--- a/dd-java-agent/instrumentation/gson-2.1/build.gradle
+++ b/dd-java-agent/instrumentation/gson-2.1/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+  id 'dd-trace-java.module.instrumentation'
+}
+
+muzzle {
+  pass {
+    group = 'com.google.code.gson'
+    module = 'gson'
+    versions = '[2.1, )'
+  }
+}
+
+addTestSuiteForDir('latestDepTest', 'test')
+
+dependencies {
+  compileOnly group: 'com.google.code.gson', name: 'gson', version: '2.1'
+
+  testImplementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
+
+  latestDepTestImplementation group: 'com.google.code.gson', name: 'gson', version: '2.+'
+}

--- a/dd-java-agent/instrumentation/gson-2.1/src/main/java/datadog/trace/instrumentation/gson/GsonDecorator.java
+++ b/dd-java-agent/instrumentation/gson-2.1/src/main/java/datadog/trace/instrumentation/gson/GsonDecorator.java
@@ -1,0 +1,36 @@
+package datadog.trace.instrumentation.gson;
+
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import datadog.trace.bootstrap.instrumentation.api.Tags;
+import datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
+import datadog.trace.bootstrap.instrumentation.decorator.BaseDecorator;
+
+public class GsonDecorator extends BaseDecorator {
+  public static final GsonDecorator DECORATE = new GsonDecorator();
+
+  public static final CharSequence GSON_COMPONENT = UTF8BytesString.create("gson");
+  public static final CharSequence JSON_TYPE = UTF8BytesString.create("json");
+  public static final CharSequence GSON_TO_JSON = UTF8BytesString.create("gson.toJson");
+  public static final CharSequence GSON_FROM_JSON = UTF8BytesString.create("gson.fromJson");
+
+  @Override
+  protected String[] instrumentationNames() {
+    return new String[] {"gson"};
+  }
+
+  @Override
+  protected CharSequence spanType() {
+    return JSON_TYPE;
+  }
+
+  @Override
+  protected CharSequence component() {
+    return GSON_COMPONENT;
+  }
+
+  @Override
+  protected void doAfterStart(AgentSpan span) {
+    super.doAfterStart(span);
+    span.setTag(Tags.SPAN_KIND, Tags.SPAN_KIND_INTERNAL);
+  }
+}

--- a/dd-java-agent/instrumentation/gson-2.1/src/main/java/datadog/trace/instrumentation/gson/GsonFromJsonAdvice.java
+++ b/dd-java-agent/instrumentation/gson-2.1/src/main/java/datadog/trace/instrumentation/gson/GsonFromJsonAdvice.java
@@ -1,0 +1,54 @@
+package datadog.trace.instrumentation.gson;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.gson.GsonDecorator.DECORATE;
+import static datadog.trace.instrumentation.gson.GsonDecorator.GSON_FROM_JSON;
+
+import com.google.gson.Gson;
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import java.lang.reflect.Type;
+import net.bytebuddy.asm.Advice;
+
+public class GsonFromJsonAdvice {
+
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  public static AgentScope onEnter(
+      @Advice.Argument(0) final Object source, @Advice.Argument(1) final Object typeArg) {
+    final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(Gson.class);
+    if (callDepth > 0) {
+      return null;
+    }
+
+    final AgentSpan span = startSpan("gson", GSON_FROM_JSON);
+    DECORATE.afterStart(span);
+
+    if (typeArg instanceof Class) {
+      span.setTag("json.target.type", ((Class<?>) typeArg).getName());
+    } else if (typeArg instanceof Type) {
+      span.setTag("json.target.type", typeArg.toString());
+    }
+
+    return activateSpan(span);
+  }
+
+  @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+  public static void onExit(
+      @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
+    if (scope == null) {
+      return;
+    }
+
+    CallDepthThreadLocalMap.reset(Gson.class);
+
+    final AgentSpan span = scope.span();
+    if (throwable != null) {
+      DECORATE.onError(span, throwable);
+    }
+    DECORATE.beforeFinish(span);
+    scope.close();
+    span.finish();
+  }
+}

--- a/dd-java-agent/instrumentation/gson-2.1/src/main/java/datadog/trace/instrumentation/gson/GsonInstrumentation.java
+++ b/dd-java-agent/instrumentation/gson-2.1/src/main/java/datadog/trace/instrumentation/gson/GsonInstrumentation.java
@@ -1,0 +1,36 @@
+package datadog.trace.instrumentation.gson;
+
+import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
+
+import com.google.auto.service.AutoService;
+import datadog.trace.agent.tooling.Instrumenter;
+import datadog.trace.agent.tooling.InstrumenterModule;
+
+@AutoService(InstrumenterModule.class)
+public final class GsonInstrumentation extends InstrumenterModule.Tracing
+    implements Instrumenter.ForSingleType, Instrumenter.HasMethodAdvice {
+
+  public GsonInstrumentation() {
+    super("gson");
+  }
+
+  @Override
+  public String instrumentedType() {
+    return "com.google.gson.Gson";
+  }
+
+  @Override
+  public String[] helperClassNames() {
+    return new String[] {
+      packageName + ".GsonDecorator",
+      packageName + ".GsonToJsonAdvice",
+      packageName + ".GsonFromJsonAdvice",
+    };
+  }
+
+  @Override
+  public void methodAdvice(MethodTransformer transformer) {
+    transformer.applyAdvice(named("toJson"), packageName + ".GsonToJsonAdvice");
+    transformer.applyAdvice(named("fromJson"), packageName + ".GsonFromJsonAdvice");
+  }
+}

--- a/dd-java-agent/instrumentation/gson-2.1/src/main/java/datadog/trace/instrumentation/gson/GsonToJsonAdvice.java
+++ b/dd-java-agent/instrumentation/gson-2.1/src/main/java/datadog/trace/instrumentation/gson/GsonToJsonAdvice.java
@@ -1,0 +1,50 @@
+package datadog.trace.instrumentation.gson;
+
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.activateSpan;
+import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
+import static datadog.trace.instrumentation.gson.GsonDecorator.DECORATE;
+import static datadog.trace.instrumentation.gson.GsonDecorator.GSON_TO_JSON;
+
+import com.google.gson.Gson;
+import datadog.trace.bootstrap.CallDepthThreadLocalMap;
+import datadog.trace.bootstrap.instrumentation.api.AgentScope;
+import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
+import net.bytebuddy.asm.Advice;
+
+public class GsonToJsonAdvice {
+
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  public static AgentScope onEnter(@Advice.Argument(0) final Object src) {
+    final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(Gson.class);
+    if (callDepth > 0) {
+      return null;
+    }
+
+    final AgentSpan span = startSpan("gson", GSON_TO_JSON);
+    DECORATE.afterStart(span);
+
+    if (src != null) {
+      span.setTag("json.source.type", src.getClass().getName());
+    }
+
+    return activateSpan(span);
+  }
+
+  @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
+  public static void onExit(
+      @Advice.Enter final AgentScope scope, @Advice.Thrown final Throwable throwable) {
+    if (scope == null) {
+      return;
+    }
+
+    CallDepthThreadLocalMap.reset(Gson.class);
+
+    final AgentSpan span = scope.span();
+    if (throwable != null) {
+      DECORATE.onError(span, throwable);
+    }
+    DECORATE.beforeFinish(span);
+    scope.close();
+    span.finish();
+  }
+}

--- a/dd-java-agent/instrumentation/gson-2.1/src/test/groovy/datadog/trace/instrumentation/gson/GsonInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/gson-2.1/src/test/groovy/datadog/trace/instrumentation/gson/GsonInstrumentationTest.groovy
@@ -1,0 +1,332 @@
+import com.google.gson.Gson
+import com.google.gson.JsonIOException
+import com.google.gson.JsonSyntaxException
+import com.google.gson.TypeAdapter
+import com.google.gson.reflect.TypeToken
+import com.google.gson.stream.JsonWriter
+import datadog.trace.agent.test.InstrumentationSpecification
+import datadog.trace.bootstrap.instrumentation.api.Tags
+
+import java.io.StringReader
+import java.io.StringWriter
+
+class GsonInstrumentationTest extends InstrumentationSpecification {
+
+  def gson = new Gson()
+
+  def "test toJson creates a span"() {
+    when:
+    def result = gson.toJson(new TestObject("hello", 42))
+
+    then:
+    result != null
+    result.contains("hello")
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "gson.toJson"
+          spanType "json"
+          errored false
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "gson"
+            "$Tags.SPAN_KIND" "internal"
+            "json.source.type" TestObject.name
+          }
+        }
+      }
+    }
+  }
+
+  def "test fromJson with Class creates a span"() {
+    when:
+    def result = gson.fromJson('{"name":"hello","value":42}', TestObject)
+
+    then:
+    result != null
+    result.name == "hello"
+    result.value == 42
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "gson.fromJson"
+          spanType "json"
+          errored false
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "gson"
+            "$Tags.SPAN_KIND" "internal"
+            "json.target.type" TestObject.name
+          }
+        }
+      }
+    }
+  }
+
+  def "test fromJson with TypeToken creates a span"() {
+    setup:
+    def typeToken = new TypeToken<List<TestObject>>() {}
+
+    when:
+    def result = gson.fromJson('[{"name":"a","value":1},{"name":"b","value":2}]', typeToken.getType())
+
+    then:
+    result != null
+    result.size() == 2
+    result[0].name == "a"
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "gson.fromJson"
+          spanType "json"
+          errored false
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "gson"
+            "$Tags.SPAN_KIND" "internal"
+            "json.target.type" String
+          }
+        }
+      }
+    }
+  }
+
+  def "test nested toJson calls produce exactly one span"() {
+    setup:
+    def outer = new NestingObject(gson, new TestObject("nested", 99))
+    TEST_WRITER.waitForTraces(1)
+    TEST_WRITER.clear()
+
+    when:
+    def result = gson.toJson(outer)
+
+    then:
+    result != null
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "gson.toJson"
+          spanType "json"
+          errored false
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "gson"
+            "$Tags.SPAN_KIND" "internal"
+            "json.source.type" NestingObject.name
+          }
+        }
+      }
+    }
+  }
+
+  def "test nested fromJson calls produce exactly one span"() {
+    when:
+    def result = gson.fromJson('{"inner":{"name":"nested","value":99}}', OuterObject)
+
+    then:
+    result != null
+    result.inner != null
+    result.inner.name == "nested"
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "gson.fromJson"
+          spanType "json"
+          errored false
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "gson"
+            "$Tags.SPAN_KIND" "internal"
+            "json.target.type" OuterObject.name
+          }
+        }
+      }
+    }
+  }
+
+  def "test fromJson with malformed input sets error tags"() {
+    when:
+    gson.fromJson('{invalid json', TestObject)
+
+    then:
+    thrown(JsonSyntaxException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "gson.fromJson"
+          spanType "json"
+          errored true
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "gson"
+            "$Tags.SPAN_KIND" "internal"
+            "json.target.type" TestObject.name
+            errorTags(JsonSyntaxException, String)
+          }
+        }
+      }
+    }
+  }
+
+  def "test toJson with Type parameter creates a span"() {
+    setup:
+    def list = [new TestObject("a", 1), new TestObject("b", 2)]
+    def type = new TypeToken<List<TestObject>>() {}.getType()
+
+    when:
+    def result = gson.toJson(list, type)
+
+    then:
+    result != null
+    result.contains("a")
+    result.contains("b")
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "gson.toJson"
+          spanType "json"
+          errored false
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "gson"
+            "$Tags.SPAN_KIND" "internal"
+            "json.source.type" ArrayList.name
+          }
+        }
+      }
+    }
+  }
+
+  def "test fromJson with Reader creates a span"() {
+    setup:
+    def reader = new StringReader('{"name":"streamed","value":7}')
+
+    when:
+    def result = gson.fromJson(reader, TestObject)
+
+    then:
+    result != null
+    result.name == "streamed"
+    result.value == 7
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "gson.fromJson"
+          spanType "json"
+          errored false
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "gson"
+            "$Tags.SPAN_KIND" "internal"
+            "json.target.type" TestObject.name
+          }
+        }
+      }
+    }
+  }
+
+  def "test toJson with Appendable writes and creates a span"() {
+    setup:
+    def writer = new StringWriter()
+
+    when:
+    gson.toJson(new TestObject("buffered", 3), writer)
+
+    then:
+    def output = writer.toString()
+    output.contains("buffered")
+    output.contains("3")
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "gson.toJson"
+          spanType "json"
+          errored false
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "gson"
+            "$Tags.SPAN_KIND" "internal"
+            "json.source.type" TestObject.name
+          }
+        }
+      }
+    }
+  }
+
+  def "test toJson with failing serializer sets error tags"() {
+    setup:
+    def failingGson = new Gson()
+
+    when:
+    failingGson.toJson(new TestObject("ok", 1), new FailingAppendable())
+
+    then:
+    thrown(JsonIOException)
+    assertTraces(1) {
+      trace(1) {
+        span {
+          operationName "gson.toJson"
+          spanType "json"
+          errored true
+          tags {
+            defaultTags()
+            "$Tags.COMPONENT" "gson"
+            "$Tags.SPAN_KIND" "internal"
+            "json.source.type" TestObject.name
+            errorTags(JsonIOException, String)
+          }
+        }
+      }
+    }
+  }
+
+  static class TestObject {
+    String name
+    int value
+
+    TestObject() {}
+
+    TestObject(String name, int value) {
+      this.name = name
+      this.value = value
+    }
+  }
+
+  static class OuterObject {
+    TestObject inner
+
+    OuterObject() {}
+  }
+
+  /**
+   * Object whose serialization triggers a nested toJson call internally,
+   * used to verify the call-depth guard produces exactly one span.
+   */
+  static class NestingObject {
+    String preSerializedInner
+
+    NestingObject() {}
+
+    NestingObject(Gson gson, TestObject inner) {
+      // Pre-serialize the inner object — this triggers a nested Gson.toJson() call
+      this.preSerializedInner = gson.toJson(inner)
+    }
+  }
+
+  static class FailingAppendable implements Appendable {
+    @Override
+    Appendable append(CharSequence csq) throws IOException {
+      throw new IOException("Simulated write failure")
+    }
+
+    @Override
+    Appendable append(CharSequence csq, int start, int end) throws IOException {
+      throw new IOException("Simulated write failure")
+    }
+
+    @Override
+    Appendable append(char c) throws IOException {
+      throw new IOException("Simulated write failure")
+    }
+  }
+}

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -6340,6 +6340,22 @@
         "aliases": ["DD_INTEGRATION_GRPC_SERVER_MATCHING_SHORTCUT_ENABLED"]
       }
     ],
+    "DD_TRACE_GSON_ANALYTICS_ENABLED": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "false",
+        "aliases": ["DD_GSON_ANALYTICS_ENABLED"]
+      }
+    ],
+    "DD_TRACE_GSON_ANALYTICS_SAMPLE_RATE": [
+      {
+        "version": "A",
+        "type": "decimal",
+        "default": "1.0",
+        "aliases": ["DD_GSON_ANALYTICS_SAMPLE_RATE"]
+      }
+    ],
     "DD_TRACE_GSON_ENABLED": [
       {
         "version": "A",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -380,6 +380,7 @@ include(
   ":dd-java-agent:instrumentation:grizzly:grizzly-http-2.3.20",
   ":dd-java-agent:instrumentation:grpc-1.5",
   ":dd-java-agent:instrumentation:gson-1.6",
+  ":dd-java-agent:instrumentation:gson-2.1",
   ":dd-java-agent:instrumentation:guava-10.0",
   ":dd-java-agent:instrumentation:guidewire-10.0",
   ":dd-java-agent:instrumentation:hazelcast:hazelcast-3.6",


### PR DESCRIPTION
## Summary

- Adds tracing instrumentation for Gson's `Gson.toJson`/`Gson.fromJson` serialization API — produces `gson.toJson` / `gson.fromJson` spans (`span.type=json`) with `json.source.type` / `json.target.type` tags identifying the concrete type being serialized/deserialized.
- A call-depth guard (`CallDepthThreadLocalMap` keyed on `Gson.class`) ensures nested/recursive `toJson`/`fromJson` calls (e.g. serializing an object graph) produce exactly one span, not one per recursive descent.
- New module lives at `dd-java-agent/instrumentation/gson-2.1/`, separate from the existing `gson-1.6/` module (which is IAST-only taint-tracking, unrelated to tracing) — no collision or edits to that module.

## Context

This is an AI-generated integration produced by Datadog's internal APM Instrumentation Toolkit (`apm-ai-toolkit`), evaluating a net-new "serialization" instrumentation category. No tracing module previously existed for Gson on `master`.

## Test plan

- [x] `GsonInstrumentationTest.groovy` (Spock/Groovy, matching repo convention): 10/10 tests passing — covers `toJson`/`fromJson` basic spans, `TypeToken`/`Type` overloads, `Reader`/`Appendable` streaming variants, nested-call single-span assertions, and error-tagging on malformed input / failing serializers.
- [x] Muzzle validation passes for Gson versions 2.1 through 2.14.0.
- [ ] Maintainer review of span/tag naming conventions and category placement.

🤖 Generated with the APM Instrumentation Toolkit
