### PR TITLE
fix tibco bw instrumentation for 5.16

### DIFF
--- a/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-5.14/src/main/java/datadog/trace/instrumentation/tibcobw5/JobPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-5.14/src/main/java/datadog/trace/instrumentation/tibcobw5/JobPoolInstrumentation.java
@@ -1,9 +1,11 @@
 package datadog.trace.instrumentation.tibcobw5;
 
+import static datadog.trace.agent.tooling.bytebuddy.matcher.HierarchyMatchers.hasInterface;
 import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.tibcobw5.TibcoDecorator.DECORATE;
 import static datadog.trace.instrumentation.tibcobw5.TibcoDecorator.TIBCO_PROCESS_OPERATION;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import com.tibco.pe.core.DDJobMate;
@@ -29,9 +31,14 @@ public class JobPoolInstrumentation extends AbstractTibcoInstrumentation
 
   @Override
   public void methodAdvice(MethodTransformer transformer) {
-
-    transformer.applyAdvice(named("addJob"), getClass().getName() + "$JobStartAdvice");
-    transformer.applyAdvice(named("removeJob"), getClass().getName() + "$JobEndAdvice");
+    transformer.applyAdvice(
+        named("addJob")
+            .and(takesArgument(0, hasInterface(named("com.tibco.pe.plugin.ProcessContext")))),
+        getClass().getName() + "$JobStartAdvice");
+    transformer.applyAdvice(
+        named("removeJob")
+            .and(takesArgument(0, hasInterface(named("com.tibco.pe.plugin.ProcessContext")))),
+        getClass().getName() + "$JobEndAdvice");
   }
 
   public static class JobStartAdvice {

--- a/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-5.14/src/main/java/datadog/trace/instrumentation/tibcobw5/JobPoolInstrumentation.java
+++ b/dd-java-agent/instrumentation/tibco-businessworks/tibco-businessworks-5.14/src/main/java/datadog/trace/instrumentation/tibcobw5/JobPoolInstrumentation.java
@@ -5,6 +5,7 @@ import static datadog.trace.agent.tooling.bytebuddy.matcher.NameMatchers.named;
 import static datadog.trace.bootstrap.instrumentation.api.AgentTracer.startSpan;
 import static datadog.trace.instrumentation.tibcobw5.TibcoDecorator.DECORATE;
 import static datadog.trace.instrumentation.tibcobw5.TibcoDecorator.TIBCO_PROCESS_OPERATION;
+import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
@@ -33,10 +34,11 @@ public class JobPoolInstrumentation extends AbstractTibcoInstrumentation
   public void methodAdvice(MethodTransformer transformer) {
     transformer.applyAdvice(
         named("addJob")
+            .and(isPublic())
             .and(takesArgument(0, hasInterface(named("com.tibco.pe.plugin.ProcessContext")))),
         getClass().getName() + "$JobStartAdvice");
     transformer.applyAdvice(
-        named("removeJob")
+        named("removeJob") // note: removeJob is a protected method (not public)
             .and(takesArgument(0, hasInterface(named("com.tibco.pe.plugin.ProcessContext")))),
         getClass().getName() + "$JobEndAdvice");
   }


### PR DESCRIPTION
# What Does This Do

A customer reported that instrumentation failed for Tibco BusinessWorks 5.16 with the following error:

```Cannot assign com.tibco.pe.core.JobData arg0 to interface com.tibco.pe.plugin.ProcessContext```

turns out this was not due to a signature change, but int introduction of a new (private) method that matched the selector as well, causing the whole instrumentation to fail.

Here are the methods in 5.16:

```
public final void addJob(Job job, String value, boolean flag);

Job addJob(JobData data) throws Exception; // new in 5.16

protected void removeJob(Job job, boolean flag1, boolean flag2);
```

I fixed it by adding a constraint matching the type we expect in the advice. Did the same for removeJob because it made sense.

# Motivation

APMS-20455

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
