### PR TITLE
Encapsulate ConcurrentHashtable.SizeManager and relocate createBounded (perf toolbox)

### DIFF
--- a/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
+++ b/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
@@ -151,7 +151,7 @@ public final class ConcurrentHashtable {
     @Nonnull
     public static <K, TEntry extends D1.Entry<K>> D1<K, TEntry> createBounded(
         @Nonnull Class<TEntry> entryClass, int maxCapacity) {
-      return new D1<>(State.createBounded(entryClass, maxCapacity));
+      return new D1<>(ConcurrentHashtable.createBounded(entryClass, maxCapacity));
     }
 
     public int size() {
@@ -414,7 +414,7 @@ public final class ConcurrentHashtable {
     @Nonnull
     public static <K1, K2, TEntry extends D2.Entry<K1, K2>> D2<K1, K2, TEntry> createBounded(
         @Nonnull Class<TEntry> entryClass, int maxCapacity) {
-      return new D2<>(State.createBounded(entryClass, maxCapacity));
+      return new D2<>(ConcurrentHashtable.createBounded(entryClass, maxCapacity));
     }
 
     public int size() {
@@ -812,25 +812,30 @@ public final class ConcurrentHashtable {
   /**
    * Bucket array and occupancy manager for a caller-defined capped table. Keep them paired and
    * prefer the {@code State}-accepting helpers so structural changes update the count consistently.
+   *
+   * <p>{@code sizeManager} is intentionally package-private: callers outside this class must go
+   * through the {@code State}-accepting static helpers ({@link #estimateSize}, {@link #isFull},
+   * {@link #tryReserve}, {@link #tryReserveOrEvict}, {@link #evictOne}, {@link #evictAll}) rather
+   * than reach into the manager directly.
    */
   public static final class State<TEntry extends Entry> {
     public final AtomicReferenceArray<TEntry> buckets;
-    public final SizeManager sizeManager;
+    final SizeManager sizeManager;
 
     private State(AtomicReferenceArray<TEntry> buckets, int maxCapacity) {
       this.buckets = buckets;
       this.sizeManager = new SizeManager(maxCapacity);
     }
+  }
 
-    /**
-     * Creates a bucket array for {@code maxCapacity} entries and pairs it with a manager enforcing
-     * that cap. {@code entryClass} is used only to infer {@code TEntry}.
-     */
-    @Nonnull
-    public static <TEntry extends Entry> State<TEntry> createBounded(
-        @Nonnull Class<TEntry> entryClass, int maxCapacity) {
-      return new State<>(createFixedBuckets(entryClass, maxCapacity), maxCapacity);
-    }
+  /**
+   * Creates a bucket array for {@code maxCapacity} entries and pairs it with a manager enforcing
+   * that cap. {@code entryClass} is used only to infer {@code TEntry}.
+   */
+  @Nonnull
+  public static <TEntry extends Entry> State<TEntry> createBounded(
+      @Nonnull Class<TEntry> entryClass, int maxCapacity) {
+    return new State<>(createFixedBuckets(entryClass, maxCapacity), maxCapacity);
   }
 
   /** Live entries in {@code state}; see {@link SizeManager#estimateSize()}. Lock-free. */
@@ -843,6 +848,18 @@ public final class ConcurrentHashtable {
    */
   public static boolean isFull(@Nonnull State<?> state) {
     return state.sizeManager.isFull();
+  }
+
+  /**
+   * Reserves one slot in {@code state} without evicting; see {@link SizeManager#tryReserve()}.
+   * Lock-free — does not acquire the table write lock. Returns {@code false} with the table
+   * unchanged when it is full.
+   *
+   * <p>Build the entry before reserving: there is no cancellation operation, so abandoning a
+   * successful reservation permanently consumes capacity. Complete it with {@link #insertReserved}.
+   */
+  public static <TEntry extends Entry> boolean tryReserve(@Nonnull State<TEntry> state) {
+    return state.sizeManager.tryReserve();
   }
 
   /**

--- a/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableSizeManagerTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableSizeManagerTest.java
@@ -40,7 +40,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void tryReserveOrEvictReservesDirectlyWhenUnderCapacity() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 2);
+        ConcurrentHashtable.createBounded(TestEntry.class, 2);
 
     boolean reserved = tryReserveOrEvict(state, e -> true);
     assertTrue(reserved);
@@ -51,7 +51,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void tryReserveOrEvictEvictsWhenFullAndSomethingMatches() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 1);
+        ConcurrentHashtable.createBounded(TestEntry.class, 1);
     TestEntry existing = insertAt(state, 0, "existing");
     assertTrue(state.sizeManager.tryReserve());
     assertTrue(state.sizeManager.isFull());
@@ -65,7 +65,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void tryReserveOrEvictFailsAndLeavesTableUntouchedWhenNothingEvictable() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 1);
+        ConcurrentHashtable.createBounded(TestEntry.class, 1);
     TestEntry existing = insertAt(state, 0, "existing");
     assertTrue(state.sizeManager.tryReserve());
 
@@ -78,7 +78,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void insertReservedSplicesWithoutTouchingTheCountAfterATryReserve() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 2);
+        ConcurrentHashtable.createBounded(TestEntry.class, 2);
     assertTrue(state.sizeManager.tryReserve());
     assertEquals(1, state.sizeManager.estimateSize());
 
@@ -95,7 +95,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void evictOneReturnsNullAndLeavesCountUnchangedWhenNothingMatches() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 4);
+        ConcurrentHashtable.createBounded(TestEntry.class, 4);
     insertAt(state, 0, "a");
     state.sizeManager.increment();
 
@@ -107,7 +107,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void evictOneUnlinksMatchAndDecrementsCount() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 4);
+        ConcurrentHashtable.createBounded(TestEntry.class, 4);
     TestEntry a = insertAt(state, 0, "a");
     TestEntry b = insertAt(state, 1, "b");
     state.sizeManager.increment();
@@ -130,7 +130,7 @@ class ConcurrentHashtableSizeManagerTest {
   void evictOneResumesFromLastEvictedBucketAndWrapsAround() {
     // Bucket-array length 4: keyHash i lands in bucket i.
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 4);
+        ConcurrentHashtable.createBounded(TestEntry.class, 4);
     TestEntry e0 = insertAt(state, 0, "e0");
     insertAt(state, 2, "e2");
     TestEntry e3 = insertAt(state, 3, "e3");
@@ -159,7 +159,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void evictAllRemovesEveryMatchAndReturnsCount() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 8);
+        ConcurrentHashtable.createBounded(TestEntry.class, 8);
     for (int i = 0; i < 6; i++) {
       insertAt(state, i, "e" + i);
       state.sizeManager.increment();
@@ -179,7 +179,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void evictAllResetsCursorSoSubsequentEvictOneScansFromBucketZero() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 4);
+        ConcurrentHashtable.createBounded(TestEntry.class, 4);
     insertAt(state, 2, "a");
     state.sizeManager.increment();
     // Advance the cursor away from 0 via a successful eviction at bucket 2.
@@ -203,7 +203,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void releaseGivesBackRemovedSlotsAndRestartsScan() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 4);
+        ConcurrentHashtable.createBounded(TestEntry.class, 4);
     insertAt(state, 2, "a");
     state.sizeManager.increment();
     evictOne(state, e -> true); // advances the cursor to 2, count back to 0
@@ -226,7 +226,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void stateCreateCappedBundlesBucketsAndSizeManager() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 3);
+        ConcurrentHashtable.createBounded(TestEntry.class, 3);
     assertEquals(0, state.sizeManager.estimateSize());
     assertEquals(3, state.sizeManager.capacity());
     assertTrue(state.buckets.length() >= 3);
@@ -235,7 +235,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void stateLevelTryReserveOrEvictAndEvictOneAndEvictAllDelegateToSizeManager() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 1);
+        ConcurrentHashtable.createBounded(TestEntry.class, 1);
     synchronized (ConcurrentHashtable.getWriteLockAt(state, 0)) {
       ConcurrentHashtable.insertHeadEntryAt(state, 0, new TestEntry(0, "a"));
     }
@@ -280,7 +280,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void clearCannotInterleaveBetweenReservationAndInsert() throws InterruptedException {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 1);
+        ConcurrentHashtable.createBounded(TestEntry.class, 1);
     insertAt(state, 0, "a");
     state.sizeManager.increment();
     assertTrue(ConcurrentHashtable.isFull(state));
@@ -318,7 +318,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void reservationSurvivesAClearLandingBetweenReserveAndInsert() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 2);
+        ConcurrentHashtable.createBounded(TestEntry.class, 2);
     insertAt(state, 0, "a");
     state.sizeManager.increment();
 


### PR DESCRIPTION
# What Does This Do

Two small, uncontroversial `ConcurrentHashtable` API cleanups surfaced during review of #12367 (the first real external consumer of `ConcurrentHashtable`):

1. **Encapsulate `SizeManager`.** `State.sizeManager` was a public field, so a caller with a `State` reference could reach into `SizeManager` directly instead of going through the `State`-accepting static helpers (`estimateSize`, `isFull`, `tryReserveOrEvict`, `evictOne`, `evictAll`). That's now package-private. It was also missing a lock-free `tryReserve(State)` wrapper — the one operation an external caller doing custom find/reserve/insert (like `LogCollector` in #12367) actually needs — so callers no longer have to bypass encapsulation just to call it.
2. **Relocate `createBounded`.** Moved from the nested `ConcurrentHashtable.State.createBounded(...)` onto `ConcurrentHashtable.createBounded(...)` directly for a nicer call site. `D1.createBounded`/`D2.createBounded` now delegate to it.

Pure refactor — no behavior change. Existing tests updated only to call `ConcurrentHashtable.createBounded` instead of `ConcurrentHashtable.State.createBounded`.

# Motivation

See the review thread on #12367 (comments from @dougqh):
- "I think there was an oversight on my part. I didn't really intend to expose anything on SizeManager directly. I guess I should fix that."
- "I'm wondering if it would look nicer to move createBounded onto ConcurrentHashtable." (bric3 agreed)

These are the least controversial items from that discussion; a couple of other, more design-heavy follow-ups (a lock-free find/matcher primitive avoiding boxed composite keys, and a doc note on the `bucketAt`/`isFull` composability hazard) are being tracked separately and are not part of this PR.

# Contributor Checklist

- [x] Format the title according to the contribution guidelines
- [ ] Assign the type: and comp: or inst: labels in addition to any other useful labels
- [x] Avoid using close, fix, or linking keywords when referencing an issue; use solves instead
- [ ] Update CODEOWNERS on source file addition, migration, or deletion
- [ ] Update public documentation with any new configuration flags or behaviors
- [ ] Once approved, use merge queue to merge the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)