### PR TITLE
Fix NullPointerException from activating a null span in scope manager (quick fix)

### DIFF
--- a/dd-java-agent/instrumentation/websocket/javax-websocket-1.0/src/main/java/datadog/trace/instrumentation/websocket/jsr256/TracingSendHandler.java
+++ b/dd-java-agent/instrumentation/websocket/javax-websocket-1.0/src/main/java/datadog/trace/instrumentation/websocket/jsr256/TracingSendHandler.java
@@ -21,7 +21,7 @@ public class TracingSendHandler implements SendHandler {
   @Override
   public void onResult(SendResult sendResult) {
     final AgentSpan wsSpan = handlerContext.getWebsocketSpan();
-    try (final ContextScope ignored = activateSpan(wsSpan)) {
+    try (final ContextScope ignored = wsSpan != null ? activateSpan(wsSpan) : null) {
       delegate.onResult(sendResult);
     } finally {
       if (sendResult.getException() != null) {

--- a/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/dd-trace-core/src/main/java/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -113,6 +113,11 @@ public final class ContinuableScopeManager {
       final byte source,
       final boolean overrideAsyncPropagation,
       final boolean isAsyncPropagating) {
+    if (span == null) {
+      log.debug(SEND_TELEMETRY, "Attempted to activate a null span.  Returning NoopScope.");
+      return INVALID_SCOPE;
+    }
+
     ScopeStack scopeStack = scopeStack();
 
     final ContinuableScope top = scopeStack.top;
@@ -130,8 +135,6 @@ public final class ContinuableScopeManager {
         return INVALID_SCOPE;
       }
     }
-
-    assert span != null;
 
     // Inherit the async propagation from the active scope unless the value is overridden
     boolean asyncPropagation =

--- a/dd-trace-core/src/test/java/datadog/trace/core/scopemanager/ScopeManagerForkedTest.java
+++ b/dd-trace-core/src/test/java/datadog/trace/core/scopemanager/ScopeManagerForkedTest.java
@@ -36,6 +36,7 @@ import datadog.trace.api.scopemanager.ScopeListener;
 import datadog.trace.bootstrap.instrumentation.api.AgentScope;
 import datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+import datadog.trace.bootstrap.instrumentation.api.NoopScope;
 import datadog.trace.bootstrap.instrumentation.api.ProfilingContextIntegration;
 import datadog.trace.common.writer.ListWriter;
 import datadog.trace.core.CoreTracer;
@@ -122,6 +123,27 @@ class ScopeManagerForkedTest extends DDCoreJavaSpecification {
     scope.close();
 
     assertNull(scopeManager.active());
+  }
+
+  @Test
+  void activatingNullSpanReturnsNoopScopeAndDoesNotCorruptStack() {
+    AgentScope nullScope = scopeManager.activateSpan(null);
+
+    assertInstanceOf(NoopScope.class, nullScope);
+    assertNull(scopeManager.active());
+
+    nullScope.close();
+
+    // a subsequent activation on the same thread must not NPE, even though the noop
+    // activation above never pushed a scope with a null context onto the stack
+    AgentSpan span = tracer.buildSpan("test", "test").start();
+    AgentScope scope = tracer.activateSpan(span);
+
+    assertSame(scope, scopeManager.active());
+    assertSame(span, scope.span());
+
+    scope.close();
+    span.finish();
   }
 
   @Test


### PR DESCRIPTION
# What Does This Do

- `ContinuableScopeManager.activate` now returns the existing `INVALID_SCOPE` (noop) sentinel when given a `null` span, instead of silently pushing a `ContinuableScope` with a `null` `Context` onto the scope stack.
- `TracingSendHandler.onResult` (JSR-356 websocket async send instrumentation) skips `activateSpan` entirely when the websocket span is `null`, matching the existing null-check already used in `TracingOutputStream.close()` for the same `HandlerContext`.
- Added `ScopeManagerForkedTest#activatingNullSpanReturnsNoopScopeAndDoesNotCorruptStack`, which reproduces the original bug: activating a `null` span returns a noop scope, and a subsequent real activation on the same thread no longer NPEs.

# Motivation

Fixes a production `NullPointerException` surfaced via Datadog error tracking (issue `6d4f45fa-b461-11f0-8716-da7ad0900002`) in `ContinuableScopeManager.activate`.

Root cause: `HandlerContext.getWebsocketSpan()` can race with `HandlerContext.reset()` clearing that field from another thread, so `TracingSendHandler.onResult` could call `activateSpan` with a `null` span. `ContinuableScopeManager.activate` had no guard for this — it pushed a `ContinuableScope` with a `null` `Context`. The corruption didn't throw immediately; it only surfaced as an NPE on the *next* activation on that thread, when `top.context.with(span)` dereferenced the poisoned `null` context. The pre-existing `assert span != null` never caught this in practice, since assertions are never enabled (`-ea`) in production JVMs.

# Additional Notes

- Low customer impact (11 total occurrences, single customer) and not a crash — the exception was already caught by the instrumentation's own exception guard — but it silently corrupted the scope stack for the affected thread, which is worse than the NPE itself.
- `./gradlew :dd-trace-core:forkedTest --tests "datadog.trace.core.scopemanager.ScopeManagerForkedTest"` passes.
- `./gradlew spotlessApply` produces no additional changes.

# Contributor Checklist

- [x] Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [x] Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue
- [ ] Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion — not applicable, no files added/removed
- [ ] Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors — not applicable, no config change
- [ ] Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: N/A — originated from Datadog Error Tracking issue `6d4f45fa-b461-11f0-8716-da7ad0900002`

🤖 Generated with [Claude Code](https://claude.com/claude-code)