### PR TITLE
Use Prince of Space

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,13 +51,13 @@ docs/                     Developer documentation (see below)
 ./gradlew :dd-java-agent:shadowJar        # Build agent jar only (dd-java-agent/build/libs/)
 ./gradlew :path:to:module:test            # Run tests for a specific module
 ./gradlew :path:to:module:test -PtestJvm=11  # Test on a specific JVM version
-./gradlew spotlessApply                   # Auto-format code (google-java-format)
+./gradlew spotlessApply                   # Auto-format code (Prince of Space)
 ./gradlew spotlessCheck                   # Verify formatting
 ```
 
 ## Code conventions
 
-- **Formatting**: google-java-format enforced via Spotless. Run `./gradlew spotlessApply` before committing.
+- **Formatting**: Prince of Space enforced via Spotless. Run `./gradlew spotlessApply` before committing.
 - **Static imports**: Prefer static imports over class-qualified calls for call-style helpers, in both test (Assertions.assertEquals, Mockito.mock) and production code (Collections.emptyList). Wildcard imports disallowed — see CONTRIBUTING.md.
 - **Documentation**: Use concise Javadoc comments (`/** ... */`) for class, method, and field documentation.
 - **Instrumentation layout**: `dd-java-agent/instrumentation/{framework}/{framework}-{minVersion}/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,9 @@ We have automatic code formatting enabled in Gradle configuration using [Spotles
 Our main goal is to avoid extensive reformatting caused by different IDEs with different opinions about how things should
 be formatted by establishing a single _point of truth_.
 
+Java sources use [Prince of Space](https://github.com/agustafson/prince-of-space) with two-space indentation and a
+100-character line width.
+
 To reformat all the files that need reformatting:
 
 ```bash
@@ -55,13 +58,15 @@ For IntelliJ IDEA, we suggest the following settings and plugin.
     * `Use single class import`: checked
     * `Class count to use import with '*'`: `9999` (some number sufficiently large that is unlikely to matter)
     * `Names count to use static import with '*'`: `9999`
-    * Use the following import layout to ensure consistency with google-java-format:
+    * Use the following import layout:
       ![import layout](https://user-images.githubusercontent.com/734411/43430811-28442636-94ae-11e8-86f1-f270ddcba023.png)
   * top right Settings icon -> `Settings...` ->`Editor` > `Code Style` > `Groovy` > `Imports`
     * `Class count to use import with '*'`: `9999` (some number sufficiently large that is unlikely to matter)
     * `Names count to use static import with '*'`: `9999`
 * To run test in a specific JDK use the `testJvm` property, e.g. `-PtestJvm=11`
-* Install the [Google Java Format](https://plugins.jetbrains.com/plugin/8527-google-java-format) plugin
+* Install the [Prince of Space](https://github.com/agustafson/prince-of-space/releases) IntelliJ plugin from its release ZIP
+  * Under `Settings` > `Tools` > `Prince of Space`, use a two-space indent, a 100-character line length, balanced wrapping,
+    no trailing commas, no closing parenthesis on a new line, and the project language level
 
 ### Static imports
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,6 @@ with(extensions["spotlessPredeclare"] as SpotlessExtension) {
     princeOfSpace(libs.versions.prince.of.space.get())
       .indentSize(2)
       .lineLength(100)
-      .closingParenOnNewLine(false)
       .javaLanguageLevel(25)
     trimTrailingWhitespace()
     tableTestFormatter(libs.versions.tabletest.formatter.get())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,11 @@ with(extensions["spotlessPredeclare"] as SpotlessExtension) {
     removeUnusedImports()
     forbidWildcardImports()
 
-    googleJavaFormat(libs.versions.google.java.format.get())
+    princeOfSpace(libs.versions.prince.of.space.get())
+      .indentSize(2)
+      .lineLength(100)
+      .closingParenOnNewLine(false)
+      .javaLanguageLevel(25)
     tableTestFormatter(libs.versions.tabletest.formatter.get())
   }
   groovyGradle {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ with(extensions["spotlessPredeclare"] as SpotlessExtension) {
       .lineLength(100)
       .closingParenOnNewLine(false)
       .javaLanguageLevel(25)
+    trimTrailingWhitespace()
     tableTestFormatter(libs.versions.tabletest.formatter.get())
   }
   groovyGradle {

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -22,7 +22,11 @@ spotless {
     targetExclude("src/test/resources/**")
     removeUnusedImports()
     forbidWildcardImports()
-    googleJavaFormat(libs.versions.google.java.format.get())
+    princeOfSpace(libs.versions.prince.of.space.get())
+      .indentSize(2)
+      .lineLength(100)
+      .closingParenOnNewLine(false)
+      .javaLanguageLevel(25)
   }
 }
 

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -25,7 +25,6 @@ spotless {
     princeOfSpace(libs.versions.prince.of.space.get())
       .indentSize(2)
       .lineLength(100)
-      .closingParenOnNewLine(false)
       .javaLanguageLevel(25)
     trimTrailingWhitespace()
   }

--- a/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
+++ b/buildSrc/call-site-instrumentation-plugin/build.gradle.kts
@@ -27,6 +27,7 @@ spotless {
       .lineLength(100)
       .closingParenOnNewLine(false)
       .javaLanguageLevel(25)
+    trimTrailingWhitespace()
   }
 }
 

--- a/buildSrc/modifiable-config-agent/build.gradle.kts
+++ b/buildSrc/modifiable-config-agent/build.gradle.kts
@@ -18,7 +18,11 @@ spotless {
     targetExclude("src/test/resources/**")
     removeUnusedImports()
     forbidWildcardImports()
-    googleJavaFormat(libs.versions.google.java.format.get())
+    princeOfSpace(libs.versions.prince.of.space.get())
+      .indentSize(2)
+      .lineLength(100)
+      .closingParenOnNewLine(false)
+      .javaLanguageLevel(25)
   }
 }
 

--- a/buildSrc/modifiable-config-agent/build.gradle.kts
+++ b/buildSrc/modifiable-config-agent/build.gradle.kts
@@ -23,6 +23,7 @@ spotless {
       .lineLength(100)
       .closingParenOnNewLine(false)
       .javaLanguageLevel(25)
+    trimTrailingWhitespace()
   }
 }
 

--- a/buildSrc/modifiable-config-agent/build.gradle.kts
+++ b/buildSrc/modifiable-config-agent/build.gradle.kts
@@ -21,7 +21,6 @@ spotless {
     princeOfSpace(libs.versions.prince.of.space.get())
       .indentSize(2)
       .lineLength(100)
-      .closingParenOnNewLine(false)
       .javaLanguageLevel(25)
     trimTrailingWhitespace()
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ shadow = "9.4.2"
 spotbugs_annotations = "4.10.3"
 
 # Source code formatters
-google-java-format = "1.36.1"
+prince-of-space = "2.2.0"
 greclipse = "4.27" # Pinned. See: https://github.com/diffplug/spotless/issues/3013
 ktlint = "1.8.0"
 scalafmt = "3.11.5"

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -49,7 +49,11 @@ spotless {
       targetExclude('src/test/resources/**', buildDirectory)
       removeUnusedImports()
       forbidWildcardImports()
-      googleJavaFormat(libs.versions.google.java.format.get())
+      princeOfSpace(libs.versions.prince.of.space.get())
+        .indentSize(2)
+        .lineLength(100)
+        .closingParenOnNewLine(false)
+        .javaLanguageLevel(25)
       tableTestFormatter(libs.versions.tabletest.formatter.get())
     }
   }

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -60,7 +60,6 @@ spotless {
       princeOfSpace(libs.versions.prince.of.space.get())
         .indentSize(2)
         .lineLength(100)
-        .closingParenOnNewLine(false)
         .javaLanguageLevel(25)
       trimTrailingWhitespace()
       tableTestFormatter(libs.versions.tabletest.formatter.get())

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -46,7 +46,15 @@ spotless {
       // set explicit target to workaround https://github.com/diffplug/spotless/issues/1163
       target 'src/**/*.java'
       // ignore embedded test projects and everything in build dir, e.g. generated sources
-      targetExclude('src/test/resources/**', buildDirectory)
+      // Prince of Space 2.2.0 does not preserve this toggle fence and conflicts with TableTest formatting.
+      targetExclude(
+        'src/test/resources/**',
+        '**/CiVisibilityCountMetric.java',
+        '**/ClientIpAddressResolver.java',
+        '**/RumInjectorConfigTest.java',
+        '**/TagInterceptorTest.java',
+        '**/TraceStructureWriterTest.java',
+        buildDirectory)
       removeUnusedImports()
       forbidWildcardImports()
       princeOfSpace(libs.versions.prince.of.space.get())
@@ -54,6 +62,7 @@ spotless {
         .lineLength(100)
         .closingParenOnNewLine(false)
         .javaLanguageLevel(25)
+      trimTrailingWhitespace()
       tableTestFormatter(libs.versions.tabletest.formatter.get())
     }
   }

--- a/test-published-dependencies/build.gradle.kts
+++ b/test-published-dependencies/build.gradle.kts
@@ -40,7 +40,6 @@ allprojects {
         princeOfSpace(libs.versions.prince.of.space.get())
           .indentSize(2)
           .lineLength(100)
-          .closingParenOnNewLine(false)
           .javaLanguageLevel(25)
         trimTrailingWhitespace()
       }

--- a/test-published-dependencies/build.gradle.kts
+++ b/test-published-dependencies/build.gradle.kts
@@ -42,6 +42,7 @@ allprojects {
           .lineLength(100)
           .closingParenOnNewLine(false)
           .javaLanguageLevel(25)
+        trimTrailingWhitespace()
       }
     }
   }

--- a/test-published-dependencies/build.gradle.kts
+++ b/test-published-dependencies/build.gradle.kts
@@ -37,7 +37,11 @@ allprojects {
         target("src/**/*.java")
         removeUnusedImports()
         forbidWildcardImports()
-        googleJavaFormat(libs.versions.google.java.format.get())
+        princeOfSpace(libs.versions.prince.of.space.get())
+          .indentSize(2)
+          .lineLength(100)
+          .closingParenOnNewLine(false)
+          .javaLanguageLevel(25)
       }
     }
   }


### PR DESCRIPTION
# What Does This Do

Switches every Spotless Java configuration from google-java-format 1.36.1 to Prince of Space 2.2.0.
It keeps the repository's two-space indentation and 100-character line width, targets Java 25 syntax, uses Prince's default closing-delimiter placement, and updates the contributor and agent guides.

## Representative Formatting Changes

### Lambda Pipelines

[`PluginApplication.java`](https://github.com/DataDog/dd-trace-java/blob/bdu/reformat-with-prince-of-space/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/PluginApplication.java)

```diff
-        Extension.EXTENSIONS.stream()
-            .filter(ext -> ext.appliesTo(spec))
-            .forEach(
-                ext -> {
+        Extension.EXTENSIONS
+          .stream()
+          .filter(ext -> ext.appliesTo(spec))
+          .forEach(ext -> {
```

### Fluent Calls

[`AdviceGeneratorImpl.java`](https://github.com/DataDog/dd-trace-java/blob/bdu/reformat-with-prince-of-space/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/impl/AdviceGeneratorImpl.java)

```diff
-      final List<Expression> helperTypes =
-          Arrays.stream(helpers)
-              .map(type -> new StringLiteralExpr(type.getClassName()))
-              .collect(Collectors.toList());
+      final List<Expression> helperTypes = Arrays
+        .stream(helpers)
+        .map(type -> new StringLiteralExpr(type.getClassName()))
+        .collect(Collectors.toList());
```

### Nested Callbacks

[`CoreTracer.java`](https://github.com/DataDog/dd-trace-java/blob/bdu/reformat-with-prince-of-space/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java)

```diff
-    sharedCommunicationObjects.whenReady(
-        () ->
-            AgentTaskScheduler.get()
-                .execute(
-                    () -> {
-                      startMetricsAggregation(config, sco);
-                      maybeStartLogsExport(config);
-                    }));
+    sharedCommunicationObjects.whenReady(() -> AgentTaskScheduler.get().execute(() -> {
+      startMetricsAggregation(config, sco);
+      maybeStartLogsExport(config);
+    }));
```

### Nested Lambda Pipelines

[`AssertBuilder.java`](https://github.com/DataDog/dd-trace-java/blob/bdu/reformat-with-prince-of-space/buildSrc/call-site-instrumentation-plugin/src/test/java/datadog/trace/plugin/csi/impl/assertion/AssertBuilder.java)

```diff
-    return type.getAnnotationByName("AutoService")
-        .<Set<Class<?>>>map(
-            annotation ->
-                annotation.asNormalAnnotationExpr().getPairs().stream()
-                    .filter(pair -> pair.getNameAsString().equals("value"))
-                    .flatMap(
-                        pair ->
-                            pair.getValue().asArrayInitializerExpr().getValues().stream()
+    return type
+      .getAnnotationByName("AutoService")
+      .<Set<Class<?>>>map(annotation -> annotation
+        .asNormalAnnotationExpr()
+        .getPairs()
+        .stream()
+        .filter(pair -> pair.getNameAsString().equals("value"))
+        .flatMap(pair -> pair
+          .getValue()
+          .asArrayInitializerExpr()
+          .getValues()
+          .stream()
```

### Balanced Parameter Wrapping

The experiment uses Prince's default `balanced` wrap style. Once this signature exceeds the 100-column target, every parameter moves to its own line.

[`PluginApplication.java`](https://github.com/DataDog/dd-trace-java/blob/bdu/reformat-with-prince-of-space/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/PluginApplication.java)

```diff
   private static void printReport(
-      final Configuration configuration, final List<CallSiteResult> result, final boolean failed) {
+      final Configuration configuration,
+      final List<CallSiteResult> result,
+      final boolean failed
+  ) {
```

### Mandatory Braces

Prince adds braces to single-statement control flow.

[`CoreTracer.java`](https://github.com/DataDog/dd-trace-java/blob/bdu/reformat-with-prince-of-space/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java)

```diff
-      if (this.inUse) return false;
+      if (this.inUse) {
+        return false;
+      }
```

### Javadoc Normalization

One-line Javadocs are expanded into canonical multiline form.

[`CoreTracer.java`](https://github.com/DataDog/dd-trace-java/blob/bdu/reformat-with-prince-of-space/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java)

```diff
-  /** Tracer start time in nanoseconds measured up to a millisecond accuracy */
+  /**
+   * Tracer start time in nanoseconds measured up to a millisecond accuracy
+   */
```

### Inline Comment Placement

Inline argument comments are moved to their own line after the argument.

[`CoreTracer.java`](https://github.com/DataDog/dd-trace-java/blob/bdu/reformat-with-prince-of-space/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java)

```diff
-          null /* serviceName */,
+          null,
+          /* serviceName */
```

### Import Separation

Prince removes the blank line between static and regular imports.

[`PluginApplication.java`](https://github.com/DataDog/dd-trace-java/blob/bdu/reformat-with-prince-of-space/buildSrc/call-site-instrumentation-plugin/src/main/java/datadog/trace/plugin/csi/PluginApplication.java)

```diff
 import static datadog.trace.plugin.csi.impl.CallSiteFactory.typeResolver;
-
 import datadog.trace.plugin.csi.AdviceGenerator.CallSiteResult;
```

Balanced parameter wrapping is configurable through `wrapStyle` and `lineLength`, while `closingParenOnNewLine` controls the closing delimiter and is left at Prince's `true` default here. The `wide` style packs more parameters onto continuation lines. Braces, Javadoc normalization, inline comment placement, and import separation are not public options.

### Switch Blocks Stay Unchanged

Unlike Palantir, Prince of Space keeps the existing layout in [`JsonToExpressionConverter.java`](https://github.com/DataDog/dd-trace-java/blob/bdu/reformat-with-prince-of-space/dd-java-agent/agent-debugger/debugger-el/src/main/java/com/datadog/debugger/el/JsonToExpressionConverter.java):

```java
case "not":
  {
    JsonReader.Token token = reader.peek();
```

# Motivation

Evaluate Prince of Space against the same repository snapshot and representative code used by the Palantir experiment. The explicit options keep the comparison focused on layout rather than changing indentation and line width at the same time.

# Additional Notes

This is the base of a two-PR draft experiment. The stacked reformatting PR is #12445.

> [!CAUTION]
> Prince of Space 2.2.0 cannot safely format this code yet, see the stacked PR for changes:
> 
> - 5 files are excluded because the formatter does not converge or does not preserve existing Spotless and TableTest fences;
> - Some `String` literal values are incorrectly changed in 95 files, including regular expressions, JSON, tabs, and Unicode escapes

I opened some PRs to fix encountered issues
* https://github.com/agustafson/prince-of-space/pull/89
* https://github.com/agustafson/prince-of-space/pull/90
* https://github.com/agustafson/prince-of-space/pull/91

> [!NOTE]
> An IntelliJ plugin exists from but it's not in the Jetbrains Marketplace. Instead, it's released as a Zip on the PoS releases.

Finally, here's the Palantir related stacked PRs

* #12421
* #12422

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR
