### PR TITLE
Strip injected _datadog context from EventBridge event payloads

### DIFF
--- a/dd-java-agent/instrumentation/aws-java/aws-java-lambda-handler-1.2/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-lambda-handler-1.2/src/main/java/datadog/trace/instrumentation/aws/v1/lambda/LambdaHandlerInstrumentation.java
@@ -18,6 +18,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.google.auto.service.AutoService;
 import datadog.trace.agent.tooling.Instrumenter;
 import datadog.trace.agent.tooling.InstrumenterModule;
+import datadog.trace.api.Config;
 import datadog.trace.bootstrap.CallDepthThreadLocalMap;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
@@ -26,6 +27,7 @@ import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
 import datadog.trace.bootstrap.instrumentation.api.InternalSpanTypes;
 import datadog.trace.bootstrap.instrumentation.api.ResourceNamePriorities;
 import datadog.trace.config.inversion.ConfigHelper;
+import java.io.InputStream;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -82,7 +84,7 @@ public class LambdaHandlerInstrumentation extends InstrumenterModule.Tracing
     @OnMethodEnter
     static AgentScope enter(
         @This final Object that,
-        @Advice.Argument(0) final Object in,
+        @Advice.Argument(value = 0, readOnly = false) InputStream in,
         @Advice.Argument(1) final Object out,
         @Advice.Argument(2) final Context awsContext,
         @Origin("#m") final String methodName) {
@@ -92,6 +94,15 @@ public class LambdaHandlerInstrumentation extends InstrumenterModule.Tracing
       }
       String lambdaRequestId = awsContext.getAwsRequestId();
       AgentSpanContext lambdaContext = AgentTracer.get().notifyLambdaStart(in, lambdaRequestId);
+
+      // Skip the strip pass entirely (extra read/parse/re-serialize) unless explicitly enabled.
+      if (Config.get().isLambdaStripInjectedContextEnabled()) {
+        InputStream stripped = AgentTracer.get().stripLambdaInjectedContext(in);
+        if (stripped != null) {
+          in = stripped;
+        }
+      }
+
       final AgentSpan span;
       if (null == lambdaContext) {
         span = startSpan("java-aws-sdk", INVOCATION_SPAN_NAME);

--- a/dd-java-agent/instrumentation/aws-java/aws-java-lambda-handler-1.2/src/test/java/LambdaHandlerInstrumentationTest.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-lambda-handler-1.2/src/test/java/LambdaHandlerInstrumentationTest.java
@@ -15,9 +15,11 @@ import com.amazonaws.services.lambda.runtime.ClientContext;
 import com.amazonaws.services.lambda.runtime.CognitoIdentity;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import datadog.trace.agent.test.AbstractInstrumentationTest;
 import datadog.trace.api.DDSpanTypes;
 import datadog.trace.api.DDTags;
+import datadog.trace.api.config.GeneralConfig;
 import datadog.trace.api.function.TriConsumer;
 import datadog.trace.api.function.TriFunction;
 import datadog.trace.api.gateway.Flow;
@@ -33,6 +35,8 @@ import datadog.trace.test.junit.utils.config.WithConfig;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -572,6 +576,46 @@ abstract class LambdaHandlerInstrumentationTest extends AbstractInstrumentationT
                     defaultTags(),
                     tag("request_id", is(REQUEST_ID)),
                     error(Error.class, "Some error"))));
+  }
+
+  @WithConfig(key = GeneralConfig.LAMBDA_STRIP_INJECTED_CONTEXT, value = "true")
+  @Test
+  void stripsInjectedDatadogContextFromEventBridgeDetail() throws IOException {
+    String eventJson =
+        "{"
+            + "\"detail-type\": \"order.created\","
+            + "\"detail\": {"
+            + "  \"orderId\": 42,"
+            + "  \"_datadog\": {\"x-datadog-trace-id\": \"123\"}"
+            + "}"
+            + "}";
+
+    ByteArrayInputStream input =
+        new ByteArrayInputStream(eventJson.getBytes(StandardCharsets.UTF_8));
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+    class CapturingHandler implements RequestStreamHandler {
+      String capturedBody;
+
+      @Override
+      public void handleRequest(InputStream in, OutputStream out, Context context)
+          throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        byte[] chunk = new byte[8192];
+        int n;
+        while ((n = in.read(chunk)) != -1) {
+          buffer.write(chunk, 0, n);
+        }
+        capturedBody = new String(buffer.toByteArray(), StandardCharsets.UTF_8);
+        out.write("{}".getBytes(StandardCharsets.UTF_8));
+      }
+    }
+
+    CapturingHandler handler = new CapturingHandler();
+    handler.handleRequest(input, output, newContext());
+
+    assertFalse(handler.capturedBody.contains("_datadog"));
+    assertTrue(handler.capturedBody.contains("\"orderId\":42"));
   }
 
   private static final class TestContext implements Context {

--- a/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/ConfigDefaults.java
@@ -341,6 +341,8 @@ public final class ConfigDefaults {
   static final boolean DEFAULT_WEBSOCKET_MESSAGES_SEPARATE_TRACES = true;
   static final boolean DEFAULT_WEBSOCKET_TAG_SESSION_ID = false;
 
+  static final boolean DEFAULT_LAMBDA_STRIP_INJECTED_CONTEXT = false;
+
   static final Set<String> DEFAULT_TRACE_CLOUD_PAYLOAD_TAGGING_SERVICES =
       new HashSet<>(
           Arrays.asList(

--- a/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/config/GeneralConfig.java
@@ -140,5 +140,7 @@ public final class GeneralConfig {
   public static final String INSTRUMENTATION_SOURCE = "instrumentation.source";
   public static final String APP_LOGS_COLLECTION_ENABLED = "app.logs.collection.enabled";
 
+  public static final String LAMBDA_STRIP_INJECTED_CONTEXT = "lambda.strip.injected.context";
+
   private GeneralConfig() {}
 }

--- a/dd-trace-core/src/jmh/java/datadog/trace/lambda/StripInjectedContextBenchmark.java
+++ b/dd-trace-core/src/jmh/java/datadog/trace/lambda/StripInjectedContextBenchmark.java
@@ -1,0 +1,48 @@
+package datadog.trace.lambda;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.nio.charset.StandardCharsets;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 5, timeUnit = SECONDS)
+@Measurement(iterations = 3, time = 5, timeUnit = SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(MICROSECONDS)
+@Fork(value = 1)
+public class StripInjectedContextBenchmark {
+
+  @Param({"true", "false"})
+  boolean containsDatadogCarrier;
+
+  byte[] payload;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    String detail =
+        containsDatadogCarrier
+            ? "{\"orderId\":42,\"customer\":\"acme\",\"_datadog\":{\"x-datadog-trace-id\":\"123\",\"x-datadog-parent-id\":\"456\"}}"
+            : "{\"orderId\":42,\"customer\":\"acme\"}";
+    String envelope = "{\"detail-type\":\"order.created\",\"detail\":" + detail + "}";
+    payload = envelope.getBytes(StandardCharsets.UTF_8);
+  }
+
+  @Benchmark
+  public void stripInternal(Blackhole blackhole) {
+    blackhole.consume(StripInjectedContext.stripInternal(payload));
+  }
+}

--- a/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/CoreTracer.java
@@ -116,8 +116,10 @@ import datadog.trace.core.taginterceptor.TagInterceptor;
 import datadog.trace.core.traceinterceptor.LatencyTraceInterceptor;
 import datadog.trace.lambda.LambdaAppSecHandler;
 import datadog.trace.lambda.LambdaHandler;
+import datadog.trace.lambda.StripInjectedContext;
 import datadog.trace.util.AgentTaskScheduler;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -1289,6 +1291,11 @@ public class CoreTracer implements AgentTracer.TracerAPI, TracerFlare.Reporter {
   public void notifyAppSecEnd(AgentSpan span, Object result) {
     LambdaAppSecHandler.processResponseData(span, result);
     LambdaAppSecHandler.processRequestEnd(span);
+  }
+
+  @Override
+  public InputStream stripLambdaInjectedContext(InputStream in) {
+    return StripInjectedContext.replaceInputStream(in);
   }
 
   @Override

--- a/dd-trace-core/src/main/java/datadog/trace/lambda/StripInjectedContext.java
+++ b/dd-trace-core/src/main/java/datadog/trace/lambda/StripInjectedContext.java
@@ -1,0 +1,239 @@
+package datadog.trace.lambda;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonReader;
+import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.Moshi;
+import com.squareup.moshi.Types;
+import datadog.trace.api.Config;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Strips the injected "_datadog" trace carrier from a Lambda event's "detail" field before the user
+ * handler runs, when {@code DD_LAMBDA_STRIP_INJECTED_CONTEXT} is enabled. Fail-open: any error or
+ * invalid result returns the original payload unchanged.
+ */
+public final class StripInjectedContext {
+
+  private static final Logger log = LoggerFactory.getLogger(StripInjectedContext.class);
+
+  private static final String DETAIL_FIELD = "detail";
+  private static final String DATADOG_CARRIER_KEY = "_datadog";
+
+  // Custom Object adapter preserves Long (not Double) for whole numbers and key order via
+  // LinkedHashMap, so re-serializing the envelope doesn't corrupt untouched fields.
+  private static final Moshi MOSHI =
+      new Moshi.Builder().add(Object.class, new NumberPreservingObjectAdapter()).build();
+
+  private static final Type STRING_OBJECT_MAP_TYPE =
+      Types.newParameterizedType(Map.class, String.class, Object.class);
+
+  @SuppressWarnings("unchecked")
+  private static final JsonAdapter<Map<String, Object>> MAP_ADAPTER =
+      (JsonAdapter<Map<String, Object>>) (JsonAdapter<?>) MOSHI.adapter(STRING_OBJECT_MAP_TYPE);
+
+  private StripInjectedContext() {}
+
+  /** Reads {@code in} fully, strips "_datadog", and returns a new stream over the result. */
+  public static ByteArrayInputStream replaceInputStream(InputStream in) {
+    if (in == null) {
+      return null;
+    }
+    try {
+      return new ByteArrayInputStream(strip(readAllBytes(in)));
+    } catch (IOException e) {
+      log.debug("Unable to read Lambda payload for _datadog stripping", e);
+      return null;
+    }
+  }
+
+  /** Strips "_datadog" from {@code payload}'s "detail" field when the config is enabled. */
+  public static byte[] strip(byte[] payload) {
+    if (!Config.get().isLambdaStripInjectedContextEnabled()) {
+      return payload;
+    }
+    return stripInternal(payload);
+  }
+
+  /** Unconditional strip logic, package-private so tests can call it directly. */
+  static byte[] stripInternal(byte[] payload) {
+    if (payload == null || payload.length == 0) {
+      return payload;
+    }
+
+    // Fast path: skip JSON parsing when there's clearly nothing to strip.
+    String json = new String(payload, StandardCharsets.UTF_8);
+    if (!json.contains(DATADOG_CARRIER_KEY)) {
+      return payload;
+    }
+
+    try {
+      Map<String, Object> envelope = MAP_ADAPTER.fromJson(json);
+      if (envelope == null || !envelope.containsKey(DETAIL_FIELD)) {
+        return payload;
+      }
+
+      Object strippedDetail = stripDetail(envelope.get(DETAIL_FIELD));
+      if (strippedDetail == null) {
+        return payload; // no "_datadog" found in detail
+      }
+
+      envelope.put(DETAIL_FIELD, strippedDetail);
+      return MAP_ADAPTER.toJson(envelope).getBytes(StandardCharsets.UTF_8);
+    } catch (IOException | RuntimeException e) {
+      // Fail open: stripping must never break the handler invocation.
+      log.debug("Unable to strip injected _datadog context from Lambda payload", e);
+      return payload;
+    }
+  }
+
+  /** Removes "_datadog" from an object or string-encoded detail value. Null if unchanged. */
+  @SuppressWarnings("unchecked")
+  private static Object stripDetail(Object detail) {
+    // Object detail: "detail": {"foo": "bar", "_datadog": {...}}
+    if (detail instanceof Map) {
+      Map<String, Object> detailMap = (Map<String, Object>) detail;
+      return detailMap.remove(DATADOG_CARRIER_KEY) != null ? detailMap : null;
+    }
+    // String-encoded detail: "detail": "{\"foo\":\"bar\",\"_datadog\":{...}}"
+    if (detail instanceof String) {
+      return stripFromJsonString((String) detail);
+    }
+    return null;
+  }
+
+  /** Parses, strips "_datadog", and re-encodes a JSON-object-shaped string. Null if unchanged. */
+  private static String stripFromJsonString(String value) {
+    if (!value.contains(DATADOG_CARRIER_KEY)) {
+      return null;
+    }
+    try {
+      Map<String, Object> inner = MAP_ADAPTER.fromJson(value);
+      if (inner == null || inner.remove(DATADOG_CARRIER_KEY) == null) {
+        return null;
+      }
+      return MAP_ADAPTER.toJson(inner);
+    } catch (IOException | RuntimeException e) {
+      return null;
+    }
+  }
+
+  /** Reads all bytes from {@code in}, restoring its position first if it's a byte stream. */
+  private static byte[] readAllBytes(InputStream in) throws IOException {
+    if (in instanceof ByteArrayInputStream) {
+      // mark/reset instead of draining, in case the stream is read again elsewhere.
+      ByteArrayInputStream bais = (ByteArrayInputStream) in;
+      bais.mark(Integer.MAX_VALUE);
+      byte[] bytes = new byte[bais.available()];
+      int read = bais.read(bytes);
+      bais.reset();
+      return (read == bytes.length) ? bytes : Arrays.copyOf(bytes, Math.max(read, 0));
+    }
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    byte[] chunk = new byte[8192];
+    int n;
+    while ((n = in.read(chunk)) != -1) {
+      buffer.write(chunk, 0, n);
+    }
+    return buffer.toByteArray();
+  }
+
+  /** Object adapter that keeps whole numbers as {@link Long} and preserves key order. */
+  private static final class NumberPreservingObjectAdapter extends JsonAdapter<Object> {
+
+    /** Recursively reads a JSON value, mapping numbers to Long/Double based on their form. */
+    @Override
+    public Object fromJson(JsonReader reader) throws IOException {
+      switch (reader.peek()) {
+        case BEGIN_ARRAY:
+          List<Object> list = new ArrayList<>();
+          reader.beginArray();
+          while (reader.hasNext()) {
+            list.add(fromJson(reader));
+          }
+          reader.endArray();
+          return list;
+
+        case BEGIN_OBJECT:
+          Map<String, Object> map = new LinkedHashMap<>();
+          reader.beginObject();
+          while (reader.hasNext()) {
+            map.put(reader.nextName(), fromJson(reader));
+          }
+          reader.endObject();
+          return map;
+
+        case STRING:
+          return reader.nextString();
+
+        case NUMBER:
+          return readNumber(reader);
+
+        case BOOLEAN:
+          return reader.nextBoolean();
+
+        case NULL:
+          return reader.nextNull();
+
+        default:
+          throw new IOException("Unexpected JSON token: " + reader.peek());
+      }
+    }
+
+    /** Returns Long for integer literals, Double for fractional/scientific ones. */
+    private Object readNumber(JsonReader reader) throws IOException {
+      String literal = reader.nextString(); // raw text avoids precision loss before parsing
+      if (literal.indexOf('.') >= 0 || literal.indexOf('e') >= 0 || literal.indexOf('E') >= 0) {
+        return Double.parseDouble(literal);
+      }
+      try {
+        return Long.parseLong(literal);
+      } catch (NumberFormatException tooLargeForLong) {
+        return Double.parseDouble(literal);
+      }
+    }
+
+    /** Recursively writes a value produced by {@link #fromJson}. */
+    @Override
+    public void toJson(JsonWriter writer, Object value) throws IOException {
+      if (value instanceof Map) {
+        writer.beginObject();
+        for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+          writer.name(String.valueOf(entry.getKey()));
+          toJson(writer, entry.getValue());
+        }
+        writer.endObject();
+      } else if (value instanceof List) {
+        writer.beginArray();
+        for (Object item : (List<?>) value) {
+          toJson(writer, item);
+        }
+        writer.endArray();
+      } else if (value instanceof String) {
+        writer.value((String) value);
+      } else if (value instanceof Long) {
+        writer.value(((Long) value).longValue());
+      } else if (value instanceof Number) {
+        writer.value((Number) value);
+      } else if (value instanceof Boolean) {
+        writer.value((Boolean) value);
+      } else if (value == null) {
+        writer.nullValue();
+      } else {
+        throw new IOException("Unsupported value type: " + value.getClass());
+      }
+    }
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/StripInjectedContextFuzzTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/StripInjectedContextFuzzTest.java
@@ -1,0 +1,101 @@
+package datadog.trace.lambda;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Randomized invariant testing for {@link StripInjectedContext}, mirroring the repo's existing
+ * fuzz-style test pattern (see {@code TagMapFuzzTest}). Generates many random EventBridge-shaped
+ * payloads instead of enumerating fixed cases by hand, and asserts core invariants hold for every
+ * one of them.
+ */
+public final class StripInjectedContextFuzzTest {
+
+  private static final int ITERATIONS = 5_000;
+
+  @Test
+  void neverThrowsAndAlwaysRemovesDatadogWhenPresent() {
+    ThreadLocalRandom random = ThreadLocalRandom.current();
+
+    for (int i = 0; i < ITERATIONS; i++) {
+      byte[] payload = randomPayload(random);
+
+      byte[] result;
+      try {
+        result = StripInjectedContext.stripInternal(payload);
+      } catch (Throwable t) {
+        fail(
+            "stripInternal must never throw, but threw for payload: "
+                + new String(payload, StandardCharsets.UTF_8),
+            t);
+        return;
+      }
+
+      String resultJson = new String(result, StandardCharsets.UTF_8);
+      assertFalse(
+          resultJson.contains("_datadog"), "output must never contain _datadog: " + resultJson);
+
+      // Idempotency: stripping an already-stripped payload must be a no-op.
+      byte[] second = StripInjectedContext.stripInternal(result);
+      assertTrue(Arrays.equals(result, second), "stripInternal must be idempotent");
+    }
+  }
+
+  private static byte[] randomPayload(ThreadLocalRandom random) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{\"detail-type\":\"order.created\",\"detail\":");
+    boolean asString = random.nextBoolean();
+    boolean includeDatadog = random.nextBoolean();
+
+    String detailJson = randomDetailObject(random, includeDatadog);
+    if (asString) {
+      sb.append('"').append(detailJson.replace("\"", "\\\"")).append('"');
+    } else {
+      sb.append(detailJson);
+    }
+    sb.append('}');
+    return sb.toString().getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static String randomDetailObject(ThreadLocalRandom random, boolean includeDatadog) {
+    StringBuilder sb = new StringBuilder("{");
+    int fieldCount = random.nextInt(1, 6);
+    for (int i = 0; i < fieldCount; i++) {
+      if (i > 0) {
+        sb.append(',');
+      }
+      sb.append('"').append("field").append(i).append("\":");
+      appendRandomValue(sb, random);
+    }
+    if (includeDatadog) {
+      if (fieldCount > 0) {
+        sb.append(',');
+      }
+      sb.append("\"_datadog\":{\"x-datadog-trace-id\":\"").append(random.nextLong()).append("\"}");
+    }
+    sb.append('}');
+    return sb.toString();
+  }
+
+  private static void appendRandomValue(StringBuilder sb, ThreadLocalRandom random) {
+    switch (random.nextInt(4)) {
+      case 0:
+        sb.append(random.nextInt());
+        break;
+      case 1:
+        sb.append(random.nextDouble());
+        break;
+      case 2:
+        sb.append('"').append("value").append(random.nextInt(1000)).append('"');
+        break;
+      default:
+        sb.append(random.nextBoolean());
+    }
+  }
+}

--- a/dd-trace-core/src/test/java/datadog/trace/lambda/StripInjectedContextTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/lambda/StripInjectedContextTest.java
@@ -1,0 +1,204 @@
+package datadog.trace.lambda;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import datadog.trace.api.config.GeneralConfig;
+import datadog.trace.test.junit.utils.config.WithConfig;
+import datadog.trace.test.util.DDJavaSpecification;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link StripInjectedContext}. */
+class StripInjectedContextTest extends DDJavaSpecification {
+
+  private static byte[] bytes(String json) {
+    return json.getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static String toUtf8(byte[] bytes) {
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
+
+  private static byte[] readAll(ByteArrayInputStream in) {
+    in.mark(Integer.MAX_VALUE);
+    byte[] bytes = new byte[in.available()];
+    int read = in.read(bytes, 0, bytes.length);
+    in.reset();
+    return read == bytes.length ? bytes : java.util.Arrays.copyOf(bytes, Math.max(read, 0));
+  }
+
+  // ============================================================================
+  // stripInternal: detail as an object
+  // ============================================================================
+
+  @Test
+  void removesDatadogKeyFromObjectDetail() {
+    byte[] input =
+        bytes(
+            "{\"detail-type\":\"order.created\",\"detail\":{\"orderId\":42,"
+                + "\"_datadog\":{\"x-datadog-trace-id\":\"123\"}}}");
+
+    byte[] result = StripInjectedContext.stripInternal(input);
+    String json = toUtf8(result);
+
+    assertTrue(json.contains("\"orderId\":42"), "unrelated fields must survive untouched");
+    assertTrue(!json.contains("_datadog"), "the _datadog carrier must be removed");
+  }
+
+  // ============================================================================
+  // stripInternal: detail as a string-encoded JSON object
+  // ============================================================================
+
+  @Test
+  void removesDatadogKeyFromStringEncodedDetail() {
+    // "detail" itself is a JSON string containing an escaped JSON object
+    byte[] input =
+        bytes(
+            "{\"detail\":\"{\\\"orderId\\\":42,\\\"_datadog\\\":{\\\"x-datadog-trace-id\\\":\\\"123\\\"}}\"}");
+
+    byte[] result = StripInjectedContext.stripInternal(input);
+    String json = toUtf8(result);
+
+    assertTrue(!json.contains("_datadog"));
+    assertTrue(json.contains("orderId"));
+  }
+
+  // ============================================================================
+  // Fail-open cases: original payload must be returned unchanged
+  // ============================================================================
+
+  @Test
+  void returnsOriginalWhenDatadogKeyIsAbsent() {
+    byte[] input = bytes("{\"detail\":{\"orderId\":42}}");
+
+    byte[] result = StripInjectedContext.stripInternal(input);
+
+    assertArrayEquals(input, result);
+  }
+
+  @Test
+  void returnsOriginalWhenDetailFieldIsMissing() {
+    byte[] input = bytes("{\"detail-type\":\"order.created\",\"_datadog\":{\"trace\":\"1\"}}");
+
+    byte[] result = StripInjectedContext.stripInternal(input);
+
+    assertArrayEquals(input, result);
+  }
+
+  @Test
+  void returnsOriginalOnMalformedJson() {
+    byte[] input = bytes("{not valid json, but contains _datadog anyway");
+
+    byte[] result = StripInjectedContext.stripInternal(input);
+
+    assertArrayEquals(input, result);
+  }
+
+  @Test
+  void returnsOriginalForNullOrEmptyPayload() {
+    assertNull(StripInjectedContext.stripInternal(null));
+    assertArrayEquals(new byte[0], StripInjectedContext.stripInternal(new byte[0]));
+  }
+
+  @Test
+  void returnsOriginalWhenDetailIsNeitherObjectNorString() {
+    // e.g. detail is a number/array/null — nothing sane to strip from
+    byte[] input = bytes("{\"detail\":42,\"_datadog\":{\"trace\":\"1\"}}");
+
+    byte[] result = StripInjectedContext.stripInternal(input);
+
+    assertArrayEquals(input, result);
+  }
+
+  // ============================================================================
+  // Number type preservation (the whole reason for the custom Moshi adapter)
+  // ============================================================================
+
+  @Test
+  void preservesWholeNumbersAsIntegersAfterStripping() {
+    byte[] input =
+        bytes("{\"detail\":{\"orderId\":42,\"quantity\":7," + "\"_datadog\":{\"trace\":\"1\"}}}");
+
+    String json = toUtf8(StripInjectedContext.stripInternal(input));
+
+    // Without the custom adapter, Moshi's default would turn these into "42.0"/"7.0"
+    assertTrue(json.contains("\"orderId\":42"));
+    assertTrue(json.contains("\"quantity\":7"));
+    assertTrue(!json.contains(".0"));
+  }
+
+  @Test
+  void preservesFractionalNumbersAsDoublesAfterStripping() {
+    byte[] input = bytes("{\"detail\":{\"price\":19.99,\"_datadog\":{\"trace\":\"1\"}}}");
+
+    String json = toUtf8(StripInjectedContext.stripInternal(input));
+
+    assertTrue(json.contains("\"price\":19.99"));
+  }
+
+  @Test
+  void preservesLargeIntegersBeyondIntRangeAsLong() {
+    byte[] input =
+        bytes("{\"detail\":{\"bigId\":9007199254740993,\"_datadog\":{\"trace\":\"1\"}}}");
+
+    String json = toUtf8(StripInjectedContext.stripInternal(input));
+
+    // A double could not represent this value exactly; Long must be used instead.
+    assertTrue(json.contains("\"bigId\":9007199254740993"));
+  }
+
+  // ============================================================================
+  // strip(): the public entry point that is gated by config
+  // ============================================================================
+
+  @Test
+  void stripReturnsOriginalPayloadWhenConfigIsDisabledByDefault() {
+    byte[] input = bytes("{\"detail\":{\"_datadog\":{\"trace\":\"1\"}}}");
+
+    byte[] result = StripInjectedContext.strip(input);
+
+    assertArrayEquals(input, result);
+  }
+
+  @Test
+  @WithConfig(key = GeneralConfig.LAMBDA_STRIP_INJECTED_CONTEXT, value = "true")
+  void stripRemovesDatadogKeyWhenConfigIsEnabled() {
+    byte[] input = bytes("{\"detail\":{\"orderId\":1,\"_datadog\":{\"trace\":\"1\"}}}");
+
+    byte[] result = StripInjectedContext.strip(input);
+    String json = toUtf8(result);
+
+    assertTrue(!json.contains("_datadog"));
+  }
+
+  // ============================================================================
+  // replaceInputStream(): the InputStream-based helper used by the advice
+  // ============================================================================
+
+  @Test
+  void replaceInputStreamReturnsNullForNullInput() {
+    assertNull(StripInjectedContext.replaceInputStream(null));
+  }
+
+  @Test
+  @WithConfig(key = GeneralConfig.LAMBDA_STRIP_INJECTED_CONTEXT, value = "true")
+  void replaceInputStreamStripsAndDoesNotConsumeTheOriginalStream() {
+    String eventJson = "{\"detail\":{\"orderId\":1,\"_datadog\":{\"trace\":\"1\"}}}";
+    ByteArrayInputStream original =
+        new ByteArrayInputStream(eventJson.getBytes(StandardCharsets.UTF_8));
+
+    ByteArrayInputStream stripped = StripInjectedContext.replaceInputStream(original);
+
+    assertNotNull(stripped);
+    String strippedJson = new String(readAll(stripped), StandardCharsets.UTF_8);
+    assertTrue(!strippedJson.contains("_datadog"));
+
+    // readAllBytes() inside replaceInputStream() must mark/reset, not drain, the original stream
+    String originalJson = new String(readAll(original), StandardCharsets.UTF_8);
+    assertTrue(originalJson.contains("_datadog"), "original stream must still be fully readable");
+  }
+}

--- a/internal-api/src/main/java/datadog/trace/api/Config.java
+++ b/internal-api/src/main/java/datadog/trace/api/Config.java
@@ -117,6 +117,7 @@ import static datadog.trace.api.ConfigDefaults.DEFAULT_JAX_RS_EXCEPTION_AS_ERROR
 import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_JMX_FETCH_MULTIPLE_RUNTIME_SERVICES_LIMIT;
+import static datadog.trace.api.ConfigDefaults.DEFAULT_LAMBDA_STRIP_INJECTED_CONTEXT;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_LLM_OBS_AGENTLESS_ENABLED;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_LLM_OBS_SAMPLE_RATE;
 import static datadog.trace.api.ConfigDefaults.DEFAULT_LOGS_INJECTION_ENABLED;
@@ -400,6 +401,7 @@ import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_STATSD_HOST;
 import static datadog.trace.api.config.GeneralConfig.HEALTH_METRICS_STATSD_PORT;
 import static datadog.trace.api.config.GeneralConfig.INSTRUMENTATION_SOURCE;
 import static datadog.trace.api.config.GeneralConfig.JDK_SOCKET_ENABLED;
+import static datadog.trace.api.config.GeneralConfig.LAMBDA_STRIP_INJECTED_CONTEXT;
 import static datadog.trace.api.config.GeneralConfig.LOG_LEVEL;
 import static datadog.trace.api.config.GeneralConfig.PERF_METRICS_ENABLED;
 import static datadog.trace.api.config.GeneralConfig.PRIMARY_TAG;
@@ -1403,6 +1405,7 @@ public class Config {
   private final String dogStatsDPath;
   private final List<String> dogStatsDArgs;
   private final int dogStatsDPort;
+  private final boolean lambdaStripInjectedContextEnabled;
 
   private String env;
   private String version;
@@ -1761,6 +1764,10 @@ public class Config {
         isInjectDatadogAttributeEnabled(DEFAULT_INJECT_DATADOG_ATTRIBUTE, "sns");
     sqsInjectDatadogAttributeEnabled =
         isInjectDatadogAttributeEnabled(DEFAULT_INJECT_DATADOG_ATTRIBUTE, "sqs");
+
+    lambdaStripInjectedContextEnabled =
+        configProvider.getBoolean(
+            LAMBDA_STRIP_INJECTED_CONTEXT, DEFAULT_LAMBDA_STRIP_INJECTED_CONTEXT);
 
     spanAttributeSchemaVersion = schemaVersionFromConfig();
 
@@ -5403,6 +5410,10 @@ public class Config {
     return sfnInjectDatadogAttributeEnabled;
   }
 
+  public boolean isLambdaStripInjectedContextEnabled() {
+    return lambdaStripInjectedContextEnabled;
+  }
+
   /**
    * @return A map of tags to be applied only to the local application root span.
    */
@@ -7088,6 +7099,8 @@ public class Config {
         + sqsInjectDatadogAttributeEnabled
         + ", snsInjectDatadogAttributeEnabled="
         + snsInjectDatadogAttributeEnabled
+        + ", lambdaStripInjectedContextEnabled="
+        + lambdaStripInjectedContextEnabled
         + '}';
   }
 }

--- a/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
+++ b/internal-api/src/main/java/datadog/trace/bootstrap/instrumentation/api/AgentTracer.java
@@ -26,6 +26,7 @@ import datadog.trace.api.scopemanager.ScopeListener;
 import datadog.trace.context.NoopTraceScope;
 import datadog.trace.context.TraceScope;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -349,6 +350,8 @@ public class AgentTracer {
 
     void notifyAppSecEnd(AgentSpan span, Object result);
 
+    InputStream stripLambdaInjectedContext(InputStream in);
+
     AgentDataStreamsMonitoring getDataStreamsMonitoring();
 
     String getTraceId(AgentSpan span);
@@ -608,6 +611,11 @@ public class AgentTracer {
 
     @Override
     public void notifyAppSecEnd(AgentSpan span, Object result) {}
+
+    @Override
+    public InputStream stripLambdaInjectedContext(InputStream in) {
+      return null;
+    }
 
     @Override
     public AgentDataStreamsMonitoring getDataStreamsMonitoring() {

--- a/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -219,6 +219,7 @@ class ConfigTest extends DDSpecification {
   private static final SFN_INJECT_DATADOG_ATTRIBUTE_ENABLED = "sfn.inject.datadog.attribute.enabled"
   private static final SNS_INJECT_DATADOG_ATTRIBUTE_ENABLED = "sns.inject.datadog.attribute.enabled"
   private static final SQS_INJECT_DATADOG_ATTRIBUTE_ENABLED = "sqs.inject.datadog.attribute.enabled"
+  private static final LAMBDA_STRIP_INJECTED_CONTEXT = "lambda.strip.injected.context"
 
   private static final DD_TRACE_OTEL_ENABLED_ENV = "DD_TRACE_OTEL_ENABLED"
   private static final DD_TRACE_OTEL_ENABLED_PROP = "dd.trace.otel.enabled"
@@ -2671,6 +2672,21 @@ class ConfigTest extends DDSpecification {
     config.llmObsMlApp == "test-service"
   }
 
+  def "test lambda strip injected context default"() {
+    when:
+    def config = new Config()
+
+    then:
+    !config.isLambdaStripInjectedContextEnabled()
+  }
+
+  def "test lambda strip injected context enabled via config"() {
+    setup:
+    injectSysConfig(LAMBDA_STRIP_INJECTED_CONTEXT, "true")
+
+    expect:
+    Config.get().isLambdaStripInjectedContextEnabled()
+  }
 
   def "config instantiation should NOT fail if llm obs is enabled (agentless disabled) via sys prop and ml app is set"() {
     setup:

--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -2308,6 +2308,14 @@
         "aliases": []
       }
     ],
+    "DD_LAMBDA_STRIP_INJECTED_CONTEXT": [
+      {
+        "version": "A",
+        "type": "boolean",
+        "default": "false",
+        "aliases": []
+      }
+    ],
     "DD_LLMOBS_AGENTLESS_ENABLED": [
       {
         "version": "B",


### PR DESCRIPTION
# What Does This Do
Strips the injected `_datadog` trace propagation carrier from the `detail` field of AWS Lambda EventBridge event payloads before the payload reaches the customer's handler code.
- Adds a new config flag `DD_LAMBDA_STRIP_INJECTED_CONTEXT` (default: `false`) to gate this behavior.
- Adds `StripInjectedContext`, which parses the EventBridge JSON payload with Moshi, removes the `_datadog` key nested under `detail`, and re-serializes it. A custom Moshi adapter preserves the original numeric type (`Long` vs `Double`) so payload values aren't silently altered. On any parsing failure, the original payload is returned unchanged (fail-open).
- Exposes this capability through the `AgentTracer`/`TracerAPI` interface(`stripLambdaInjectedContext`), implemented in `CoreTracer` and delegating to `StripInjectedContext`. This indirection is needed because instrumentation modules cannot depend on `dd-trace-core` directly.
- Updates `LambdaHandlerInstrumentation` to intercept the raw `InputStream` argument of the Lambda handler and, when the flag is enabled, replace it with the stripped stream before invoking the customer's handler.
- Adds unit tests, a randomized fuzz-style test that generates 5,000 EventBridge-shaped payloads to assert fail-open behavior and idempotency, and a JMH benchmark comparing performance with/without a `_datadog` carrier present.

# Motivation
When Lambda tracing injects `_datadog` propagation context into an EventBridge `detail` payload, that extra key leaks into the customer's business payload and can break strict schema validation or unexpected-field checks on the consumer side. This change strips the injected context before the handler sees it, scoped specifically to EventBridge-shaped events (the `detail` field).

# Additional Notes
- Scope: only the `_datadog` key under the EventBridge `detail` field is stripped. SNS/SQS message payloads are not touched by this change.
- The feature is disabled by default (`DD_LAMBDA_STRIP_INJECTED_CONTEXT=false`) to avoid any performance or behavior impact unless explicitly opted in.
- Verified locally using the Lambda Runtime Interface Emulator (RIE) in Docker with a patched javaagent jar, confirming stripping occurs only when the flag is enabled.
- Note to reviewers: I don't have label permissions on this repo. Could someone
  please add `type: feature`, `inst: aws lambda`, and `tag: serverless` labels to
  this PR? Thanks!

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [[APMSVLS-313]](https://datadoghq.atlassian.net/browse/APMSVLS-313)

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->


[APMSVLS-313]: https://datadoghq.atlassian.net/browse/APMSVLS-313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ