### PR TITLE
Add find-or-insert Reservation API to ConcurrentHashtable

### DIFF
--- a/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapCounterBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapCounterBenchmark.java
@@ -23,11 +23,10 @@ import org.openjdk.jmh.annotations.Warmup;
  * Measures lookup followed by an atomic counter increment in a shared, pre-populated table. Models
  * per-class or per-method hit counters in the tracer.
  *
- * <p>The {@link ConcurrentHashtable.D1} case embeds a {@code volatile long} in each entry. {@link
- * AtomicLongFieldUpdater} updates that field atomically without allocating an {@link AtomicLong}
- * per key. The map baselines store a separate {@link AtomicLong} or {@link LongAdder}; {@code
- * LongAdder} spreads contention across internal cells at the cost of more memory and a more
- * expensive read.
+ * <p>The {@link ConcurrentHashtable.D1} case embeds a {@code volatile long} counter directly in the
+ * entry and increments it via {@link AtomicLongFieldUpdater}, avoiding a second heap object. The
+ * map baselines store a separate {@link AtomicLong} or {@link LongAdder}; {@code LongAdder} spreads
+ * contention across internal cells at the cost of more memory and a more expensive read.
  *
  * <p>Lookups reuse the key instances installed during setup. {@code Objects.equals} therefore
  * returns on its identity check without dispatching to {@code equals}, so this measures the
@@ -50,8 +49,8 @@ import org.openjdk.jmh.annotations.Warmup;
  *   <li>{@code LongAdder} is marginally faster (79 vs 71 ops/us) because it shards the counter
  *       across cells to reduce CAS contention; the advantage grows with thread count.
  *   <li>{@code ConcurrentHashtable} matches {@code AtomicLong} throughput (69 vs 71 ops/us) while
- *       embedding the counter directly in the entry — one object instead of two, with no throughput
- *       penalty.
+ *       embedding the counter directly in the entry via {@code AtomicLongFieldUpdater} — one object
+ *       instead of two, with no throughput penalty.
  * </ul>
  */
 @Fork(2)
@@ -73,8 +72,12 @@ public class ThreadSafeMapCounterBenchmark {
     }
   }
 
+  /**
+   * Shared state ({@link Scope#Benchmark}): one instance of each map across all threads, modelling
+   * a shared instrumentation counter table.
+   */
   static final class CounterEntry extends ConcurrentHashtable.D1.Entry<String, CounterEntry> {
-    private static final AtomicLongFieldUpdater<CounterEntry> COUNT =
+    static final AtomicLongFieldUpdater<CounterEntry> COUNT =
         AtomicLongFieldUpdater.newUpdater(CounterEntry.class, "count");
 
     volatile long count;
@@ -82,16 +85,8 @@ public class ThreadSafeMapCounterBenchmark {
     CounterEntry(String key) {
       super(key);
     }
-
-    long increment() {
-      return COUNT.incrementAndGet(this);
-    }
   }
 
-  /**
-   * Shared state ({@link Scope#Benchmark}): one instance of each map across all threads, modelling
-   * a shared instrumentation counter table.
-   */
   @State(Scope.Benchmark)
   public static class SharedState {
     ConcurrentHashtable.D1<String, CounterEntry> table;
@@ -125,7 +120,7 @@ public class ThreadSafeMapCounterBenchmark {
 
   @Benchmark
   public long increment_concurrentHashtable(SharedState s, ThreadState t) {
-    return s.table.get(KEYS[t.next()]).increment();
+    return CounterEntry.COUNT.incrementAndGet(s.table.get(KEYS[t.next()]));
   }
 
   @Benchmark

--- a/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapCounterBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapCounterBenchmark.java
@@ -73,7 +73,7 @@ public class ThreadSafeMapCounterBenchmark {
     }
   }
 
-  static final class CounterEntry extends ConcurrentHashtable.D1.Entry<String> {
+  static final class CounterEntry extends ConcurrentHashtable.D1.Entry<String, CounterEntry> {
     private static final AtomicLongFieldUpdater<CounterEntry> COUNT =
         AtomicLongFieldUpdater.newUpdater(CounterEntry.class, "count");
 

--- a/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapCounterBenchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapCounterBenchmark.java
@@ -76,7 +76,7 @@ public class ThreadSafeMapCounterBenchmark {
    * Shared state ({@link Scope#Benchmark}): one instance of each map across all threads, modelling
    * a shared instrumentation counter table.
    */
-  static final class CounterEntry extends ConcurrentHashtable.D1.Entry<String, CounterEntry> {
+  static final class CounterEntry extends ConcurrentHashtable.D1.Entry<String> {
     static final AtomicLongFieldUpdater<CounterEntry> COUNT =
         AtomicLongFieldUpdater.newUpdater(CounterEntry.class, "count");
 

--- a/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapD1Benchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapD1Benchmark.java
@@ -83,7 +83,7 @@ public class ThreadSafeMapD1Benchmark {
     }
   }
 
-  static final class D1Entry extends ConcurrentHashtable.D1.Entry<String> {
+  static final class D1Entry extends ConcurrentHashtable.D1.Entry<String, D1Entry> {
     final long value;
 
     D1Entry(String key) {

--- a/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapD1Benchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapD1Benchmark.java
@@ -83,34 +83,35 @@ public class ThreadSafeMapD1Benchmark {
     }
   }
 
-  static final class D1Entry extends ConcurrentHashtable.D1.Entry<String, D1Entry> {
-    final long value;
-
-    D1Entry(String key) {
-      super(key);
-      this.value = 1L;
-    }
-  }
-
   /**
    * Shared state ({@link Scope#Benchmark}): one instance of each map across all threads, modelling
    * a shared instrumentation cache.
    */
+  static final class LongEntry extends ConcurrentHashtable.D1.Entry<String, LongEntry> {
+    final long value;
+
+    LongEntry(String key, long value) {
+      super(key);
+      this.value = value;
+    }
+  }
+
   @State(Scope.Benchmark)
   public static class SharedState {
-    ConcurrentHashtable.D1<String, D1Entry> table;
+    ConcurrentHashtable.D1<String, LongEntry> table;
     ConcurrentHashMap<String, Long> concurrentHashMap;
     ConcurrentSkipListMap<String, Long> skipListMap;
     Map<String, Long> synchronizedHashMap;
 
     @Setup(Level.Iteration)
     public void setUp() {
-      table = ConcurrentHashtable.D1.createBounded(D1Entry.class, CAPACITY);
+      table = ConcurrentHashtable.D1.createBounded(LongEntry.class, CAPACITY);
       concurrentHashMap = new ConcurrentHashMap<>(CAPACITY);
       skipListMap = new ConcurrentSkipListMap<>();
       synchronizedHashMap = Collections.synchronizedMap(new HashMap<>(CAPACITY));
       for (int i = 0; i < N_KEYS; ++i) {
-        table.tryGetOrCreateOrNull(KEYS[i], D1Entry::new);
+        long value = i;
+        table.tryGetOrCreateOrNull(KEYS[i], k -> new LongEntry(k, value));
         concurrentHashMap.put(KEYS[i], (long) i);
         skipListMap.put(KEYS[i], (long) i);
         synchronizedHashMap.put(KEYS[i], (long) i);
@@ -131,7 +132,7 @@ public class ThreadSafeMapD1Benchmark {
   }
 
   @Benchmark
-  public D1Entry get_concurrentHashtable(SharedState s, ThreadState t) {
+  public LongEntry get_concurrentHashtable(SharedState s, ThreadState t) {
     return s.table.get(KEYS[t.next()]);
   }
 
@@ -151,8 +152,8 @@ public class ThreadSafeMapD1Benchmark {
   }
 
   @Benchmark
-  public D1Entry getOrCreate_concurrentHashtable(SharedState s, ThreadState t) {
-    return s.table.tryGetOrCreateOrNull(KEYS[t.next()], D1Entry::new);
+  public LongEntry getOrCreate_concurrentHashtable(SharedState s, ThreadState t) {
+    return s.table.tryGetOrCreateOrNull(KEYS[t.next()], k -> new LongEntry(k, 0L));
   }
 
   /**

--- a/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapD1Benchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapD1Benchmark.java
@@ -87,7 +87,7 @@ public class ThreadSafeMapD1Benchmark {
    * Shared state ({@link Scope#Benchmark}): one instance of each map across all threads, modelling
    * a shared instrumentation cache.
    */
-  static final class LongEntry extends ConcurrentHashtable.D1.Entry<String, LongEntry> {
+  static final class LongEntry extends ConcurrentHashtable.D1.Entry<String> {
     final long value;
 
     LongEntry(String key, long value) {

--- a/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapD2Benchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapD2Benchmark.java
@@ -126,7 +126,7 @@ public class ThreadSafeMapD2Benchmark {
   }
 
   /** Entry used with {@link ConcurrentHashtable.D2}. */
-  static final class PairEntry extends ConcurrentHashtable.D2.Entry<String, Integer, PairEntry> {
+  static final class PairEntry extends ConcurrentHashtable.D2.Entry<String, Integer> {
     final long value;
 
     PairEntry(String key1, Integer key2, long value) {

--- a/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapD2Benchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapD2Benchmark.java
@@ -95,6 +95,15 @@ public class ThreadSafeMapD2Benchmark {
     }
   }
 
+  static final class D2Entry extends ConcurrentHashtable.D2.Entry<String, Integer> {
+    final long value;
+
+    D2Entry(String k1, Integer k2) {
+      super(k1, k2);
+      this.value = 1L;
+    }
+  }
+
   /**
    * Entry used with the static helpers. Its primitive second key keeps storage and lookup unboxed,
    * independently of {@link Integer} caching or JVM escape analysis.
@@ -122,16 +131,6 @@ public class ThreadSafeMapD2Benchmark {
     @Override
     public boolean matches(SupportEntry other) {
       return matches(other.k1, other.k2);
-    }
-  }
-
-  /** Entry used with {@link ConcurrentHashtable.D2}. */
-  static final class PairEntry extends ConcurrentHashtable.D2.Entry<String, Integer> {
-    final long value;
-
-    PairEntry(String key1, Integer key2, long value) {
-      super(key1, key2);
-      this.value = value;
     }
   }
 
@@ -177,7 +176,7 @@ public class ThreadSafeMapD2Benchmark {
    */
   @State(Scope.Benchmark)
   public static class SharedState {
-    ConcurrentHashtable.D2<String, Integer, PairEntry> table;
+    ConcurrentHashtable.D2<String, Integer, D2Entry> table;
     java.util.concurrent.atomic.AtomicReferenceArray<SupportEntry> supportBuckets;
     ConcurrentHashMap<Key2, Long> concurrentHashMap;
     ConcurrentSkipListMap<Key2, Long> skipListMap;
@@ -185,14 +184,14 @@ public class ThreadSafeMapD2Benchmark {
 
     @Setup(Level.Iteration)
     public void setUp() {
-      table = ConcurrentHashtable.D2.createBounded(PairEntry.class, CAPACITY);
+      table = ConcurrentHashtable.D2.createBounded(D2Entry.class, CAPACITY);
       supportBuckets = ConcurrentHashtable.createFixedBuckets(SupportEntry.class, CAPACITY);
       concurrentHashMap = new ConcurrentHashMap<>(CAPACITY);
       skipListMap = new ConcurrentSkipListMap<>();
       synchronizedHashMap = Collections.synchronizedMap(new HashMap<>(CAPACITY));
       for (int i = 0; i < N_KEYS; ++i) {
         int k2 = SOURCE_K2[i];
-        table.tryGetOrCreateOrNull(SOURCE_K1[i], SOURCE_K2[i], (a, b) -> new PairEntry(a, b, 1L));
+        table.tryGetOrCreateOrNull(SOURCE_K1[i], SOURCE_K2[i], D2Entry::new);
         // populate support table
         SupportEntry se = new SupportEntry(SOURCE_K1[i], k2);
         synchronized (ConcurrentHashtable.getWriteLock(supportBuckets, se.keyHash)) {
@@ -219,7 +218,7 @@ public class ThreadSafeMapD2Benchmark {
   }
 
   @Benchmark
-  public PairEntry get_concurrentHashtable(SharedState s, ThreadState t) {
+  public D2Entry get_concurrentHashtable(SharedState s, ThreadState t) {
     int i = t.next();
     return s.table.get(SOURCE_K1[i], SOURCE_K2[i]);
   }
@@ -259,10 +258,9 @@ public class ThreadSafeMapD2Benchmark {
   }
 
   @Benchmark
-  public PairEntry getOrCreate_concurrentHashtable(SharedState s, ThreadState t) {
+  public D2Entry getOrCreate_concurrentHashtable(SharedState s, ThreadState t) {
     int i = t.next();
-    return s.table.tryGetOrCreateOrNull(
-        SOURCE_K1[i], SOURCE_K2[i], (k1, k2) -> new PairEntry(k1, k2, 0L));
+    return s.table.tryGetOrCreateOrNull(SOURCE_K1[i], SOURCE_K2[i], D2Entry::new);
   }
 
   @Benchmark

--- a/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapD2Benchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapD2Benchmark.java
@@ -95,15 +95,6 @@ public class ThreadSafeMapD2Benchmark {
     }
   }
 
-  static final class D2Entry extends ConcurrentHashtable.D2.Entry<String, Integer, D2Entry> {
-    final long value;
-
-    D2Entry(String k1, Integer k2) {
-      super(k1, k2);
-      this.value = 1L;
-    }
-  }
-
   /**
    * Entry used with the static helpers. Its primitive second key keeps storage and lookup unboxed,
    * independently of {@link Integer} caching or JVM escape analysis.
@@ -131,6 +122,16 @@ public class ThreadSafeMapD2Benchmark {
     @Override
     public boolean matches(SupportEntry other) {
       return matches(other.k1, other.k2);
+    }
+  }
+
+  /** Entry used with {@link ConcurrentHashtable.D2}. */
+  static final class PairEntry extends ConcurrentHashtable.D2.Entry<String, Integer, PairEntry> {
+    final long value;
+
+    PairEntry(String key1, Integer key2, long value) {
+      super(key1, key2);
+      this.value = value;
     }
   }
 
@@ -176,7 +177,7 @@ public class ThreadSafeMapD2Benchmark {
    */
   @State(Scope.Benchmark)
   public static class SharedState {
-    ConcurrentHashtable.D2<String, Integer, D2Entry> table;
+    ConcurrentHashtable.D2<String, Integer, PairEntry> table;
     java.util.concurrent.atomic.AtomicReferenceArray<SupportEntry> supportBuckets;
     ConcurrentHashMap<Key2, Long> concurrentHashMap;
     ConcurrentSkipListMap<Key2, Long> skipListMap;
@@ -184,14 +185,14 @@ public class ThreadSafeMapD2Benchmark {
 
     @Setup(Level.Iteration)
     public void setUp() {
-      table = ConcurrentHashtable.D2.createBounded(D2Entry.class, CAPACITY);
+      table = ConcurrentHashtable.D2.createBounded(PairEntry.class, CAPACITY);
       supportBuckets = ConcurrentHashtable.createFixedBuckets(SupportEntry.class, CAPACITY);
       concurrentHashMap = new ConcurrentHashMap<>(CAPACITY);
       skipListMap = new ConcurrentSkipListMap<>();
       synchronizedHashMap = Collections.synchronizedMap(new HashMap<>(CAPACITY));
       for (int i = 0; i < N_KEYS; ++i) {
         int k2 = SOURCE_K2[i];
-        table.tryGetOrCreateOrNull(SOURCE_K1[i], SOURCE_K2[i], D2Entry::new);
+        table.tryGetOrCreateOrNull(SOURCE_K1[i], SOURCE_K2[i], (a, b) -> new PairEntry(a, b, 1L));
         // populate support table
         SupportEntry se = new SupportEntry(SOURCE_K1[i], k2);
         synchronized (ConcurrentHashtable.getWriteLock(supportBuckets, se.keyHash)) {
@@ -218,7 +219,7 @@ public class ThreadSafeMapD2Benchmark {
   }
 
   @Benchmark
-  public D2Entry get_concurrentHashtable(SharedState s, ThreadState t) {
+  public PairEntry get_concurrentHashtable(SharedState s, ThreadState t) {
     int i = t.next();
     return s.table.get(SOURCE_K1[i], SOURCE_K2[i]);
   }
@@ -258,9 +259,10 @@ public class ThreadSafeMapD2Benchmark {
   }
 
   @Benchmark
-  public D2Entry getOrCreate_concurrentHashtable(SharedState s, ThreadState t) {
+  public PairEntry getOrCreate_concurrentHashtable(SharedState s, ThreadState t) {
     int i = t.next();
-    return s.table.tryGetOrCreateOrNull(SOURCE_K1[i], SOURCE_K2[i], D2Entry::new);
+    return s.table.tryGetOrCreateOrNull(
+        SOURCE_K1[i], SOURCE_K2[i], (k1, k2) -> new PairEntry(k1, k2, 0L));
   }
 
   @Benchmark

--- a/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapD2Benchmark.java
+++ b/internal-api/src/jmh/java/datadog/trace/util/ThreadSafeMapD2Benchmark.java
@@ -95,7 +95,7 @@ public class ThreadSafeMapD2Benchmark {
     }
   }
 
-  static final class D2Entry extends ConcurrentHashtable.D2.Entry<String, Integer> {
+  static final class D2Entry extends ConcurrentHashtable.D2.Entry<String, Integer, D2Entry> {
     final long value;
 
     D2Entry(String k1, Integer k2) {
@@ -108,7 +108,7 @@ public class ThreadSafeMapD2Benchmark {
    * Entry used with the static helpers. Its primitive second key keeps storage and lookup unboxed,
    * independently of {@link Integer} caching or JVM escape analysis.
    */
-  static final class SupportEntry extends ConcurrentHashtable.Entry {
+  static final class SupportEntry extends ConcurrentHashtable.Entry<SupportEntry> {
     final String k1;
     final int k2;
     final long value;
@@ -126,6 +126,11 @@ public class ThreadSafeMapD2Benchmark {
 
     boolean matches(String k1, int k2) {
       return this.k2 == k2 && this.k1.equals(k1);
+    }
+
+    @Override
+    public boolean matches(SupportEntry other) {
+      return matches(other.k1, other.k2);
     }
   }
 

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/LogCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/LogCollector.java
@@ -1,16 +1,15 @@
 package datadog.trace.api.telemetry;
 
+import datadog.trace.util.ConcurrentHashtable;
 import datadog.trace.util.HashingUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
@@ -20,8 +19,7 @@ public class LogCollector {
   public static final Marker EXCLUDE_TELEMETRY = MarkerFactory.getMarker("EXCLUDE_TELEMETRY");
   private static final int DEFAULT_MAX_CAPACITY = 10;
   private static final LogCollector INSTANCE = new LogCollector();
-  private final Map<RawLogMessage, AtomicInteger> rawLogMessages;
-  private final int maxCapacity;
+  private final ConcurrentHashtable.State<RawLogMessage> rawLogMessages;
 
   public static LogCollector get() {
     return INSTANCE;
@@ -35,8 +33,7 @@ public class LogCollector {
       value = "SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR",
       justification = "Usage in tests")
   LogCollector(int maxCapacity) {
-    this.maxCapacity = maxCapacity;
-    this.rawLogMessages = new ConcurrentHashMap<>(maxCapacity);
+    this.rawLogMessages = ConcurrentHashtable.createBounded(RawLogMessage.class, maxCapacity);
   }
 
   public void addLogMessage(String logLevel, String message, @Nullable Throwable throwable) {
@@ -54,57 +51,62 @@ public class LogCollector {
    */
   public void addLogMessage(
       String logLevel, String message, @Nullable Throwable throwable, @Nullable String tags) {
-    if (rawLogMessages.size() >= maxCapacity) {
-      // TODO: We could emit a metric for dropped logs.
-      return;
+    long keyHash = RawLogMessage.hash(logLevel, message, throwable);
+
+    // Lock-free scan first: most calls are re-observations of an already-seen message, so this
+    // avoids paying for a reservation and a RawLogMessage allocation on the common path.
+    for (RawLogMessage existing = ConcurrentHashtable.bucketFor(rawLogMessages, keyHash);
+        existing != null;
+        existing = existing.next()) {
+      if (existing.keyHash == keyHash && existing.matchesKey(logLevel, message, throwable)) {
+        existing.count.incrementAndGet();
+        return;
+      }
     }
-    RawLogMessage rawLogMessage =
-        new RawLogMessage(logLevel, message, throwable, tags, System.currentTimeMillis() / 1000);
-    AtomicInteger count = rawLogMessages.computeIfAbsent(rawLogMessage, k -> new AtomicInteger());
-    count.incrementAndGet();
+
+    try (ConcurrentHashtable.Reservation<RawLogMessage> reservation =
+        ConcurrentHashtable.reserve(rawLogMessages)) {
+      // TODO: We could emit a metric for dropped logs when the reservation is empty (table full).
+      RawLogMessage rawLogMessage =
+          reservation.tryGetOrInsertOrNull(RawLogMessage::new, logLevel, message, throwable, tags);
+      if (rawLogMessage != null) {
+        rawLogMessage.count.incrementAndGet();
+      }
+    }
   }
 
   public Collection<RawLogMessage> drain() {
-    if (rawLogMessages.isEmpty()) {
+    if (ConcurrentHashtable.estimateSize(rawLogMessages) == 0) {
       return Collections.emptyList();
     }
 
-    List<RawLogMessage> list = new ArrayList<>(rawLogMessages.size());
-    Iterator<Map.Entry<RawLogMessage, AtomicInteger>> iterator =
-        rawLogMessages.entrySet().iterator();
-
-    while (iterator.hasNext()) {
-      Map.Entry<RawLogMessage, AtomicInteger> entry = iterator.next();
-      RawLogMessage logMessage = entry.getKey();
-      // XXX: There might be lost writers to the counters under concurrency if another thread
-      // increments it
-      //      while we are reading it here. At the moment, we are not overdoing this to prevent some
-      // counter losses.
-      logMessage.count = entry.getValue().get();
-      iterator.remove();
-      list.add(logMessage);
-    }
-
+    List<RawLogMessage> list = new ArrayList<>(ConcurrentHashtable.estimateSize(rawLogMessages));
+    ConcurrentHashtable.drain(rawLogMessages, list::add);
     return list;
   }
 
-  public static final class RawLogMessage {
+  public static final class RawLogMessage extends ConcurrentHashtable.Entry<RawLogMessage> {
     public final String message;
     public final String logLevel;
     public final Throwable throwable;
     public final String tags;
     public final long timestamp;
-    public int count;
+    public final AtomicInteger count = new AtomicInteger();
 
     private StackTraceElement[] cachedStackTrace = null;
 
     public RawLogMessage(
-        String logLevel, String message, Throwable throwable, String tags, long timestamp) {
+        String logLevel, String message, Throwable throwable, @Nullable String tags) {
+      super(hash(logLevel, message, throwable));
       this.logLevel = logLevel;
       this.message = message;
       this.throwable = throwable;
       this.tags = tags;
-      this.timestamp = timestamp;
+      this.timestamp = System.currentTimeMillis() / 1000;
+    }
+
+    static long hash(String logLevel, String message, @Nullable Throwable throwable) {
+      return HashingUtils.hash(logLevel, message, throwable == null ? null : throwable.getClass());
     }
 
     public StackTraceElement[] stackTrace() {
@@ -122,25 +124,20 @@ public class LogCollector {
       return stackTrace;
     }
 
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      RawLogMessage that = (RawLogMessage) o;
+    private boolean matchesKey(String logLevel, String message, @Nullable Throwable throwable) {
+      if (!Objects.equals(this.logLevel, logLevel)) return false;
+      if (!Objects.equals(this.message, message)) return false;
 
-      if (!Objects.equals(logLevel, that.logLevel)) return false;
-      if (!Objects.equals(message, that.message)) return false;
-
-      if (throwable == that.throwable) {
+      if (this.throwable == throwable) {
         // DQH - While this path may seem unlikely, it does happen if the JVM fast
         // throws optimization kicks-in (for NPE, etc), so this case is worth optimizing.
 
         // This also covers the case where both throwables are null
         return true;
-      } else if (throwable != null && that.throwable != null) {
+      } else if (this.throwable != null && throwable != null) {
         // Both have a throwable perform a deeper comparison
-        return throwable.getClass().equals(that.throwable.getClass())
-            && Objects.deepEquals(stackTrace(), that.stackTrace());
+        return this.throwable.getClass().equals(throwable.getClass())
+            && Objects.deepEquals(stackTrace(), throwable.getStackTrace());
       } else {
         // One has an exception & the other doesn't, not equal
         return false;
@@ -148,8 +145,18 @@ public class LogCollector {
     }
 
     @Override
-    public int hashCode() {
-      return HashingUtils.hash(logLevel, message, throwable == null ? null : throwable.getClass());
+    public boolean matches(@Nonnull RawLogMessage other) {
+      if (!Objects.equals(logLevel, other.logLevel)) return false;
+      if (!Objects.equals(message, other.message)) return false;
+
+      if (throwable == other.throwable) {
+        return true;
+      } else if (throwable != null && other.throwable != null) {
+        return throwable.getClass().equals(other.throwable.getClass())
+            && Objects.deepEquals(stackTrace(), other.stackTrace());
+      } else {
+        return false;
+      }
     }
   }
 }

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/LogCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/LogCollector.java
@@ -63,9 +63,6 @@ public class LogCollector {
     for (Iterator<RawLogMessage> it = ConcurrentHashtable.hashIterator(rawLogMessages, keyHash);
         it.hasNext(); ) {
       RawLogMessage existing = it.next();
-      if (existing.keyHash != keyHash) {
-        continue;
-      }
       if (throwable != null && existing.throwable != null && existing.throwable != throwable) {
         if (throwableStackTrace == null) {
           throwableStackTrace = throwable.getStackTrace();

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/LogCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/LogCollector.java
@@ -6,7 +6,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -60,9 +59,7 @@ public class LogCollector {
 
     // Lock-free scan first: most calls are re-observations of an already-seen message, so this
     // avoids paying for a reservation and a RawLogMessage allocation on the common path.
-    for (Iterator<RawLogMessage> it = ConcurrentHashtable.hashIterator(rawLogMessages, keyHash);
-        it.hasNext(); ) {
-      RawLogMessage existing = it.next();
+    for (RawLogMessage existing : ConcurrentHashtable.hashIterable(rawLogMessages, keyHash)) {
       if (throwable != null && existing.throwable != null && existing.throwable != throwable) {
         if (throwableStackTrace == null) {
           throwableStackTrace = throwable.getStackTrace();
@@ -78,7 +75,7 @@ public class LogCollector {
         ConcurrentHashtable.tryReserve(rawLogMessages)) {
       // TODO: We could emit a metric for dropped logs when the reservation is empty (table full).
       RawLogMessage rawLogMessage =
-          reservation.tryGetOrInsertOrNull(RawLogMessage::new, logLevel, message, throwable, tags);
+          reservation.tryGetOrInsertOrNull(logLevel, message, throwable, tags, RawLogMessage::new);
       if (rawLogMessage != null) {
         rawLogMessage.count.incrementAndGet();
       }

--- a/internal-api/src/main/java/datadog/trace/api/telemetry/LogCollector.java
+++ b/internal-api/src/main/java/datadog/trace/api/telemetry/LogCollector.java
@@ -6,6 +6,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -53,19 +54,31 @@ public class LogCollector {
       String logLevel, String message, @Nullable Throwable throwable, @Nullable String tags) {
     long keyHash = RawLogMessage.hash(logLevel, message, throwable);
 
+    // Memoized once per call and shared across every candidate below, rather than letting
+    // matchesKey call throwable.getStackTrace() (a defensive-copy allocation) on each comparison.
+    StackTraceElement[] throwableStackTrace = null;
+
     // Lock-free scan first: most calls are re-observations of an already-seen message, so this
     // avoids paying for a reservation and a RawLogMessage allocation on the common path.
-    for (RawLogMessage existing = ConcurrentHashtable.bucketFor(rawLogMessages, keyHash);
-        existing != null;
-        existing = existing.next()) {
-      if (existing.keyHash == keyHash && existing.matchesKey(logLevel, message, throwable)) {
+    for (Iterator<RawLogMessage> it = ConcurrentHashtable.hashIterator(rawLogMessages, keyHash);
+        it.hasNext(); ) {
+      RawLogMessage existing = it.next();
+      if (existing.keyHash != keyHash) {
+        continue;
+      }
+      if (throwable != null && existing.throwable != null && existing.throwable != throwable) {
+        if (throwableStackTrace == null) {
+          throwableStackTrace = throwable.getStackTrace();
+        }
+      }
+      if (existing.matchesKey(logLevel, message, throwable, throwableStackTrace)) {
         existing.count.incrementAndGet();
         return;
       }
     }
 
     try (ConcurrentHashtable.Reservation<RawLogMessage> reservation =
-        ConcurrentHashtable.reserve(rawLogMessages)) {
+        ConcurrentHashtable.tryReserve(rawLogMessages)) {
       // TODO: We could emit a metric for dropped logs when the reservation is empty (table full).
       RawLogMessage rawLogMessage =
           reservation.tryGetOrInsertOrNull(RawLogMessage::new, logLevel, message, throwable, tags);
@@ -76,11 +89,12 @@ public class LogCollector {
   }
 
   public Collection<RawLogMessage> drain() {
-    if (ConcurrentHashtable.estimateSize(rawLogMessages) == 0) {
+    int size = ConcurrentHashtable.estimateSize(rawLogMessages);
+    if (size == 0) {
       return Collections.emptyList();
     }
 
-    List<RawLogMessage> list = new ArrayList<>(ConcurrentHashtable.estimateSize(rawLogMessages));
+    List<RawLogMessage> list = new ArrayList<>(size);
     ConcurrentHashtable.drain(rawLogMessages, list::add);
     return list;
   }
@@ -124,7 +138,17 @@ public class LogCollector {
       return stackTrace;
     }
 
-    private boolean matchesKey(String logLevel, String message, @Nullable Throwable throwable) {
+    /**
+     * @param throwableStackTrace {@code throwable.getStackTrace()}, memoized once by the caller and
+     *     shared across every candidate scanned for a given {@code addLogMessage} call -- avoids
+     *     paying {@code getStackTrace()}'s defensive-copy allocation on each comparison. Only
+     *     non-null when {@code throwable} needs a deep comparison against some candidate.
+     */
+    private boolean matchesKey(
+        String logLevel,
+        String message,
+        @Nullable Throwable throwable,
+        @Nullable StackTraceElement[] throwableStackTrace) {
       if (!Objects.equals(this.logLevel, logLevel)) return false;
       if (!Objects.equals(this.message, message)) return false;
 
@@ -137,7 +161,7 @@ public class LogCollector {
       } else if (this.throwable != null && throwable != null) {
         // Both have a throwable perform a deeper comparison
         return this.throwable.getClass().equals(throwable.getClass())
-            && Objects.deepEquals(stackTrace(), throwable.getStackTrace());
+            && Objects.deepEquals(stackTrace(), throwableStackTrace);
       } else {
         // One has an exception & the other doesn't, not equal
         return false;

--- a/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
+++ b/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
@@ -69,10 +69,16 @@ public final class ConcurrentHashtable {
    * arity. See {@link D1.Entry} and {@link D2.Entry}; for higher arities, or for primitive key
    * components, subclass this directly and drive the table with the static building blocks on
    * {@link ConcurrentHashtable}.
+   *
+   * <p>The self-bound type parameter ({@code TEntry extends Entry<TEntry>}, mirroring {@code Enum<E
+   * extends Enum<E>>}) exists so {@link #matches(Entry)} can compare two already-built entries
+   * without an {@code Object}/{@code instanceof} boundary. It requires every concrete subclass to
+   * declare itself as its own type argument (see {@link D1.Entry}/{@link D2.Entry}); Java has no
+   * true {@code Self} type, so this is enforced by convention, not the compiler.
    */
-  public abstract static class Entry {
+  public abstract static class Entry<TEntry extends Entry<TEntry>> {
     public final long keyHash;
-    private volatile Entry next = null;
+    private volatile Entry<?> next = null;
 
     protected Entry(long keyHash) {
       this.keyHash = keyHash;
@@ -81,33 +87,48 @@ public final class ConcurrentHashtable {
     // Package-private: the only writers are the static insert/remove building blocks
     // (insertHeadEntry, unlink) on the enclosing class, which reach it via the Entry bound. Custom
     // tables mutate chains through those helpers, never by touching next directly.
-    final <TEntry extends Entry> void setNext(TEntry next) {
+    final <TNext extends Entry<TNext>> void setNext(TNext next) {
       this.next = next;
     }
 
     @SuppressWarnings("unchecked")
     @Nullable
-    public final <TEntry extends Entry> TEntry next() {
-      return (TEntry) this.next;
+    public final <TNext extends Entry<TNext>> TNext next() {
+      return (TNext) this.next;
     }
+
+    /**
+     * Returns {@code true} if {@code other} is logically the same entry as this one (same key(s)),
+     * used to compare two already-built entries under the write lock (e.g. in {@link
+     * Reservation#tryGetOrInsertOrNull}). Deliberately narrower than {@code equals}/{@code
+     * hashCode}: this class doesn't need reflexive/symmetric-with-null-and-unrelated-types contract
+     * baggage, and a bespoke method avoids entries accidentally working as {@code HashSet}/{@code
+     * HashMap} keys via an unrelated identity notion. {@link D1.Entry}/{@link D2.Entry} implement
+     * this in terms of their existing key-based {@code matches(...)}, so most callers never write
+     * it directly.
+     */
+    public abstract boolean matches(@Nonnull TEntry other);
   }
 
   /**
    * Single-key concurrent hash table. Lock-free on hit; locked on miss/mutation.
    *
    * @param <K> the key type
-   * @param <TEntry> the user's {@link D1.Entry D1.Entry&lt;K&gt;} subclass
+   * @param <TEntry> the user's {@link D1.Entry D1.Entry&lt;K, TEntry&gt;} subclass
    */
   @ThreadSafe
-  public static final class D1<K, TEntry extends D1.Entry<K>> {
+  public static final class D1<K, TEntry extends D1.Entry<K, TEntry>> {
 
     /**
      * Abstract base for {@link D1} entries. Subclass to add value fields you wish to mutate in
      * place after retrieving the entry via {@link D1#get}.
      *
      * @param <K> the key type
+     * @param <TEntry> the concrete subclass extending this one (self-bound, see {@link
+     *     ConcurrentHashtable.Entry})
      */
-    public abstract static class Entry<K> extends ConcurrentHashtable.Entry {
+    public abstract static class Entry<K, TEntry extends Entry<K, TEntry>>
+        extends ConcurrentHashtable.Entry<TEntry> {
       final K key;
 
       protected Entry(@Nullable K key) {
@@ -125,6 +146,12 @@ public final class ConcurrentHashtable {
         // equals() on the lookup param, not the field, so the JIT can devirtualize it once
         // matches() inlines into get/getOrCreate (the caller's key type is known there).
         return Objects.equals(key, this.key);
+      }
+
+      /** {@link ConcurrentHashtable.Entry#matches(Entry)} in terms of the key-based overload. */
+      @Override
+      public boolean matches(@Nonnull TEntry other) {
+        return matches(other.key);
       }
 
       /**
@@ -149,7 +176,7 @@ public final class ConcurrentHashtable {
      * the insertion methods. The table does not resize.
      */
     @Nonnull
-    public static <K, TEntry extends D1.Entry<K>> D1<K, TEntry> createBounded(
+    public static <K, TEntry extends D1.Entry<K, TEntry>> D1<K, TEntry> createBounded(
         @Nonnull Class<TEntry> entryClass, int maxCapacity) {
       return new D1<>(ConcurrentHashtable.createBounded(entryClass, maxCapacity));
     }
@@ -354,10 +381,10 @@ public final class ConcurrentHashtable {
    *
    * @param <K1> first key type
    * @param <K2> second key type
-   * @param <TEntry> the user's {@link D2.Entry D2.Entry&lt;K1, K2&gt;} subclass
+   * @param <TEntry> the user's {@link D2.Entry D2.Entry&lt;K1, K2, TEntry&gt;} subclass
    */
   @ThreadSafe
-  public static final class D2<K1, K2, TEntry extends D2.Entry<K1, K2>> {
+  public static final class D2<K1, K2, TEntry extends D2.Entry<K1, K2, TEntry>> {
 
     /**
      * Abstract base for {@link D2} entries. Subclass to add value fields you wish to mutate in
@@ -365,8 +392,11 @@ public final class ConcurrentHashtable {
      *
      * @param <K1> first key type
      * @param <K2> second key type
+     * @param <TEntry> the concrete subclass extending this one (self-bound, see {@link
+     *     ConcurrentHashtable.Entry})
      */
-    public abstract static class Entry<K1, K2> extends ConcurrentHashtable.Entry {
+    public abstract static class Entry<K1, K2, TEntry extends Entry<K1, K2, TEntry>>
+        extends ConcurrentHashtable.Entry<TEntry> {
       final K1 key1;
       final K2 key2;
 
@@ -394,6 +424,12 @@ public final class ConcurrentHashtable {
         return Objects.equals(key1, this.key1) && Objects.equals(key2, this.key2);
       }
 
+      /** {@link ConcurrentHashtable.Entry#matches(Entry)} in terms of the key-based overload. */
+      @Override
+      public boolean matches(@Nonnull TEntry other) {
+        return matches(other.key1, other.key2);
+      }
+
       /** Returns the 64-bit lookup hash combining both key parts via {@link LongHashingUtils}. */
       public static long hash(@Nullable Object key1, @Nullable Object key2) {
         return LongHashingUtils.hash(key1, key2);
@@ -412,8 +448,8 @@ public final class ConcurrentHashtable {
      * the insertion methods. The table does not resize.
      */
     @Nonnull
-    public static <K1, K2, TEntry extends D2.Entry<K1, K2>> D2<K1, K2, TEntry> createBounded(
-        @Nonnull Class<TEntry> entryClass, int maxCapacity) {
+    public static <K1, K2, TEntry extends D2.Entry<K1, K2, TEntry>>
+        D2<K1, K2, TEntry> createBounded(@Nonnull Class<TEntry> entryClass, int maxCapacity) {
       return new D2<>(ConcurrentHashtable.createBounded(entryClass, maxCapacity));
     }
 
@@ -663,8 +699,9 @@ public final class ConcurrentHashtable {
      * cannot both acquire the last slot. Returns {@code false} with the count unchanged when the
      * table is full.
      *
-     * <p>Build the entry before reserving: there is no cancellation operation, so abandoning a
-     * successful reservation permanently consumes capacity.
+     * <p>Prefer {@link #cancelReservation()} plus deferred entry construction (see {@link
+     * ConcurrentHashtable#reserve}) over abandoning a reservation outright: this method by itself
+     * still has no way to give back a slot once claimed.
      */
     public boolean tryReserve() {
       if (size.incrementAndGet() > capacity) {
@@ -675,6 +712,27 @@ public final class ConcurrentHashtable {
     }
 
     /**
+     * Gives back a slot claimed by {@link #tryReserve()} that was never filled — e.g. a concurrent
+     * match was found under the write lock instead of inserting. Lock-free, symmetric with {@link
+     * #decrement()}.
+     *
+     * <p>Caller must call this at most once per successful {@link #tryReserve()}; double-cancelling
+     * corrupts the count the same way double-incrementing would. {@link Reservation#close()}
+     * handles this bookkeeping automatically and should be preferred over calling this directly.
+     *
+     * <p>Under heavy contention on the same logical duplicate, multiple threads can each reserve a
+     * slot for what turns out to be the same entry before any of them cancels, transiently
+     * inflating {@code size} above the table's true occupancy. This can cause an unrelated,
+     * genuinely distinct concurrent insert to see the table as full when it isn't, until the losing
+     * reservations cancel. The effect is self-correcting (bounded by in-flight reservations, not
+     * sustained) and considered an acceptable tradeoff for tables expecting bursts of identical
+     * inserts (e.g. deduplication).
+     */
+    public void cancelReservation() {
+      size.decrementAndGet();
+    }
+
+    /**
      * Reserves one slot, evicting an entry matching {@code evictable} when the table is full.
      * Returns {@code false} without changing the table when no entry can be evicted.
      *
@@ -682,7 +740,7 @@ public final class ConcurrentHashtable {
      * an abandoned reservation permanently consumes capacity.
      */
     @GuardedBy("getTableWriteLock(buckets)")
-    public <TEntry extends Entry> boolean tryReserveOrEvict(
+    public <TEntry extends Entry<TEntry>> boolean tryReserveOrEvict(
         @Nonnull AtomicReferenceArray<TEntry> buckets,
         @Nonnull Predicate<? super TEntry> evictable) {
       if (tryReserve()) {
@@ -733,7 +791,7 @@ public final class ConcurrentHashtable {
      */
     @GuardedBy("getTableWriteLock(buckets)")
     @Nullable
-    public <TEntry extends Entry> TEntry evictOne(
+    public <TEntry extends Entry<TEntry>> TEntry evictOne(
         @Nonnull AtomicReferenceArray<TEntry> buckets,
         @Nonnull Predicate<? super TEntry> evictable) {
       TEntry evicted = evictOneInRange(buckets, evictable, evictionCursor, buckets.length());
@@ -758,7 +816,7 @@ public final class ConcurrentHashtable {
             "evictionCursor is read and written only under synchronized (getTableWriteLock(buckets)); SpotBugs"
                 + " cannot model that dynamic guard")
     @Nullable
-    private <TEntry extends Entry> TEntry evictOneInRange(
+    private <TEntry extends Entry<TEntry>> TEntry evictOneInRange(
         @Nonnull AtomicReferenceArray<TEntry> buckets,
         @Nonnull Predicate<? super TEntry> evictable,
         int startBucket,
@@ -788,7 +846,7 @@ public final class ConcurrentHashtable {
         justification =
             "evictionCursor is read and written only under synchronized (getTableWriteLock(buckets)); SpotBugs"
                 + " cannot model that dynamic guard")
-    public <TEntry extends Entry> int evictAll(
+    public <TEntry extends Entry<TEntry>> int evictAll(
         @Nonnull AtomicReferenceArray<TEntry> buckets,
         @Nonnull Predicate<? super TEntry> evictable) {
       int count = 0;
@@ -818,7 +876,7 @@ public final class ConcurrentHashtable {
    * {@link #tryReserve}, {@link #tryReserveOrEvict}, {@link #evictOne}, {@link #evictAll}) rather
    * than reach into the manager directly.
    */
-  public static final class State<TEntry extends Entry> {
+  public static final class State<TEntry extends Entry<TEntry>> {
     public final AtomicReferenceArray<TEntry> buckets;
     final SizeManager sizeManager;
 
@@ -833,7 +891,7 @@ public final class ConcurrentHashtable {
    * that cap. {@code entryClass} is used only to infer {@code TEntry}.
    */
   @Nonnull
-  public static <TEntry extends Entry> State<TEntry> createBounded(
+  public static <TEntry extends Entry<TEntry>> State<TEntry> createBounded(
       @Nonnull Class<TEntry> entryClass, int maxCapacity) {
     return new State<>(createFixedBuckets(entryClass, maxCapacity), maxCapacity);
   }
@@ -855,11 +913,149 @@ public final class ConcurrentHashtable {
    * Lock-free — does not acquire the table write lock. Returns {@code false} with the table
    * unchanged when it is full.
    *
-   * <p>Build the entry before reserving: there is no cancellation operation, so abandoning a
-   * successful reservation permanently consumes capacity. Complete it with {@link #insertReserved}.
+   * <p>Complete it with {@link #insertReserved}, or prefer {@link #reserve} for a higher-level,
+   * auto-cancelling handle that also defers entry construction until the reservation succeeds.
    */
-  public static <TEntry extends Entry> boolean tryReserve(@Nonnull State<TEntry> state) {
+  public static <TEntry extends Entry<TEntry>> boolean tryReserve(@Nonnull State<TEntry> state) {
     return state.sizeManager.tryReserve();
+  }
+
+  /**
+   * Claims one slot in {@code state} and returns a handle for completing the find-or-insert
+   * protocol, or an empty handle if the table is full. Lock-free — does not acquire the table write
+   * lock. Never returns {@code null}, so this always composes with try-with-resources:
+   *
+   * <pre>{@code
+   * try (Reservation<TEntry> r = ConcurrentHashtable.reserve(state)) {
+   *   return r.tryGetOrInsertOrNull(TEntry::new, component1, component2, component3);
+   * }
+   * }</pre>
+   *
+   * <p>Run a lock-free scan first (see {@link #bucketFor}/{@link #bucketAt}) and only call this
+   * once that scan has missed — a successful reservation isn't required for correctness (the
+   * reservation itself, and the locked comparison inside {@link Reservation#tryGetOrInsertOrNull},
+   * are the source of truth), it just avoids paying for a lock and a factory call when a hit was
+   * already visible lock-free.
+   */
+  @Nonnull
+  public static <TEntry extends Entry<TEntry>> Reservation<TEntry> reserve(
+      @Nonnull State<TEntry> state) {
+    return new Reservation<>(state.sizeManager.tryReserve() ? state : null);
+  }
+
+  /**
+   * Handle returned by {@link #reserve}, gating {@link #tryGetOrInsertOrNull} behind a claimed slot
+   * and auto-cancelling it on {@link #close} if it's never consumed. A single {@code Reservation}
+   * must be used for at most one {@code tryGetOrInsertOrNull} call.
+   *
+   * <p>Overloaded up to 4 key components ({@link #tryGetOrInsertOrNull(Function, Object)} through
+   * {@link #tryGetOrInsertOrNull(Function4, Object, Object, Object, Object)}) so a non-capturing
+   * method reference can build the entry directly from its natural constructor arguments, without
+   * an intermediate holder object or a capturing lambda.
+   *
+   * @param <TEntry> the table's entry type, itself self-bound (see {@link
+   *     ConcurrentHashtable.Entry})
+   */
+  public static final class Reservation<TEntry extends Entry<TEntry>> implements AutoCloseable {
+    @Nullable private final State<TEntry> state;
+    private boolean consumed;
+
+    private Reservation(@Nullable State<TEntry> state) {
+      this.state = state;
+    }
+
+    /** {@code true} if this is a real, claimed reservation rather than an empty one. */
+    public boolean isPresent() {
+      return state != null;
+    }
+
+    /**
+     * One key component; see {@link #tryGetOrInsertOrNull(BiFunction, Object, Object)} for the
+     * general contract.
+     */
+    @Nullable
+    public <A> TEntry tryGetOrInsertOrNull(
+        @Nonnull Function<? super A, ? extends TEntry> factory, A a) {
+      return state == null ? null : finish(factory.apply(a));
+    }
+
+    /**
+     * Two key components. Builds {@code factory.apply(...)} (skipped entirely if this reservation
+     * is empty — the table was full) and either links the result as a new entry or discards it in
+     * favor of an existing match found under the write lock. Returns {@code null} only when this
+     * reservation is empty; otherwise always returns a real entry (the newly built one, or the
+     * concurrent match).
+     *
+     * <p>Building the entry here, after the reservation already succeeded, keeps the write lock's
+     * critical section limited to the comparison/link/discard decision rather than whatever
+     * construction cost {@code factory} pays. See {@link ConcurrentHashtable.Entry#matches} — the
+     * under-lock comparison is entry-to-entry, so it needs {@code newEntry} already built.
+     */
+    @Nullable
+    public <A, B> TEntry tryGetOrInsertOrNull(
+        @Nonnull BiFunction<? super A, ? super B, ? extends TEntry> factory, A a, B b) {
+      return state == null ? null : finish(factory.apply(a, b));
+    }
+
+    /**
+     * Three key components; see {@link #tryGetOrInsertOrNull(BiFunction, Object, Object)} for the
+     * general contract.
+     */
+    @Nullable
+    public <A, B, C> TEntry tryGetOrInsertOrNull(
+        @Nonnull Function3<? super A, ? super B, ? super C, ? extends TEntry> factory,
+        A a,
+        B b,
+        C c) {
+      return state == null ? null : finish(factory.apply(a, b, c));
+    }
+
+    /** Four key components; see {@link #tryGetOrInsertOrNull(BiFunction, Object, Object)}. */
+    @Nullable
+    public <A, B, C, D> TEntry tryGetOrInsertOrNull(
+        @Nonnull Function4<? super A, ? super B, ? super C, ? super D, ? extends TEntry> factory,
+        A a,
+        B b,
+        C c,
+        D d) {
+      return state == null ? null : finish(factory.apply(a, b, c, d));
+    }
+
+    private TEntry finish(@Nonnull TEntry newEntry) {
+      synchronized (getTableWriteLock(state)) {
+        int index = bucketIndex(state.buckets, newEntry.keyHash);
+        for (TEntry curEntry = bucketAt(state, index);
+            curEntry != null;
+            curEntry = curEntry.next()) {
+          if (curEntry.keyHash == newEntry.keyHash && curEntry.matches(newEntry)) {
+            return curEntry;
+          }
+        }
+        insertHeadEntryAt(state, index, newEntry);
+        consumed = true;
+        return newEntry;
+      }
+    }
+
+    /** Gives back an unconsumed reservation's slot; a no-op on an empty reservation. */
+    @Override
+    public void close() {
+      if (state != null && !consumed) {
+        state.sizeManager.cancelReservation();
+      }
+    }
+  }
+
+  /** Three-argument analogue of {@link java.util.function.BiFunction}. */
+  @FunctionalInterface
+  public interface Function3<A, B, C, R> {
+    R apply(A a, B b, C c);
+  }
+
+  /** Four-argument analogue of {@link java.util.function.BiFunction}. */
+  @FunctionalInterface
+  public interface Function4<A, B, C, D, R> {
+    R apply(A a, B b, C c, D d);
   }
 
   /**
@@ -870,7 +1066,7 @@ public final class ConcurrentHashtable {
    * <p>The reservation survives drain and clear operations. Complete it with {@link
    * #insertReserved}; abandoning it permanently consumes capacity.
    */
-  public static <TEntry extends Entry> boolean tryReserveOrEvict(
+  public static <TEntry extends Entry<TEntry>> boolean tryReserveOrEvict(
       @Nonnull State<TEntry> state, @Nonnull Predicate<? super TEntry> evictable) {
     synchronized (getTableWriteLock(state)) {
       return state.sizeManager.tryReserveOrEvict(state.buckets, evictable);
@@ -883,7 +1079,7 @@ public final class ConcurrentHashtable {
    * Self-locking.
    */
   @Nullable
-  public static <TEntry extends Entry> TEntry evictOne(
+  public static <TEntry extends Entry<TEntry>> TEntry evictOne(
       @Nonnull State<TEntry> state, @Nonnull Predicate<? super TEntry> evictable) {
     synchronized (getTableWriteLock(state)) {
       return state.sizeManager.evictOne(state.buckets, evictable);
@@ -894,7 +1090,7 @@ public final class ConcurrentHashtable {
    * Unlinks every entry in {@code state} matching {@code evictable}, decrementing per removal, and
    * returns how many went. Self-locking.
    */
-  public static <TEntry extends Entry> int evictAll(
+  public static <TEntry extends Entry<TEntry>> int evictAll(
       @Nonnull State<TEntry> state, @Nonnull Predicate<? super TEntry> evictable) {
     synchronized (getTableWriteLock(state)) {
       return state.sizeManager.evictAll(state.buckets, evictable);
@@ -918,7 +1114,7 @@ public final class ConcurrentHashtable {
    * reflective allocation or runtime type checks; it only lets the compiler infer {@code TEntry}.
    */
   @Nonnull
-  public static <TEntry extends Entry> AtomicReferenceArray<TEntry> createFixedBuckets(
+  public static <TEntry extends Entry<TEntry>> AtomicReferenceArray<TEntry> createFixedBuckets(
       @Nonnull Class<TEntry> entryClass, int capacity) {
     return new AtomicReferenceArray<>(sizeFor(capacity));
   }
@@ -1013,14 +1209,14 @@ public final class ConcurrentHashtable {
    * bucket.
    */
   @Nullable
-  public static <TEntry extends Entry> TEntry bucketFor(
+  public static <TEntry extends Entry<TEntry>> TEntry bucketFor(
       @Nonnull AtomicReferenceArray<TEntry> buckets, long keyHash) {
     return buckets.get(bucketIndex(buckets, keyHash));
   }
 
   /** {@link #bucketFor(AtomicReferenceArray, long)} over a {@link State}. */
   @Nullable
-  public static <TEntry extends Entry> TEntry bucketFor(
+  public static <TEntry extends Entry<TEntry>> TEntry bucketFor(
       @Nonnull State<TEntry> state, long keyHash) {
     return bucketFor(state.buckets, keyHash);
   }
@@ -1032,14 +1228,15 @@ public final class ConcurrentHashtable {
    * overload of it.
    */
   @Nullable
-  public static <TEntry extends Entry> TEntry bucketAt(
+  public static <TEntry extends Entry<TEntry>> TEntry bucketAt(
       @Nonnull AtomicReferenceArray<TEntry> buckets, int index) {
     return buckets.get(index);
   }
 
   /** {@link #bucketAt(AtomicReferenceArray, int)} over a {@link State}. */
   @Nullable
-  public static <TEntry extends Entry> TEntry bucketAt(@Nonnull State<TEntry> state, int index) {
+  public static <TEntry extends Entry<TEntry>> TEntry bucketAt(
+      @Nonnull State<TEntry> state, int index) {
     return bucketAt(state.buckets, index);
   }
 
@@ -1053,7 +1250,7 @@ public final class ConcurrentHashtable {
    * retains its {@code next} link for readers already traversing that chain.
    */
   @GuardedBy("getWriteLockAt(buckets, index)")
-  public static <TEntry extends Entry> void insertHeadEntryAt(
+  public static <TEntry extends Entry<TEntry>> void insertHeadEntryAt(
       @Nonnull AtomicReferenceArray<TEntry> buckets, int index, @Nonnull TEntry entry) {
     assert Thread.holdsLock(getWriteLockAt(buckets, index))
         : "insertHeadEntryAt called without holding getWriteLockAt(buckets, index)";
@@ -1067,7 +1264,7 @@ public final class ConcurrentHashtable {
 
   /** {@link #insertHeadEntryAt(AtomicReferenceArray, int, Entry)} over a {@link State}. */
   @GuardedBy("getWriteLockAt(state, index)")
-  public static <TEntry extends Entry> void insertHeadEntryAt(
+  public static <TEntry extends Entry<TEntry>> void insertHeadEntryAt(
       @Nonnull State<TEntry> state, int index, @Nonnull TEntry entry) {
     insertHeadEntryAt(state.buckets, index, entry);
   }
@@ -1078,7 +1275,7 @@ public final class ConcurrentHashtable {
    * getOrCreate} that reuses it across the lock-free pre-check).
    */
   @GuardedBy("getWriteLock(buckets, keyHash)")
-  public static <TEntry extends Entry> void insertHeadEntryFor(
+  public static <TEntry extends Entry<TEntry>> void insertHeadEntryFor(
       @Nonnull AtomicReferenceArray<TEntry> buckets, long keyHash, @Nonnull TEntry entry) {
     insertHeadEntryAt(buckets, bucketIndex(buckets, keyHash), entry);
   }
@@ -1092,7 +1289,7 @@ public final class ConcurrentHashtable {
    * reservations.
    */
   @GuardedBy("getTableWriteLock(state)")
-  public static <TEntry extends Entry> void insertReserved(
+  public static <TEntry extends Entry<TEntry>> void insertReserved(
       @Nonnull State<TEntry> state, long keyHash, @Nonnull TEntry entry) {
     insertHeadEntryFor(state.buckets, keyHash, entry);
   }
@@ -1107,7 +1304,7 @@ public final class ConcurrentHashtable {
    * Does not touch size accounting.
    */
   @GuardedBy("getWriteLockAt(buckets, index)")
-  public static <TEntry extends Entry> void unlink(
+  public static <TEntry extends Entry<TEntry>> void unlink(
       @Nonnull AtomicReferenceArray<TEntry> buckets,
       int index,
       @Nullable TEntry prev,
@@ -1124,7 +1321,7 @@ public final class ConcurrentHashtable {
 
   /** {@link #unlink(AtomicReferenceArray, int, Entry, Entry)} over a {@link State}. */
   @GuardedBy("getWriteLockAt(state, index)")
-  public static <TEntry extends Entry> void unlink(
+  public static <TEntry extends Entry<TEntry>> void unlink(
       @Nonnull State<TEntry> state, int index, @Nullable TEntry prev, @Nonnull TEntry entry) {
     unlink(state.buckets, index, prev, entry);
   }
@@ -1135,7 +1332,7 @@ public final class ConcurrentHashtable {
    * predicate sees a stable table and concurrent writers are excluded; lock-free readers continue
    * throughout.
    */
-  public static <TEntry extends Entry> boolean removeIf(
+  public static <TEntry extends Entry<TEntry>> boolean removeIf(
       @Nonnull AtomicReferenceArray<TEntry> buckets,
       @Nonnull AtomicInteger size,
       @Nonnull Predicate<? super TEntry> predicate) {
@@ -1163,7 +1360,7 @@ public final class ConcurrentHashtable {
    * occupancy with a {@link State} instead of a bare counter — used by {@link D1#removeIf} and
    * {@link D2#removeIf}.
    */
-  public static <TEntry extends Entry> boolean removeIf(
+  public static <TEntry extends Entry<TEntry>> boolean removeIf(
       @Nonnull State<TEntry> state, @Nonnull Predicate<? super TEntry> predicate) {
     AtomicReferenceArray<TEntry> buckets = state.buckets;
     synchronized (getTableWriteLock(state)) {
@@ -1192,7 +1389,7 @@ public final class ConcurrentHashtable {
    *
    * <p>The sink must not throw. If it does, the partial drain is not rolled back.
    */
-  public static <TEntry extends Entry> void drain(
+  public static <TEntry extends Entry<TEntry>> void drain(
       @Nonnull AtomicReferenceArray<TEntry> buckets, @Nonnull Consumer<? super TEntry> sink) {
     drainCounting(buckets, sink);
   }
@@ -1202,7 +1399,7 @@ public final class ConcurrentHashtable {
    * sink}, so a {@link State} form can subtract exactly that from its {@link SizeManager} instead
    * of zeroing. The count is free here: the sweep already visits every entry.
    */
-  private static <TEntry extends Entry> int drainCounting(
+  private static <TEntry extends Entry<TEntry>> int drainCounting(
       @Nonnull AtomicReferenceArray<TEntry> buckets, @Nonnull Consumer<? super TEntry> sink) {
     int removed = 0;
     synchronized (getTableWriteLock(buckets)) {
@@ -1222,7 +1419,7 @@ public final class ConcurrentHashtable {
   }
 
   /** Context-passing variant of {@link #drain(AtomicReferenceArray, Consumer)}. Self-locking. */
-  public static <C, TEntry extends Entry> void drain(
+  public static <C, TEntry extends Entry<TEntry>> void drain(
       @Nonnull AtomicReferenceArray<TEntry> buckets,
       C context,
       @Nonnull BiConsumer<? super C, ? super TEntry> sink) {
@@ -1230,7 +1427,7 @@ public final class ConcurrentHashtable {
   }
 
   /** {@link #drainCounting(AtomicReferenceArray, Consumer)}, context-passing form. */
-  private static <C, TEntry extends Entry> int drainCounting(
+  private static <C, TEntry extends Entry<TEntry>> int drainCounting(
       @Nonnull AtomicReferenceArray<TEntry> buckets,
       C context,
       @Nonnull BiConsumer<? super C, ? super TEntry> sink) {
@@ -1257,7 +1454,7 @@ public final class ConcurrentHashtable {
    * freed. Draining without that leaves the cap permanently consumed, so the two belong in one call
    * rather than as a pair the caller has to remember.
    */
-  public static <TEntry extends Entry> void drain(
+  public static <TEntry extends Entry<TEntry>> void drain(
       @Nonnull State<TEntry> state, @Nonnull Consumer<? super TEntry> sink) {
     synchronized (getTableWriteLock(state)) {
       state.sizeManager.release(drainCounting(state.buckets, sink));
@@ -1265,7 +1462,7 @@ public final class ConcurrentHashtable {
   }
 
   /** Context-passing form of {@link #drain(State, Consumer)}. */
-  public static <C, TEntry extends Entry> void drain(
+  public static <C, TEntry extends Entry<TEntry>> void drain(
       @Nonnull State<TEntry> state,
       C context,
       @Nonnull BiConsumer<? super C, ? super TEntry> sink) {
@@ -1290,16 +1487,16 @@ public final class ConcurrentHashtable {
    * rather than O(buckets); clear is a rare, whole-table operation, so the walk is affordable and
    * keeping the count honest is worth more than the constant.
    */
-  private static int clearCounting(@Nonnull AtomicReferenceArray<? extends Entry> buckets) {
+  private static int clearCounting(@Nonnull AtomicReferenceArray<? extends Entry<?>> buckets) {
     int removed = 0;
     synchronized (getTableWriteLock(buckets)) {
       for (int i = 0; i < buckets.length(); i++) {
-        Entry head = buckets.get(i);
+        Entry<?> head = buckets.get(i);
         if (head == null) {
           continue;
         }
         buckets.set(i, null);
-        for (Entry e = head; e != null; e = e.next()) {
+        for (Entry<?> e = head; e != null; e = e.next()) {
           removed++;
         }
       }
@@ -1316,7 +1513,7 @@ public final class ConcurrentHashtable {
     }
   }
 
-  public static <TEntry extends Entry> void forEach(
+  public static <TEntry extends Entry<TEntry>> void forEach(
       @Nonnull AtomicReferenceArray<TEntry> buckets, @Nonnull Consumer<? super TEntry> consumer) {
     for (int i = 0; i < buckets.length(); i++) {
       for (TEntry curEntry = buckets.get(i); curEntry != null; curEntry = curEntry.next()) {
@@ -1325,7 +1522,7 @@ public final class ConcurrentHashtable {
     }
   }
 
-  public static <C, TEntry extends Entry> void forEach(
+  public static <C, TEntry extends Entry<TEntry>> void forEach(
       @Nonnull AtomicReferenceArray<TEntry> buckets,
       C context,
       @Nonnull BiConsumer<? super C, ? super TEntry> consumer) {
@@ -1337,13 +1534,13 @@ public final class ConcurrentHashtable {
   }
 
   /** {@link #forEach(AtomicReferenceArray, Consumer)} over a {@link State}. */
-  public static <TEntry extends Entry> void forEach(
+  public static <TEntry extends Entry<TEntry>> void forEach(
       @Nonnull State<TEntry> state, @Nonnull Consumer<? super TEntry> consumer) {
     forEach(state.buckets, consumer);
   }
 
   /** {@link #forEach(AtomicReferenceArray, Object, BiConsumer)} over a {@link State}. */
-  public static <C, TEntry extends Entry> void forEach(
+  public static <C, TEntry extends Entry<TEntry>> void forEach(
       @Nonnull State<TEntry> state,
       C context,
       @Nonnull BiConsumer<? super C, ? super TEntry> consumer) {

--- a/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
+++ b/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
@@ -941,7 +941,7 @@ public final class ConcurrentHashtable {
    *
    * <pre>{@code
    * try (Reservation<TEntry> r = ConcurrentHashtable.tryReserve(state)) {
-   *   return r.tryGetOrInsertOrNull(TEntry::new, component1, component2, component3);
+   *   return r.tryGetOrInsertOrNull(component1, component2, component3, TEntry::new);
    * }
    * }</pre>
    *
@@ -966,8 +966,8 @@ public final class ConcurrentHashtable {
    * slot and auto-cancelling it on {@link #close} if it's never consumed. A single {@code
    * Reservation} must be used for at most one {@code tryGetOrInsertOrNull} call.
    *
-   * <p>Overloaded up to 4 key components ({@link #tryGetOrInsertOrNull(Function, Object)} through
-   * {@link #tryGetOrInsertOrNull(Function4, Object, Object, Object, Object)}) so a non-capturing
+   * <p>Overloaded up to 4 key components ({@link #tryGetOrInsertOrNull(Object, Function)} through
+   * {@link #tryGetOrInsertOrNull(Object, Object, Object, Object, Function4)}) so a non-capturing
    * method reference can build the entry directly from its natural constructor arguments, without
    * an intermediate holder object or a capturing lambda.
    *
@@ -988,13 +988,13 @@ public final class ConcurrentHashtable {
     }
 
     /**
-     * One key component; see {@link #tryGetOrInsertOrNull(BiFunction, Object, Object)} for the
+     * One key component; see {@link #tryGetOrInsertOrNull(Object, Object, BiFunction)} for the
      * general contract.
      */
     @StrategyConsumer
     @Nullable
     public <A> TEntry tryGetOrInsertOrNull(
-        @Strategy @Nonnull Function<? super A, ? extends TEntry> factory, A a) {
+        A a, @Strategy @Nonnull Function<? super A, ? extends TEntry> factory) {
       return state == null ? null : finish(factory.apply(a));
     }
 
@@ -1013,74 +1013,76 @@ public final class ConcurrentHashtable {
     @StrategyConsumer
     @Nullable
     public <A, B> TEntry tryGetOrInsertOrNull(
-        @Strategy @Nonnull BiFunction<? super A, ? super B, ? extends TEntry> factory, A a, B b) {
+        A a, B b, @Strategy @Nonnull BiFunction<? super A, ? super B, ? extends TEntry> factory) {
       return state == null ? null : finish(factory.apply(a, b));
     }
 
     /**
-     * Three key components; see {@link #tryGetOrInsertOrNull(BiFunction, Object, Object)} for the
+     * Three key components; see {@link #tryGetOrInsertOrNull(Object, Object, BiFunction)} for the
      * general contract.
      */
     @StrategyConsumer
     @Nullable
     public <A, B, C> TEntry tryGetOrInsertOrNull(
-        @Nonnull Function3<? super A, ? super B, ? super C, ? extends TEntry> factory,
-        A a,
-        B b,
-        C c) {
-      return state == null ? null : finish(factory.apply(a, b, c));
-    }
-
-    /** Four key components; see {@link #tryGetOrInsertOrNull(BiFunction, Object, Object)}. */
-    @StrategyConsumer
-    @Nullable
-    public <A, B, C, D> TEntry tryGetOrInsertOrNull(
-        @Nonnull Function4<? super A, ? super B, ? super C, ? super D, ? extends TEntry> factory,
         A a,
         B b,
         C c,
-        D d) {
+        @Strategy @Nonnull Function3<? super A, ? super B, ? super C, ? extends TEntry> factory) {
+      return state == null ? null : finish(factory.apply(a, b, c));
+    }
+
+    /** Four key components; see {@link #tryGetOrInsertOrNull(Object, Object, BiFunction)}. */
+    @StrategyConsumer
+    @Nullable
+    public <A, B, C, D> TEntry tryGetOrInsertOrNull(
+        A a,
+        B b,
+        C c,
+        D d,
+        @Strategy @Nonnull
+            Function4<? super A, ? super B, ? super C, ? super D, ? extends TEntry> factory) {
       return state == null ? null : finish(factory.apply(a, b, c, d));
     }
 
     /**
-     * {@link Maybe}-wrapping counterpart of {@link #tryGetOrInsertOrNull(Function, Object)}, for
+     * {@link Maybe}-wrapping counterpart of {@link #tryGetOrInsertOrNull(Object, Function)}, for
      * callers who'd rather make the "this can fail unlike unbounded collections" outcome visible in
      * the return type than rely on a {@code null} check — mirrors {@link D1#tryGetOrCreate} /
      * {@link D2#tryGetOrCreate} wrapping their own {@code ...OrNull} methods.
      */
     @Nonnull
     public <A> Maybe<TEntry> tryGetOrInsert(
-        @Strategy @Nonnull Function<? super A, ? extends TEntry> factory, A a) {
-      return Maybe.of(tryGetOrInsertOrNull(factory, a));
+        A a, @Strategy @Nonnull Function<? super A, ? extends TEntry> factory) {
+      return Maybe.of(tryGetOrInsertOrNull(a, factory));
     }
 
-    /** Two key components; see {@link #tryGetOrInsert(Function, Object)}. */
+    /** Two key components; see {@link #tryGetOrInsert(Object, Function)}. */
     @Nonnull
     public <A, B> Maybe<TEntry> tryGetOrInsert(
-        @Strategy @Nonnull BiFunction<? super A, ? super B, ? extends TEntry> factory, A a, B b) {
-      return Maybe.of(tryGetOrInsertOrNull(factory, a, b));
+        A a, B b, @Strategy @Nonnull BiFunction<? super A, ? super B, ? extends TEntry> factory) {
+      return Maybe.of(tryGetOrInsertOrNull(a, b, factory));
     }
 
-    /** Three key components; see {@link #tryGetOrInsert(Function, Object)}. */
+    /** Three key components; see {@link #tryGetOrInsert(Object, Function)}. */
     @Nonnull
     public <A, B, C> Maybe<TEntry> tryGetOrInsert(
-        @Nonnull Function3<? super A, ? super B, ? super C, ? extends TEntry> factory,
-        A a,
-        B b,
-        C c) {
-      return Maybe.of(tryGetOrInsertOrNull(factory, a, b, c));
-    }
-
-    /** Four key components; see {@link #tryGetOrInsert(Function, Object)}. */
-    @Nonnull
-    public <A, B, C, D> Maybe<TEntry> tryGetOrInsert(
-        @Nonnull Function4<? super A, ? super B, ? super C, ? super D, ? extends TEntry> factory,
         A a,
         B b,
         C c,
-        D d) {
-      return Maybe.of(tryGetOrInsertOrNull(factory, a, b, c, d));
+        @Strategy @Nonnull Function3<? super A, ? super B, ? super C, ? extends TEntry> factory) {
+      return Maybe.of(tryGetOrInsertOrNull(a, b, c, factory));
+    }
+
+    /** Four key components; see {@link #tryGetOrInsert(Object, Function)}. */
+    @Nonnull
+    public <A, B, C, D> Maybe<TEntry> tryGetOrInsert(
+        A a,
+        B b,
+        C c,
+        D d,
+        @Strategy @Nonnull
+            Function4<? super A, ? super B, ? super C, ? super D, ? extends TEntry> factory) {
+      return Maybe.of(tryGetOrInsertOrNull(a, b, c, d, factory));
     }
 
     private TEntry finish(@Nonnull TEntry newEntry) {
@@ -1352,6 +1354,24 @@ public final class ConcurrentHashtable {
   public static <TEntry extends Entry<TEntry>> Iterator<TEntry> hashIterator(
       @Nonnull State<TEntry> state, long keyHash) {
     return hashIterator(state.buckets, keyHash);
+  }
+
+  /**
+   * {@link Iterable} wrapper around {@link #hashIterator(AtomicReferenceArray, long)}, for callers
+   * that want a plain for-each loop over the candidates for {@code keyHash} rather than driving the
+   * {@link Iterator} by hand.
+   */
+  @Nonnull
+  public static <TEntry extends Entry<TEntry>> Iterable<TEntry> hashIterable(
+      @Nonnull AtomicReferenceArray<TEntry> buckets, long keyHash) {
+    return () -> hashIterator(buckets, keyHash);
+  }
+
+  /** {@link #hashIterable(AtomicReferenceArray, long)} over a {@link State}. */
+  @Nonnull
+  public static <TEntry extends Entry<TEntry>> Iterable<TEntry> hashIterable(
+      @Nonnull State<TEntry> state, long keyHash) {
+    return hashIterable(state.buckets, keyHash);
   }
 
   /**

--- a/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
+++ b/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
@@ -151,7 +151,7 @@ public final class ConcurrentHashtable {
     @Nonnull
     public static <K, TEntry extends D1.Entry<K>> D1<K, TEntry> createBounded(
         @Nonnull Class<TEntry> entryClass, int maxCapacity) {
-      return new D1<>(State.createBounded(entryClass, maxCapacity));
+      return new D1<>(ConcurrentHashtable.createBounded(entryClass, maxCapacity));
     }
 
     public int size() {
@@ -414,7 +414,7 @@ public final class ConcurrentHashtable {
     @Nonnull
     public static <K1, K2, TEntry extends D2.Entry<K1, K2>> D2<K1, K2, TEntry> createBounded(
         @Nonnull Class<TEntry> entryClass, int maxCapacity) {
-      return new D2<>(State.createBounded(entryClass, maxCapacity));
+      return new D2<>(ConcurrentHashtable.createBounded(entryClass, maxCapacity));
     }
 
     public int size() {
@@ -812,25 +812,30 @@ public final class ConcurrentHashtable {
   /**
    * Bucket array and occupancy manager for a caller-defined capped table. Keep them paired and
    * prefer the {@code State}-accepting helpers so structural changes update the count consistently.
+   *
+   * <p>{@code sizeManager} is intentionally package-private: callers outside this class must go
+   * through the {@code State}-accepting static helpers ({@link #estimateSize}, {@link #isFull},
+   * {@link #tryReserve}, {@link #tryReserveOrEvict}, {@link #evictOne}, {@link #evictAll}) rather
+   * than reach into the manager directly.
    */
   public static final class State<TEntry extends Entry> {
     public final AtomicReferenceArray<TEntry> buckets;
-    public final SizeManager sizeManager;
+    final SizeManager sizeManager;
 
     private State(AtomicReferenceArray<TEntry> buckets, int maxCapacity) {
       this.buckets = buckets;
       this.sizeManager = new SizeManager(maxCapacity);
     }
+  }
 
-    /**
-     * Creates a bucket array for {@code maxCapacity} entries and pairs it with a manager enforcing
-     * that cap. {@code entryClass} is used only to infer {@code TEntry}.
-     */
-    @Nonnull
-    public static <TEntry extends Entry> State<TEntry> createBounded(
-        @Nonnull Class<TEntry> entryClass, int maxCapacity) {
-      return new State<>(createFixedBuckets(entryClass, maxCapacity), maxCapacity);
-    }
+  /**
+   * Creates a bucket array for {@code maxCapacity} entries and pairs it with a manager enforcing
+   * that cap. {@code entryClass} is used only to infer {@code TEntry}.
+   */
+  @Nonnull
+  public static <TEntry extends Entry> State<TEntry> createBounded(
+      @Nonnull Class<TEntry> entryClass, int maxCapacity) {
+    return new State<>(createFixedBuckets(entryClass, maxCapacity), maxCapacity);
   }
 
   /** Live entries in {@code state}; see {@link SizeManager#estimateSize()}. Lock-free. */
@@ -843,6 +848,18 @@ public final class ConcurrentHashtable {
    */
   public static boolean isFull(@Nonnull State<?> state) {
     return state.sizeManager.isFull();
+  }
+
+  /**
+   * Reserves one slot in {@code state} without evicting; see {@link SizeManager#tryReserve()}.
+   * Lock-free — does not acquire the table write lock. Returns {@code false} with the table
+   * unchanged when it is full.
+   *
+   * <p>Build the entry before reserving: there is no cancellation operation, so abandoning a
+   * successful reservation permanently consumes capacity. Complete it with {@link #insertReserved}.
+   */
+  public static <TEntry extends Entry> boolean tryReserve(@Nonnull State<TEntry> state) {
+    return state.sizeManager.tryReserve();
   }
 
   /**

--- a/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
+++ b/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
@@ -1305,19 +1305,30 @@ public final class ConcurrentHashtable {
   }
 
   /**
-   * Returns a lock-free iterator over the bucket chain that {@code keyHash} maps to, starting from
-   * {@link #bucketFor(AtomicReferenceArray, long)}. Each {@link Iterator#next()} call follows
-   * {@link Entry#next()}, so the iterator reflects entries linked at the time each step runs rather
-   * than a point-in-time snapshot -- entries inserted ahead of the iterator's current position
-   * after iteration starts may or may not be observed, and a concurrently removed entry remains
-   * reachable because {@code unlink()} deliberately retains its {@code next} link for in-flight
-   * readers.
+   * Returns a lock-free iterator over the candidates for {@code keyHash}: entries in the bucket
+   * chain that {@code keyHash} maps to (starting from {@link #bucketFor(AtomicReferenceArray,
+   * long)}) whose own {@link Entry#keyHash} equals it, skipping any other entry sharing the same
+   * bucket via hash collision on {@link #bucketIndex}. Callers only need a {@code matches} check
+   * against the entries this yields, not a {@code keyHash} check of their own.
+   *
+   * <p>Each step follows {@link Entry#next()}, so the iterator reflects entries linked at the time
+   * each step runs rather than a point-in-time snapshot -- entries inserted ahead of the iterator's
+   * current position after iteration starts may or may not be observed, and a concurrently removed
+   * entry remains reachable because {@code unlink()} deliberately retains its {@code next} link for
+   * in-flight readers.
    */
   @Nonnull
   public static <TEntry extends Entry<TEntry>> Iterator<TEntry> hashIterator(
       @Nonnull AtomicReferenceArray<TEntry> buckets, long keyHash) {
     return new Iterator<TEntry>() {
-      private TEntry next = bucketFor(buckets, keyHash);
+      private TEntry next = advance(bucketFor(buckets, keyHash));
+
+      private TEntry advance(TEntry candidate) {
+        while (candidate != null && candidate.keyHash != keyHash) {
+          candidate = candidate.next();
+        }
+        return candidate;
+      }
 
       @Override
       public boolean hasNext() {
@@ -1330,7 +1341,7 @@ public final class ConcurrentHashtable {
         if (current == null) {
           throw new NoSuchElementException();
         }
-        next = current.next();
+        next = advance(current.next());
         return current;
       }
     };

--- a/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
+++ b/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
@@ -951,8 +951,9 @@ public final class ConcurrentHashtable {
    * already visible lock-free.
    *
    * <p>Always returns a non-null handle — even when the table is full — so the caller must check
-   * {@link Reservation#isPresent()} (or simply call {@link Reservation#tryGetOrInsertOrNull}, which
-   * returns {@code null} on an absent reservation) rather than assume every reservation is real.
+   * {@link Reservation#isReserved()} (or simply call {@link Reservation#tryGetOrInsertOrNull},
+   * which returns {@code null} on an absent reservation) rather than assume every reservation is
+   * real.
    */
   @Nonnull
   public static <TEntry extends Entry<TEntry>> Reservation<TEntry> tryReserve(
@@ -982,8 +983,29 @@ public final class ConcurrentHashtable {
     }
 
     /** {@code true} if this is a real, claimed reservation rather than an empty one. */
-    public boolean isPresent() {
+    public boolean isReserved() {
       return state != null;
+    }
+
+    /**
+     * Escape hatch for a caller that already built {@code newEntry} itself -- e.g. more than 4 key
+     * components, or components the caller wants to keep as primitives rather than boxing them into
+     * a {@code Function}'s type argument:
+     *
+     * <pre>{@code
+     * try (Reservation<TEntry> r = ConcurrentHashtable.tryReserve(state)) {
+     *   if (!r.isReserved()) {
+     *     return null;
+     *   }
+     *   return r.tryGetOrInsertOrNull(new TEntry(longComponent1, longComponent2));
+     * }
+     * }</pre>
+     *
+     * See {@link #tryGetOrInsertOrNull(Object, Object, BiFunction)} for the general contract.
+     */
+    @Nullable
+    public TEntry tryGetOrInsertOrNull(@Nonnull TEntry newEntry) {
+      return state == null ? null : finish(newEntry);
     }
 
     /**
@@ -1041,6 +1063,12 @@ public final class ConcurrentHashtable {
         @Strategy @Nonnull
             Function4<? super A, ? super B, ? super C, ? super D, ? extends TEntry> factory) {
       return state == null ? null : finish(factory.apply(a, b, c, d));
+    }
+
+    /** {@link Maybe}-wrapping counterpart of {@link #tryGetOrInsertOrNull(Entry)}. */
+    @Nonnull
+    public Maybe<TEntry> tryGetOrInsert(@Nonnull TEntry newEntry) {
+      return Maybe.of(tryGetOrInsertOrNull(newEntry));
     }
 
     /**

--- a/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
+++ b/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
@@ -82,7 +82,7 @@ public final class ConcurrentHashtable {
    */
   public abstract static class Entry<TEntry extends Entry<TEntry>> {
     public final long keyHash;
-    private volatile Entry<?> next = null;
+    private volatile TEntry next = null;
 
     protected Entry(long keyHash) {
       this.keyHash = keyHash;
@@ -91,14 +91,13 @@ public final class ConcurrentHashtable {
     // Package-private: the only writers are the static insert/remove building blocks
     // (insertHeadEntry, unlink) on the enclosing class, which reach it via the Entry bound. Custom
     // tables mutate chains through those helpers, never by touching next directly.
-    final <TNext extends Entry<TNext>> void setNext(TNext next) {
+    final void setNext(TEntry next) {
       this.next = next;
     }
 
-    @SuppressWarnings("unchecked")
     @Nullable
-    public final <TNext extends Entry<TNext>> TNext next() {
-      return (TNext) this.next;
+    public final TEntry next() {
+      return this.next;
     }
 
     /**

--- a/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
+++ b/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
@@ -1,6 +1,10 @@
 package datadog.trace.util;
 
+import datadog.trace.api.function.Strategy;
+import datadog.trace.api.function.StrategyConsumer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
@@ -129,7 +133,7 @@ public final class ConcurrentHashtable {
      */
     public abstract static class Entry<K, TEntry extends Entry<K, TEntry>>
         extends ConcurrentHashtable.Entry<TEntry> {
-      final K key;
+      @Nullable final K key;
 
       protected Entry(@Nullable K key) {
         super(hash(key));
@@ -172,8 +176,9 @@ public final class ConcurrentHashtable {
 
     /**
      * Creates a fixed-size table holding at most {@code maxCapacity} entries. {@code entryClass} is
-     * used only to infer the concrete entry type; entries are created by the functions passed to
-     * the insertion methods. The table does not resize.
+     * used only to allocate the backing array with the right component type; entries themselves are
+     * created by the {@code creator}/{@code evictable} functions passed to the insertion methods.
+     * The table does not resize.
      */
     @Nonnull
     public static <K, TEntry extends D1.Entry<K, TEntry>> D1<K, TEntry> createBounded(
@@ -209,7 +214,7 @@ public final class ConcurrentHashtable {
      */
     @Nonnull
     public Maybe<TEntry> tryGetOrCreate(
-        @Nullable K key, @Nonnull Function<? super K, ? extends TEntry> creator) {
+        @Nullable K key, @Strategy @Nonnull Function<? super K, ? extends TEntry> creator) {
       return Maybe.of(tryGetOrCreateOrNull(key, creator));
     }
 
@@ -219,9 +224,10 @@ public final class ConcurrentHashtable {
      * {@code key} was not already present. Re-checks under the lock to avoid duplicate entries
      * under concurrent misses.
      */
+    @StrategyConsumer
     @Nullable
     public TEntry tryGetOrCreateOrNull(
-        @Nullable K key, @Nonnull Function<? super K, ? extends TEntry> creator) {
+        @Nullable K key, @Strategy @Nonnull Function<? super K, ? extends TEntry> creator) {
       long keyHash = D1.Entry.hash(key);
       int index = bucketIndex(state.buckets, keyHash);
       for (TEntry curEntry = bucketAt(state, index); curEntry != null; curEntry = curEntry.next()) {
@@ -260,8 +266,8 @@ public final class ConcurrentHashtable {
     @Nonnull
     public Maybe<TEntry> tryGetOrCreateOrEvict(
         @Nullable K key,
-        @Nonnull Function<? super K, ? extends TEntry> creator,
-        @Nonnull Predicate<? super TEntry> evictable) {
+        @Strategy @Nonnull Function<? super K, ? extends TEntry> creator,
+        @Strategy @Nonnull Predicate<? super TEntry> evictable) {
       return Maybe.of(tryGetOrCreateOrEvictOrNull(key, creator, evictable));
     }
 
@@ -272,11 +278,12 @@ public final class ConcurrentHashtable {
      * ever leaving a slot double-booked. A creator that throws after a successful eviction simply
      * leaves the table one entry smaller — no corruption, just a wasted eviction.
      */
+    @StrategyConsumer
     @Nullable
     public TEntry tryGetOrCreateOrEvictOrNull(
         @Nullable K key,
-        @Nonnull Function<? super K, ? extends TEntry> creator,
-        @Nonnull Predicate<? super TEntry> evictable) {
+        @Strategy @Nonnull Function<? super K, ? extends TEntry> creator,
+        @Strategy @Nonnull Predicate<? super TEntry> evictable) {
       long keyHash = D1.Entry.hash(key);
       int index = bucketIndex(state.buckets, keyHash);
       for (TEntry curEntry = bucketAt(state, index); curEntry != null; curEntry = curEntry.next()) {
@@ -332,7 +339,7 @@ public final class ConcurrentHashtable {
      * Holds the table-level lock for the whole sweep, so the predicate sees a stable table and
      * concurrent writers are excluded; lock-free readers continue throughout.
      */
-    public boolean removeIf(@Nonnull Predicate<? super TEntry> predicate) {
+    public boolean removeIf(@Strategy @Nonnull Predicate<? super TEntry> predicate) {
       return ConcurrentHashtable.removeIf(state, predicate);
     }
 
@@ -343,7 +350,7 @@ public final class ConcurrentHashtable {
      *
      * <p>Use {@link #drain(Object, BiConsumer)} to avoid a capturing lambda.
      */
-    public void drain(@Nonnull Consumer<? super TEntry> sink) {
+    public void drain(@Strategy @Nonnull Consumer<? super TEntry> sink) {
       ConcurrentHashtable.drain(state, sink);
     }
 
@@ -352,7 +359,8 @@ public final class ConcurrentHashtable {
      * a {@code static final}) plus the accumulator as {@code context} (e.g. the target list or
      * event builder) to avoid a capturing-lambda allocation.
      */
-    public <C> void drain(C context, @Nonnull BiConsumer<? super C, ? super TEntry> sink) {
+    public <C> void drain(
+        C context, @Strategy @Nonnull BiConsumer<? super C, ? super TEntry> sink) {
       ConcurrentHashtable.drain(state, context, sink);
     }
 
@@ -361,7 +369,7 @@ public final class ConcurrentHashtable {
       ConcurrentHashtable.clear(state);
     }
 
-    public void forEach(@Nonnull Consumer<? super TEntry> consumer) {
+    public void forEach(@Strategy @Nonnull Consumer<? super TEntry> consumer) {
       ConcurrentHashtable.forEach(state, consumer);
     }
 
@@ -369,7 +377,8 @@ public final class ConcurrentHashtable {
      * Context-passing forEach. Avoids a capturing-lambda allocation — pass a non-capturing {@link
      * BiConsumer} (typically a {@code static final}) plus whatever side-band state it needs.
      */
-    public <C> void forEach(C context, @Nonnull BiConsumer<? super C, ? super TEntry> consumer) {
+    public <C> void forEach(
+        C context, @Strategy @Nonnull BiConsumer<? super C, ? super TEntry> consumer) {
       ConcurrentHashtable.forEach(state, context, consumer);
     }
   }
@@ -388,7 +397,7 @@ public final class ConcurrentHashtable {
 
     /**
      * Abstract base for {@link D2} entries. Subclass to add value fields you wish to mutate in
-     * place.
+     * place after retrieving the entry via {@link D2#get}.
      *
      * @param <K1> first key type
      * @param <K2> second key type
@@ -397,8 +406,8 @@ public final class ConcurrentHashtable {
      */
     public abstract static class Entry<K1, K2, TEntry extends Entry<K1, K2, TEntry>>
         extends ConcurrentHashtable.Entry<TEntry> {
-      final K1 key1;
-      final K2 key2;
+      @Nullable final K1 key1;
+      @Nullable final K2 key2;
 
       protected Entry(@Nullable K1 key1, @Nullable K2 key2) {
         super(hash(key1, key2));
@@ -444,8 +453,9 @@ public final class ConcurrentHashtable {
 
     /**
      * Creates a fixed-size table holding at most {@code maxCapacity} entries. {@code entryClass} is
-     * used only to infer the concrete entry type; entries are created by the functions passed to
-     * the insertion methods. The table does not resize.
+     * used only to allocate the backing array with the right component type; entries themselves are
+     * created by the {@code creator}/{@code evictable} functions passed to the insertion methods.
+     * The table does not resize.
      */
     @Nonnull
     public static <K1, K2, TEntry extends D2.Entry<K1, K2, TEntry>>
@@ -478,15 +488,12 @@ public final class ConcurrentHashtable {
      * Returns the entry for {@code (key1, key2)}, creating one via {@code creator} if absent and
      * the table is under capacity. Lock-free on hit; acquires a table-level lock on miss. Wraps
      * {@link #tryGetOrCreateOrNull} — see that method for the refusal and ordering details.
-     *
-     * <p>The {@code creator} should build an entry whose {@code keyHash} equals {@link
-     * D2.Entry#hash(Object, Object) D2.Entry.hash(key1, key2)}.
      */
     @Nonnull
     public Maybe<TEntry> tryGetOrCreate(
         @Nullable K1 key1,
         @Nullable K2 key2,
-        @Nonnull BiFunction<? super K1, ? super K2, ? extends TEntry> creator) {
+        @Strategy @Nonnull BiFunction<? super K1, ? super K2, ? extends TEntry> creator) {
       return Maybe.of(tryGetOrCreateOrNull(key1, key2, creator));
     }
 
@@ -496,11 +503,12 @@ public final class ConcurrentHashtable {
      * {@code (key1, key2)} was not already present. Re-checks under the lock to avoid duplicate
      * entries under concurrent misses.
      */
+    @StrategyConsumer
     @Nullable
     public TEntry tryGetOrCreateOrNull(
         @Nullable K1 key1,
         @Nullable K2 key2,
-        @Nonnull BiFunction<? super K1, ? super K2, ? extends TEntry> creator) {
+        @Strategy @Nonnull BiFunction<? super K1, ? super K2, ? extends TEntry> creator) {
       long keyHash = D2.Entry.hash(key1, key2);
       int index = bucketIndex(state.buckets, keyHash);
       for (TEntry curEntry = bucketAt(state, index); curEntry != null; curEntry = curEntry.next()) {
@@ -540,8 +548,8 @@ public final class ConcurrentHashtable {
     public Maybe<TEntry> tryGetOrCreateOrEvict(
         @Nullable K1 key1,
         @Nullable K2 key2,
-        @Nonnull BiFunction<? super K1, ? super K2, ? extends TEntry> creator,
-        @Nonnull Predicate<? super TEntry> evictable) {
+        @Strategy @Nonnull BiFunction<? super K1, ? super K2, ? extends TEntry> creator,
+        @Strategy @Nonnull Predicate<? super TEntry> evictable) {
       return Maybe.of(tryGetOrCreateOrEvictOrNull(key1, key2, creator, evictable));
     }
 
@@ -552,12 +560,13 @@ public final class ConcurrentHashtable {
      * ever leaving a slot double-booked. A creator that throws after a successful eviction simply
      * leaves the table one entry smaller — no corruption, just a wasted eviction.
      */
+    @StrategyConsumer
     @Nullable
     public TEntry tryGetOrCreateOrEvictOrNull(
         @Nullable K1 key1,
         @Nullable K2 key2,
-        @Nonnull BiFunction<? super K1, ? super K2, ? extends TEntry> creator,
-        @Nonnull Predicate<? super TEntry> evictable) {
+        @Strategy @Nonnull BiFunction<? super K1, ? super K2, ? extends TEntry> creator,
+        @Strategy @Nonnull Predicate<? super TEntry> evictable) {
       long keyHash = D2.Entry.hash(key1, key2);
       int index = bucketIndex(state.buckets, keyHash);
       for (TEntry curEntry = bucketAt(state, index); curEntry != null; curEntry = curEntry.next()) {
@@ -613,7 +622,7 @@ public final class ConcurrentHashtable {
      * Holds the table-level lock for the whole sweep, so the predicate sees a stable table and
      * concurrent writers are excluded; lock-free readers continue throughout.
      */
-    public boolean removeIf(@Nonnull Predicate<? super TEntry> predicate) {
+    public boolean removeIf(@Strategy @Nonnull Predicate<? super TEntry> predicate) {
       return ConcurrentHashtable.removeIf(state, predicate);
     }
 
@@ -624,7 +633,7 @@ public final class ConcurrentHashtable {
      *
      * <p>Use {@link #drain(Object, BiConsumer)} to avoid a capturing lambda.
      */
-    public void drain(@Nonnull Consumer<? super TEntry> sink) {
+    public void drain(@Strategy @Nonnull Consumer<? super TEntry> sink) {
       ConcurrentHashtable.drain(state, sink);
     }
 
@@ -633,7 +642,8 @@ public final class ConcurrentHashtable {
      * a {@code static final}) plus the accumulator as {@code context} (e.g. the target list or
      * event builder) to avoid a capturing-lambda allocation.
      */
-    public <C> void drain(C context, @Nonnull BiConsumer<? super C, ? super TEntry> sink) {
+    public <C> void drain(
+        C context, @Strategy @Nonnull BiConsumer<? super C, ? super TEntry> sink) {
       ConcurrentHashtable.drain(state, context, sink);
     }
 
@@ -642,7 +652,7 @@ public final class ConcurrentHashtable {
       ConcurrentHashtable.clear(state);
     }
 
-    public void forEach(@Nonnull Consumer<? super TEntry> consumer) {
+    public void forEach(@Strategy @Nonnull Consumer<? super TEntry> consumer) {
       ConcurrentHashtable.forEach(state, consumer);
     }
 
@@ -650,7 +660,8 @@ public final class ConcurrentHashtable {
      * Context-passing forEach. Avoids a capturing-lambda allocation — pass a non-capturing {@link
      * BiConsumer} (typically a {@code static final}) plus whatever side-band state it needs.
      */
-    public <C> void forEach(C context, @Nonnull BiConsumer<? super C, ? super TEntry> consumer) {
+    public <C> void forEach(
+        C context, @Strategy @Nonnull BiConsumer<? super C, ? super TEntry> consumer) {
       ConcurrentHashtable.forEach(state, context, consumer);
     }
   }
@@ -742,7 +753,7 @@ public final class ConcurrentHashtable {
     @GuardedBy("getTableWriteLock(buckets)")
     public <TEntry extends Entry<TEntry>> boolean tryReserveOrEvict(
         @Nonnull AtomicReferenceArray<TEntry> buckets,
-        @Nonnull Predicate<? super TEntry> evictable) {
+        @Strategy @Nonnull Predicate<? super TEntry> evictable) {
       if (tryReserve()) {
         return true;
       }
@@ -793,7 +804,7 @@ public final class ConcurrentHashtable {
     @Nullable
     public <TEntry extends Entry<TEntry>> TEntry evictOne(
         @Nonnull AtomicReferenceArray<TEntry> buckets,
-        @Nonnull Predicate<? super TEntry> evictable) {
+        @Strategy @Nonnull Predicate<? super TEntry> evictable) {
       TEntry evicted = evictOneInRange(buckets, evictable, evictionCursor, buckets.length());
       if (evicted == null && evictionCursor != 0) {
         evicted = evictOneInRange(buckets, evictable, 0, evictionCursor);
@@ -815,10 +826,11 @@ public final class ConcurrentHashtable {
         justification =
             "evictionCursor is read and written only under synchronized (getTableWriteLock(buckets)); SpotBugs"
                 + " cannot model that dynamic guard")
+    @StrategyConsumer
     @Nullable
     private <TEntry extends Entry<TEntry>> TEntry evictOneInRange(
         @Nonnull AtomicReferenceArray<TEntry> buckets,
-        @Nonnull Predicate<? super TEntry> evictable,
+        @Strategy @Nonnull Predicate<? super TEntry> evictable,
         int startBucket,
         int endBucket) {
       for (int i = startBucket; i < endBucket; i++) {
@@ -846,9 +858,10 @@ public final class ConcurrentHashtable {
         justification =
             "evictionCursor is read and written only under synchronized (getTableWriteLock(buckets)); SpotBugs"
                 + " cannot model that dynamic guard")
+    @StrategyConsumer
     public <TEntry extends Entry<TEntry>> int evictAll(
         @Nonnull AtomicReferenceArray<TEntry> buckets,
-        @Nonnull Predicate<? super TEntry> evictable) {
+        @Strategy @Nonnull Predicate<? super TEntry> evictable) {
       int count = 0;
       for (int i = 0; i < buckets.length(); i++) {
         TEntry prev = null;
@@ -913,10 +926,11 @@ public final class ConcurrentHashtable {
    * Lock-free — does not acquire the table write lock. Returns {@code false} with the table
    * unchanged when it is full.
    *
-   * <p>Complete it with {@link #insertReserved}, or prefer {@link #reserve} for a higher-level,
+   * <p>Complete it with {@link #insertReserved}, or prefer {@link #tryReserve} for a higher-level,
    * auto-cancelling handle that also defers entry construction until the reservation succeeds.
    */
-  public static <TEntry extends Entry<TEntry>> boolean tryReserve(@Nonnull State<TEntry> state) {
+  public static <TEntry extends Entry<TEntry>> boolean tryReserveSlot(
+      @Nonnull State<TEntry> state) {
     return state.sizeManager.tryReserve();
   }
 
@@ -926,7 +940,7 @@ public final class ConcurrentHashtable {
    * lock. Never returns {@code null}, so this always composes with try-with-resources:
    *
    * <pre>{@code
-   * try (Reservation<TEntry> r = ConcurrentHashtable.reserve(state)) {
+   * try (Reservation<TEntry> r = ConcurrentHashtable.tryReserve(state)) {
    *   return r.tryGetOrInsertOrNull(TEntry::new, component1, component2, component3);
    * }
    * }</pre>
@@ -936,17 +950,21 @@ public final class ConcurrentHashtable {
    * reservation itself, and the locked comparison inside {@link Reservation#tryGetOrInsertOrNull},
    * are the source of truth), it just avoids paying for a lock and a factory call when a hit was
    * already visible lock-free.
+   *
+   * <p>Always returns a non-null handle — even when the table is full — so the caller must check
+   * {@link Reservation#isPresent()} (or simply call {@link Reservation#tryGetOrInsertOrNull}, which
+   * returns {@code null} on an absent reservation) rather than assume every reservation is real.
    */
   @Nonnull
-  public static <TEntry extends Entry<TEntry>> Reservation<TEntry> reserve(
+  public static <TEntry extends Entry<TEntry>> Reservation<TEntry> tryReserve(
       @Nonnull State<TEntry> state) {
     return new Reservation<>(state.sizeManager.tryReserve() ? state : null);
   }
 
   /**
-   * Handle returned by {@link #reserve}, gating {@link #tryGetOrInsertOrNull} behind a claimed slot
-   * and auto-cancelling it on {@link #close} if it's never consumed. A single {@code Reservation}
-   * must be used for at most one {@code tryGetOrInsertOrNull} call.
+   * Handle returned by {@link #tryReserve}, gating {@link #tryGetOrInsertOrNull} behind a claimed
+   * slot and auto-cancelling it on {@link #close} if it's never consumed. A single {@code
+   * Reservation} must be used for at most one {@code tryGetOrInsertOrNull} call.
    *
    * <p>Overloaded up to 4 key components ({@link #tryGetOrInsertOrNull(Function, Object)} through
    * {@link #tryGetOrInsertOrNull(Function4, Object, Object, Object, Object)}) so a non-capturing
@@ -973,9 +991,10 @@ public final class ConcurrentHashtable {
      * One key component; see {@link #tryGetOrInsertOrNull(BiFunction, Object, Object)} for the
      * general contract.
      */
+    @StrategyConsumer
     @Nullable
     public <A> TEntry tryGetOrInsertOrNull(
-        @Nonnull Function<? super A, ? extends TEntry> factory, A a) {
+        @Strategy @Nonnull Function<? super A, ? extends TEntry> factory, A a) {
       return state == null ? null : finish(factory.apply(a));
     }
 
@@ -991,9 +1010,10 @@ public final class ConcurrentHashtable {
      * construction cost {@code factory} pays. See {@link ConcurrentHashtable.Entry#matches} — the
      * under-lock comparison is entry-to-entry, so it needs {@code newEntry} already built.
      */
+    @StrategyConsumer
     @Nullable
     public <A, B> TEntry tryGetOrInsertOrNull(
-        @Nonnull BiFunction<? super A, ? super B, ? extends TEntry> factory, A a, B b) {
+        @Strategy @Nonnull BiFunction<? super A, ? super B, ? extends TEntry> factory, A a, B b) {
       return state == null ? null : finish(factory.apply(a, b));
     }
 
@@ -1001,6 +1021,7 @@ public final class ConcurrentHashtable {
      * Three key components; see {@link #tryGetOrInsertOrNull(BiFunction, Object, Object)} for the
      * general contract.
      */
+    @StrategyConsumer
     @Nullable
     public <A, B, C> TEntry tryGetOrInsertOrNull(
         @Nonnull Function3<? super A, ? super B, ? super C, ? extends TEntry> factory,
@@ -1011,6 +1032,7 @@ public final class ConcurrentHashtable {
     }
 
     /** Four key components; see {@link #tryGetOrInsertOrNull(BiFunction, Object, Object)}. */
+    @StrategyConsumer
     @Nullable
     public <A, B, C, D> TEntry tryGetOrInsertOrNull(
         @Nonnull Function4<? super A, ? super B, ? super C, ? super D, ? extends TEntry> factory,
@@ -1019,6 +1041,46 @@ public final class ConcurrentHashtable {
         C c,
         D d) {
       return state == null ? null : finish(factory.apply(a, b, c, d));
+    }
+
+    /**
+     * {@link Maybe}-wrapping counterpart of {@link #tryGetOrInsertOrNull(Function, Object)}, for
+     * callers who'd rather make the "this can fail unlike unbounded collections" outcome visible in
+     * the return type than rely on a {@code null} check — mirrors {@link D1#tryGetOrCreate} /
+     * {@link D2#tryGetOrCreate} wrapping their own {@code ...OrNull} methods.
+     */
+    @Nonnull
+    public <A> Maybe<TEntry> tryGetOrInsert(
+        @Strategy @Nonnull Function<? super A, ? extends TEntry> factory, A a) {
+      return Maybe.of(tryGetOrInsertOrNull(factory, a));
+    }
+
+    /** Two key components; see {@link #tryGetOrInsert(Function, Object)}. */
+    @Nonnull
+    public <A, B> Maybe<TEntry> tryGetOrInsert(
+        @Strategy @Nonnull BiFunction<? super A, ? super B, ? extends TEntry> factory, A a, B b) {
+      return Maybe.of(tryGetOrInsertOrNull(factory, a, b));
+    }
+
+    /** Three key components; see {@link #tryGetOrInsert(Function, Object)}. */
+    @Nonnull
+    public <A, B, C> Maybe<TEntry> tryGetOrInsert(
+        @Nonnull Function3<? super A, ? super B, ? super C, ? extends TEntry> factory,
+        A a,
+        B b,
+        C c) {
+      return Maybe.of(tryGetOrInsertOrNull(factory, a, b, c));
+    }
+
+    /** Four key components; see {@link #tryGetOrInsert(Function, Object)}. */
+    @Nonnull
+    public <A, B, C, D> Maybe<TEntry> tryGetOrInsert(
+        @Nonnull Function4<? super A, ? super B, ? super C, ? super D, ? extends TEntry> factory,
+        A a,
+        B b,
+        C c,
+        D d) {
+      return Maybe.of(tryGetOrInsertOrNull(factory, a, b, c, d));
     }
 
     private TEntry finish(@Nonnull TEntry newEntry) {
@@ -1047,12 +1109,14 @@ public final class ConcurrentHashtable {
   }
 
   /** Three-argument analogue of {@link java.util.function.BiFunction}. */
+  @Strategy
   @FunctionalInterface
   public interface Function3<A, B, C, R> {
     R apply(A a, B b, C c);
   }
 
   /** Four-argument analogue of {@link java.util.function.BiFunction}. */
+  @Strategy
   @FunctionalInterface
   public interface Function4<A, B, C, D, R> {
     R apply(A a, B b, C c, D d);
@@ -1067,7 +1131,7 @@ public final class ConcurrentHashtable {
    * #insertReserved}; abandoning it permanently consumes capacity.
    */
   public static <TEntry extends Entry<TEntry>> boolean tryReserveOrEvict(
-      @Nonnull State<TEntry> state, @Nonnull Predicate<? super TEntry> evictable) {
+      @Nonnull State<TEntry> state, @Strategy @Nonnull Predicate<? super TEntry> evictable) {
     synchronized (getTableWriteLock(state)) {
       return state.sizeManager.tryReserveOrEvict(state.buckets, evictable);
     }
@@ -1080,7 +1144,7 @@ public final class ConcurrentHashtable {
    */
   @Nullable
   public static <TEntry extends Entry<TEntry>> TEntry evictOne(
-      @Nonnull State<TEntry> state, @Nonnull Predicate<? super TEntry> evictable) {
+      @Nonnull State<TEntry> state, @Strategy @Nonnull Predicate<? super TEntry> evictable) {
     synchronized (getTableWriteLock(state)) {
       return state.sizeManager.evictOne(state.buckets, evictable);
     }
@@ -1091,7 +1155,7 @@ public final class ConcurrentHashtable {
    * returns how many went. Self-locking.
    */
   public static <TEntry extends Entry<TEntry>> int evictAll(
-      @Nonnull State<TEntry> state, @Nonnull Predicate<? super TEntry> evictable) {
+      @Nonnull State<TEntry> state, @Strategy @Nonnull Predicate<? super TEntry> evictable) {
     synchronized (getTableWriteLock(state)) {
       return state.sizeManager.evictAll(state.buckets, evictable);
     }
@@ -1241,6 +1305,45 @@ public final class ConcurrentHashtable {
   }
 
   /**
+   * Returns a lock-free iterator over the bucket chain that {@code keyHash} maps to, starting from
+   * {@link #bucketFor(AtomicReferenceArray, long)}. Each {@link Iterator#next()} call follows
+   * {@link Entry#next()}, so the iterator reflects entries linked at the time each step runs rather
+   * than a point-in-time snapshot -- entries inserted ahead of the iterator's current position
+   * after iteration starts may or may not be observed, and a concurrently removed entry remains
+   * reachable because {@code unlink()} deliberately retains its {@code next} link for in-flight
+   * readers.
+   */
+  @Nonnull
+  public static <TEntry extends Entry<TEntry>> Iterator<TEntry> hashIterator(
+      @Nonnull AtomicReferenceArray<TEntry> buckets, long keyHash) {
+    return new Iterator<TEntry>() {
+      private TEntry next = bucketFor(buckets, keyHash);
+
+      @Override
+      public boolean hasNext() {
+        return next != null;
+      }
+
+      @Override
+      public TEntry next() {
+        TEntry current = next;
+        if (current == null) {
+          throw new NoSuchElementException();
+        }
+        next = current.next();
+        return current;
+      }
+    };
+  }
+
+  /** {@link #hashIterator(AtomicReferenceArray, long)} over a {@link State}. */
+  @Nonnull
+  public static <TEntry extends Entry<TEntry>> Iterator<TEntry> hashIterator(
+      @Nonnull State<TEntry> state, long keyHash) {
+    return hashIterator(state.buckets, keyHash);
+  }
+
+  /**
    * Publishes {@code entry} as the head of bucket {@code index}. The helper writes the entry's
    * {@code next} link before the volatile {@link AtomicReferenceArray#set}; a volatile bucket read
    * that observes the new head also sees the initialized entry and its link. The caller must hold
@@ -1332,10 +1435,11 @@ public final class ConcurrentHashtable {
    * predicate sees a stable table and concurrent writers are excluded; lock-free readers continue
    * throughout.
    */
+  @StrategyConsumer
   public static <TEntry extends Entry<TEntry>> boolean removeIf(
       @Nonnull AtomicReferenceArray<TEntry> buckets,
       @Nonnull AtomicInteger size,
-      @Nonnull Predicate<? super TEntry> predicate) {
+      @Strategy @Nonnull Predicate<? super TEntry> predicate) {
     synchronized (getTableWriteLock(buckets)) {
       boolean removed = false;
       for (int i = 0; i < buckets.length(); i++) {
@@ -1360,8 +1464,9 @@ public final class ConcurrentHashtable {
    * occupancy with a {@link State} instead of a bare counter — used by {@link D1#removeIf} and
    * {@link D2#removeIf}.
    */
+  @StrategyConsumer
   public static <TEntry extends Entry<TEntry>> boolean removeIf(
-      @Nonnull State<TEntry> state, @Nonnull Predicate<? super TEntry> predicate) {
+      @Nonnull State<TEntry> state, @Strategy @Nonnull Predicate<? super TEntry> predicate) {
     AtomicReferenceArray<TEntry> buckets = state.buckets;
     synchronized (getTableWriteLock(state)) {
       boolean removed = false;
@@ -1390,7 +1495,8 @@ public final class ConcurrentHashtable {
    * <p>The sink must not throw. If it does, the partial drain is not rolled back.
    */
   public static <TEntry extends Entry<TEntry>> void drain(
-      @Nonnull AtomicReferenceArray<TEntry> buckets, @Nonnull Consumer<? super TEntry> sink) {
+      @Nonnull AtomicReferenceArray<TEntry> buckets,
+      @Strategy @Nonnull Consumer<? super TEntry> sink) {
     drainCounting(buckets, sink);
   }
 
@@ -1399,8 +1505,10 @@ public final class ConcurrentHashtable {
    * sink}, so a {@link State} form can subtract exactly that from its {@link SizeManager} instead
    * of zeroing. The count is free here: the sweep already visits every entry.
    */
+  @StrategyConsumer
   private static <TEntry extends Entry<TEntry>> int drainCounting(
-      @Nonnull AtomicReferenceArray<TEntry> buckets, @Nonnull Consumer<? super TEntry> sink) {
+      @Nonnull AtomicReferenceArray<TEntry> buckets,
+      @Strategy @Nonnull Consumer<? super TEntry> sink) {
     int removed = 0;
     synchronized (getTableWriteLock(buckets)) {
       for (int i = 0; i < buckets.length(); i++) {
@@ -1422,15 +1530,16 @@ public final class ConcurrentHashtable {
   public static <C, TEntry extends Entry<TEntry>> void drain(
       @Nonnull AtomicReferenceArray<TEntry> buckets,
       C context,
-      @Nonnull BiConsumer<? super C, ? super TEntry> sink) {
+      @Strategy @Nonnull BiConsumer<? super C, ? super TEntry> sink) {
     drainCounting(buckets, context, sink);
   }
 
   /** {@link #drainCounting(AtomicReferenceArray, Consumer)}, context-passing form. */
+  @StrategyConsumer
   private static <C, TEntry extends Entry<TEntry>> int drainCounting(
       @Nonnull AtomicReferenceArray<TEntry> buckets,
       C context,
-      @Nonnull BiConsumer<? super C, ? super TEntry> sink) {
+      @Strategy @Nonnull BiConsumer<? super C, ? super TEntry> sink) {
     int removed = 0;
     synchronized (getTableWriteLock(buckets)) {
       for (int i = 0; i < buckets.length(); i++) {
@@ -1455,7 +1564,7 @@ public final class ConcurrentHashtable {
    * rather than as a pair the caller has to remember.
    */
   public static <TEntry extends Entry<TEntry>> void drain(
-      @Nonnull State<TEntry> state, @Nonnull Consumer<? super TEntry> sink) {
+      @Nonnull State<TEntry> state, @Strategy @Nonnull Consumer<? super TEntry> sink) {
     synchronized (getTableWriteLock(state)) {
       state.sizeManager.release(drainCounting(state.buckets, sink));
     }
@@ -1465,7 +1574,7 @@ public final class ConcurrentHashtable {
   public static <C, TEntry extends Entry<TEntry>> void drain(
       @Nonnull State<TEntry> state,
       C context,
-      @Nonnull BiConsumer<? super C, ? super TEntry> sink) {
+      @Strategy @Nonnull BiConsumer<? super C, ? super TEntry> sink) {
     synchronized (getTableWriteLock(state)) {
       state.sizeManager.release(drainCounting(state.buckets, context, sink));
     }
@@ -1513,8 +1622,10 @@ public final class ConcurrentHashtable {
     }
   }
 
+  @StrategyConsumer
   public static <TEntry extends Entry<TEntry>> void forEach(
-      @Nonnull AtomicReferenceArray<TEntry> buckets, @Nonnull Consumer<? super TEntry> consumer) {
+      @Nonnull AtomicReferenceArray<TEntry> buckets,
+      @Strategy @Nonnull Consumer<? super TEntry> consumer) {
     for (int i = 0; i < buckets.length(); i++) {
       for (TEntry curEntry = buckets.get(i); curEntry != null; curEntry = curEntry.next()) {
         consumer.accept(curEntry);
@@ -1522,10 +1633,11 @@ public final class ConcurrentHashtable {
     }
   }
 
+  @StrategyConsumer
   public static <C, TEntry extends Entry<TEntry>> void forEach(
       @Nonnull AtomicReferenceArray<TEntry> buckets,
       C context,
-      @Nonnull BiConsumer<? super C, ? super TEntry> consumer) {
+      @Strategy @Nonnull BiConsumer<? super C, ? super TEntry> consumer) {
     for (int i = 0; i < buckets.length(); i++) {
       for (TEntry curEntry = buckets.get(i); curEntry != null; curEntry = curEntry.next()) {
         consumer.accept(context, curEntry);
@@ -1535,7 +1647,7 @@ public final class ConcurrentHashtable {
 
   /** {@link #forEach(AtomicReferenceArray, Consumer)} over a {@link State}. */
   public static <TEntry extends Entry<TEntry>> void forEach(
-      @Nonnull State<TEntry> state, @Nonnull Consumer<? super TEntry> consumer) {
+      @Nonnull State<TEntry> state, @Strategy @Nonnull Consumer<? super TEntry> consumer) {
     forEach(state.buckets, consumer);
   }
 
@@ -1543,7 +1655,7 @@ public final class ConcurrentHashtable {
   public static <C, TEntry extends Entry<TEntry>> void forEach(
       @Nonnull State<TEntry> state,
       C context,
-      @Nonnull BiConsumer<? super C, ? super TEntry> consumer) {
+      @Strategy @Nonnull BiConsumer<? super C, ? super TEntry> consumer) {
     forEach(state.buckets, context, consumer);
   }
 }

--- a/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
+++ b/internal-api/src/main/java/datadog/trace/util/ConcurrentHashtable.java
@@ -117,21 +117,25 @@ public final class ConcurrentHashtable {
    * Single-key concurrent hash table. Lock-free on hit; locked on miss/mutation.
    *
    * @param <K> the key type
-   * @param <TEntry> the user's {@link D1.Entry D1.Entry&lt;K, TEntry&gt;} subclass
+   * @param <TEntry> the user's {@link D1.Entry D1.Entry&lt;K&gt;} subclass
    */
   @ThreadSafe
-  public static final class D1<K, TEntry extends D1.Entry<K, TEntry>> {
+  public static final class D1<K, TEntry extends D1.Entry<K>> {
 
     /**
      * Abstract base for {@link D1} entries. Subclass to add value fields you wish to mutate in
      * place after retrieving the entry via {@link D1#get}.
      *
+     * <p>Deliberately parameterized on {@code K} alone, not self-bound on the concrete subclass:
+     * {@link D1} stores and links entries internally as {@code Entry<K>} and casts back to {@code
+     * TEntry} at its API boundary, trading one unchecked cast (always sound -- the table only ever
+     * holds instances the caller's own {@code creator} produced) for a simpler subclass signature,
+     * e.g. {@code class MyEntry extends D1.Entry<String>} rather than {@code D1.Entry<String,
+     * MyEntry>}.
+     *
      * @param <K> the key type
-     * @param <TEntry> the concrete subclass extending this one (self-bound, see {@link
-     *     ConcurrentHashtable.Entry})
      */
-    public abstract static class Entry<K, TEntry extends Entry<K, TEntry>>
-        extends ConcurrentHashtable.Entry<TEntry> {
+    public abstract static class Entry<K> extends ConcurrentHashtable.Entry<Entry<K>> {
       @Nullable final K key;
 
       protected Entry(@Nullable K key) {
@@ -153,7 +157,7 @@ public final class ConcurrentHashtable {
 
       /** {@link ConcurrentHashtable.Entry#matches(Entry)} in terms of the key-based overload. */
       @Override
-      public boolean matches(@Nonnull TEntry other) {
+      public final boolean matches(@Nonnull Entry<K> other) {
         return matches(other.key);
       }
 
@@ -167,9 +171,9 @@ public final class ConcurrentHashtable {
       }
     }
 
-    private final State<TEntry> state;
+    private final State<Entry<K>> state;
 
-    private D1(State<TEntry> state) {
+    private D1(State<Entry<K>> state) {
       this.state = state;
     }
 
@@ -180,9 +184,38 @@ public final class ConcurrentHashtable {
      * The table does not resize.
      */
     @Nonnull
-    public static <K, TEntry extends D1.Entry<K, TEntry>> D1<K, TEntry> createBounded(
+    @SuppressWarnings("unchecked")
+    public static <K, TEntry extends D1.Entry<K>> D1<K, TEntry> createBounded(
         @Nonnull Class<TEntry> entryClass, int maxCapacity) {
-      return new D1<>(ConcurrentHashtable.createBounded(entryClass, maxCapacity));
+      // entryClass is erased away (see ConcurrentHashtable#createFixedBuckets), so treating it as
+      // Class<Entry<K>> instead of the caller's concrete Class<TEntry> is safe.
+      Class<Entry<K>> baseEntryClass = (Class<Entry<K>>) (Class<?>) entryClass;
+      return new D1<>(ConcurrentHashtable.createBounded(baseEntryClass, maxCapacity));
+    }
+
+    /**
+     * Sound because every entry ever inserted into {@link #state} was produced as a {@code TEntry}.
+     */
+    @SuppressWarnings("unchecked")
+    private TEntry cast(@Nullable Entry<K> entry) {
+      return (TEntry) entry;
+    }
+
+    /** See {@link #cast(Entry)}; casts the functional-interface reference, not each element. */
+    @SuppressWarnings("unchecked")
+    private Predicate<? super Entry<K>> castPredicate(Predicate<? super TEntry> predicate) {
+      return (Predicate<? super Entry<K>>) predicate;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Consumer<? super Entry<K>> castConsumer(Consumer<? super TEntry> consumer) {
+      return (Consumer<? super Entry<K>>) consumer;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <C> BiConsumer<? super C, ? super Entry<K>> castConsumer(
+        BiConsumer<? super C, ? super TEntry> consumer) {
+      return (BiConsumer<? super C, ? super Entry<K>>) consumer;
     }
 
     public int size() {
@@ -196,11 +229,11 @@ public final class ConcurrentHashtable {
     @Nullable
     public TEntry get(@Nullable K key) {
       long keyHash = D1.Entry.hash(key);
-      for (TEntry curEntry = bucketFor(state, keyHash);
+      for (Entry<K> curEntry = bucketFor(state, keyHash);
           curEntry != null;
           curEntry = curEntry.next()) {
         if (curEntry.keyHash == keyHash && curEntry.matches(key)) {
-          return curEntry;
+          return cast(curEntry);
         }
       }
       return null;
@@ -229,17 +262,19 @@ public final class ConcurrentHashtable {
         @Nullable K key, @Strategy @Nonnull Function<? super K, ? extends TEntry> creator) {
       long keyHash = D1.Entry.hash(key);
       int index = bucketIndex(state.buckets, keyHash);
-      for (TEntry curEntry = bucketAt(state, index); curEntry != null; curEntry = curEntry.next()) {
+      for (Entry<K> curEntry = bucketAt(state, index);
+          curEntry != null;
+          curEntry = curEntry.next()) {
         if (curEntry.keyHash == keyHash && curEntry.matches(key)) {
-          return curEntry;
+          return cast(curEntry);
         }
       }
       synchronized (getTableWriteLock(state)) {
-        for (TEntry curEntry = bucketAt(state, index);
+        for (Entry<K> curEntry = bucketAt(state, index);
             curEntry != null;
             curEntry = curEntry.next()) {
           if (curEntry.keyHash == keyHash && curEntry.matches(key)) {
-            return curEntry;
+            return cast(curEntry);
           }
         }
         // isFull() is checked before creating the entry, not before reserving a slot for it:
@@ -285,21 +320,23 @@ public final class ConcurrentHashtable {
         @Strategy @Nonnull Predicate<? super TEntry> evictable) {
       long keyHash = D1.Entry.hash(key);
       int index = bucketIndex(state.buckets, keyHash);
-      for (TEntry curEntry = bucketAt(state, index); curEntry != null; curEntry = curEntry.next()) {
+      for (Entry<K> curEntry = bucketAt(state, index);
+          curEntry != null;
+          curEntry = curEntry.next()) {
         if (curEntry.keyHash == keyHash && curEntry.matches(key)) {
-          return curEntry;
+          return cast(curEntry);
         }
       }
       synchronized (getTableWriteLock(state)) {
-        for (TEntry curEntry = bucketAt(state, index);
+        for (Entry<K> curEntry = bucketAt(state, index);
             curEntry != null;
             curEntry = curEntry.next()) {
           if (curEntry.keyHash == keyHash && curEntry.matches(key)) {
-            return curEntry;
+            return cast(curEntry);
           }
         }
         if (state.sizeManager.isFull()
-            && state.sizeManager.evictOne(state.buckets, evictable) == null) {
+            && state.sizeManager.evictOne(state.buckets, castPredicate(evictable)) == null) {
           return null;
         }
         TEntry newEntry = creator.apply(key);
@@ -319,14 +356,14 @@ public final class ConcurrentHashtable {
       long keyHash = D1.Entry.hash(key);
       int index = bucketIndex(state.buckets, keyHash);
       synchronized (getTableWriteLock(state)) {
-        TEntry prev = null;
-        for (TEntry curEntry = bucketAt(state, index);
+        Entry<K> prev = null;
+        for (Entry<K> curEntry = bucketAt(state, index);
             curEntry != null;
             prev = curEntry, curEntry = curEntry.next()) {
           if (curEntry.keyHash == keyHash && curEntry.matches(key)) {
             unlink(state, index, prev, curEntry);
             state.sizeManager.decrement();
-            return curEntry;
+            return cast(curEntry);
           }
         }
         return null;
@@ -339,7 +376,7 @@ public final class ConcurrentHashtable {
      * concurrent writers are excluded; lock-free readers continue throughout.
      */
     public boolean removeIf(@Strategy @Nonnull Predicate<? super TEntry> predicate) {
-      return ConcurrentHashtable.removeIf(state, predicate);
+      return ConcurrentHashtable.removeIf(state, castPredicate(predicate));
     }
 
     /**
@@ -350,7 +387,7 @@ public final class ConcurrentHashtable {
      * <p>Use {@link #drain(Object, BiConsumer)} to avoid a capturing lambda.
      */
     public void drain(@Strategy @Nonnull Consumer<? super TEntry> sink) {
-      ConcurrentHashtable.drain(state, sink);
+      ConcurrentHashtable.drain(state, castConsumer(sink));
     }
 
     /**
@@ -360,7 +397,7 @@ public final class ConcurrentHashtable {
      */
     public <C> void drain(
         C context, @Strategy @Nonnull BiConsumer<? super C, ? super TEntry> sink) {
-      ConcurrentHashtable.drain(state, context, sink);
+      ConcurrentHashtable.drain(state, context, castConsumer(sink));
     }
 
     /** Removes all entries. Lock-free readers mid-walk complete against the entries they hold. */
@@ -369,7 +406,7 @@ public final class ConcurrentHashtable {
     }
 
     public void forEach(@Strategy @Nonnull Consumer<? super TEntry> consumer) {
-      ConcurrentHashtable.forEach(state, consumer);
+      ConcurrentHashtable.forEach(state, castConsumer(consumer));
     }
 
     /**
@@ -378,7 +415,7 @@ public final class ConcurrentHashtable {
      */
     public <C> void forEach(
         C context, @Strategy @Nonnull BiConsumer<? super C, ? super TEntry> consumer) {
-      ConcurrentHashtable.forEach(state, context, consumer);
+      ConcurrentHashtable.forEach(state, context, castConsumer(consumer));
     }
   }
 
@@ -389,22 +426,22 @@ public final class ConcurrentHashtable {
    *
    * @param <K1> first key type
    * @param <K2> second key type
-   * @param <TEntry> the user's {@link D2.Entry D2.Entry&lt;K1, K2, TEntry&gt;} subclass
+   * @param <TEntry> the user's {@link D2.Entry D2.Entry&lt;K1, K2&gt;} subclass
    */
   @ThreadSafe
-  public static final class D2<K1, K2, TEntry extends D2.Entry<K1, K2, TEntry>> {
+  public static final class D2<K1, K2, TEntry extends D2.Entry<K1, K2>> {
 
     /**
      * Abstract base for {@link D2} entries. Subclass to add value fields you wish to mutate in
      * place after retrieving the entry via {@link D2#get}.
      *
+     * <p>Deliberately parameterized on {@code K1}/{@code K2} alone, not self-bound on the concrete
+     * subclass -- see {@link D1.Entry} for why.
+     *
      * @param <K1> first key type
      * @param <K2> second key type
-     * @param <TEntry> the concrete subclass extending this one (self-bound, see {@link
-     *     ConcurrentHashtable.Entry})
      */
-    public abstract static class Entry<K1, K2, TEntry extends Entry<K1, K2, TEntry>>
-        extends ConcurrentHashtable.Entry<TEntry> {
+    public abstract static class Entry<K1, K2> extends ConcurrentHashtable.Entry<Entry<K1, K2>> {
       @Nullable final K1 key1;
       @Nullable final K2 key2;
 
@@ -434,7 +471,7 @@ public final class ConcurrentHashtable {
 
       /** {@link ConcurrentHashtable.Entry#matches(Entry)} in terms of the key-based overload. */
       @Override
-      public boolean matches(@Nonnull TEntry other) {
+      public final boolean matches(@Nonnull Entry<K1, K2> other) {
         return matches(other.key1, other.key2);
       }
 
@@ -444,9 +481,9 @@ public final class ConcurrentHashtable {
       }
     }
 
-    private final State<TEntry> state;
+    private final State<Entry<K1, K2>> state;
 
-    private D2(State<TEntry> state) {
+    private D2(State<Entry<K1, K2>> state) {
       this.state = state;
     }
 
@@ -457,9 +494,38 @@ public final class ConcurrentHashtable {
      * The table does not resize.
      */
     @Nonnull
-    public static <K1, K2, TEntry extends D2.Entry<K1, K2, TEntry>>
-        D2<K1, K2, TEntry> createBounded(@Nonnull Class<TEntry> entryClass, int maxCapacity) {
-      return new D2<>(ConcurrentHashtable.createBounded(entryClass, maxCapacity));
+    @SuppressWarnings("unchecked")
+    public static <K1, K2, TEntry extends D2.Entry<K1, K2>> D2<K1, K2, TEntry> createBounded(
+        @Nonnull Class<TEntry> entryClass, int maxCapacity) {
+      // entryClass is erased away (see ConcurrentHashtable#createFixedBuckets), so treating it as
+      // Class<Entry<K1, K2>> instead of the caller's concrete Class<TEntry> is safe.
+      Class<Entry<K1, K2>> baseEntryClass = (Class<Entry<K1, K2>>) (Class<?>) entryClass;
+      return new D2<>(ConcurrentHashtable.createBounded(baseEntryClass, maxCapacity));
+    }
+
+    /**
+     * Sound because every entry ever inserted into {@link #state} was produced as a {@code TEntry}.
+     */
+    @SuppressWarnings("unchecked")
+    private TEntry cast(@Nullable Entry<K1, K2> entry) {
+      return (TEntry) entry;
+    }
+
+    /** See {@link #cast(Entry)}; casts the functional-interface reference, not each element. */
+    @SuppressWarnings("unchecked")
+    private Predicate<? super Entry<K1, K2>> castPredicate(Predicate<? super TEntry> predicate) {
+      return (Predicate<? super Entry<K1, K2>>) predicate;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Consumer<? super Entry<K1, K2>> castConsumer(Consumer<? super TEntry> consumer) {
+      return (Consumer<? super Entry<K1, K2>>) consumer;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <C> BiConsumer<? super C, ? super Entry<K1, K2>> castConsumer(
+        BiConsumer<? super C, ? super TEntry> consumer) {
+      return (BiConsumer<? super C, ? super Entry<K1, K2>>) consumer;
     }
 
     public int size() {
@@ -473,11 +539,11 @@ public final class ConcurrentHashtable {
     @Nullable
     public TEntry get(@Nullable K1 key1, @Nullable K2 key2) {
       long keyHash = D2.Entry.hash(key1, key2);
-      for (TEntry curEntry = bucketFor(state, keyHash);
+      for (Entry<K1, K2> curEntry = bucketFor(state, keyHash);
           curEntry != null;
           curEntry = curEntry.next()) {
         if (curEntry.keyHash == keyHash && curEntry.matches(key1, key2)) {
-          return curEntry;
+          return cast(curEntry);
         }
       }
       return null;
@@ -510,17 +576,19 @@ public final class ConcurrentHashtable {
         @Strategy @Nonnull BiFunction<? super K1, ? super K2, ? extends TEntry> creator) {
       long keyHash = D2.Entry.hash(key1, key2);
       int index = bucketIndex(state.buckets, keyHash);
-      for (TEntry curEntry = bucketAt(state, index); curEntry != null; curEntry = curEntry.next()) {
+      for (Entry<K1, K2> curEntry = bucketAt(state, index);
+          curEntry != null;
+          curEntry = curEntry.next()) {
         if (curEntry.keyHash == keyHash && curEntry.matches(key1, key2)) {
-          return curEntry;
+          return cast(curEntry);
         }
       }
       synchronized (getTableWriteLock(state)) {
-        for (TEntry curEntry = bucketAt(state, index);
+        for (Entry<K1, K2> curEntry = bucketAt(state, index);
             curEntry != null;
             curEntry = curEntry.next()) {
           if (curEntry.keyHash == keyHash && curEntry.matches(key1, key2)) {
-            return curEntry;
+            return cast(curEntry);
           }
         }
         // isFull() is checked before creating the entry, not before reserving a slot for it:
@@ -568,21 +636,23 @@ public final class ConcurrentHashtable {
         @Strategy @Nonnull Predicate<? super TEntry> evictable) {
       long keyHash = D2.Entry.hash(key1, key2);
       int index = bucketIndex(state.buckets, keyHash);
-      for (TEntry curEntry = bucketAt(state, index); curEntry != null; curEntry = curEntry.next()) {
+      for (Entry<K1, K2> curEntry = bucketAt(state, index);
+          curEntry != null;
+          curEntry = curEntry.next()) {
         if (curEntry.keyHash == keyHash && curEntry.matches(key1, key2)) {
-          return curEntry;
+          return cast(curEntry);
         }
       }
       synchronized (getTableWriteLock(state)) {
-        for (TEntry curEntry = bucketAt(state, index);
+        for (Entry<K1, K2> curEntry = bucketAt(state, index);
             curEntry != null;
             curEntry = curEntry.next()) {
           if (curEntry.keyHash == keyHash && curEntry.matches(key1, key2)) {
-            return curEntry;
+            return cast(curEntry);
           }
         }
         if (state.sizeManager.isFull()
-            && state.sizeManager.evictOne(state.buckets, evictable) == null) {
+            && state.sizeManager.evictOne(state.buckets, castPredicate(evictable)) == null) {
           return null;
         }
         TEntry newEntry = creator.apply(key1, key2);
@@ -602,14 +672,14 @@ public final class ConcurrentHashtable {
       long keyHash = D2.Entry.hash(key1, key2);
       int index = bucketIndex(state.buckets, keyHash);
       synchronized (getTableWriteLock(state)) {
-        TEntry prev = null;
-        for (TEntry curEntry = bucketAt(state, index);
+        Entry<K1, K2> prev = null;
+        for (Entry<K1, K2> curEntry = bucketAt(state, index);
             curEntry != null;
             prev = curEntry, curEntry = curEntry.next()) {
           if (curEntry.keyHash == keyHash && curEntry.matches(key1, key2)) {
             unlink(state, index, prev, curEntry);
             state.sizeManager.decrement();
-            return curEntry;
+            return cast(curEntry);
           }
         }
         return null;
@@ -622,7 +692,7 @@ public final class ConcurrentHashtable {
      * concurrent writers are excluded; lock-free readers continue throughout.
      */
     public boolean removeIf(@Strategy @Nonnull Predicate<? super TEntry> predicate) {
-      return ConcurrentHashtable.removeIf(state, predicate);
+      return ConcurrentHashtable.removeIf(state, castPredicate(predicate));
     }
 
     /**
@@ -633,7 +703,7 @@ public final class ConcurrentHashtable {
      * <p>Use {@link #drain(Object, BiConsumer)} to avoid a capturing lambda.
      */
     public void drain(@Strategy @Nonnull Consumer<? super TEntry> sink) {
-      ConcurrentHashtable.drain(state, sink);
+      ConcurrentHashtable.drain(state, castConsumer(sink));
     }
 
     /**
@@ -643,7 +713,7 @@ public final class ConcurrentHashtable {
      */
     public <C> void drain(
         C context, @Strategy @Nonnull BiConsumer<? super C, ? super TEntry> sink) {
-      ConcurrentHashtable.drain(state, context, sink);
+      ConcurrentHashtable.drain(state, context, castConsumer(sink));
     }
 
     /** Removes all entries. Lock-free readers mid-walk complete against the entries they hold. */
@@ -652,7 +722,7 @@ public final class ConcurrentHashtable {
     }
 
     public void forEach(@Strategy @Nonnull Consumer<? super TEntry> consumer) {
-      ConcurrentHashtable.forEach(state, consumer);
+      ConcurrentHashtable.forEach(state, castConsumer(consumer));
     }
 
     /**
@@ -661,7 +731,7 @@ public final class ConcurrentHashtable {
      */
     public <C> void forEach(
         C context, @Strategy @Nonnull BiConsumer<? super C, ? super TEntry> consumer) {
-      ConcurrentHashtable.forEach(state, context, consumer);
+      ConcurrentHashtable.forEach(state, context, castConsumer(consumer));
     }
   }
 

--- a/internal-api/src/test/groovy/datadog/trace/api/telemetry/LogCollectorTest.groovy
+++ b/internal-api/src/test/groovy/datadog/trace/api/telemetry/LogCollectorTest.groovy
@@ -1,6 +1,7 @@
 package datadog.trace.api.telemetry
 
 import datadog.trace.test.util.DDSpecification
+import datadog.trace.util.ConcurrentHashtable
 
 class LogCollectorTest extends DDSpecification {
 
@@ -30,7 +31,7 @@ class LogCollectorTest extends DDSpecification {
     logCollector.addLogMessage("ERROR", "Message 4", null)
 
     then:
-    logCollector.rawLogMessages.size() == 3
+    ConcurrentHashtable.estimateSize(logCollector.rawLogMessages) == 3
   }
 
   void "grouping messages in LogCollector"() {
@@ -57,7 +58,7 @@ class LogCollectorTest extends DDSpecification {
 
   boolean listContains(Collection<LogCollector.RawLogMessage> list, String logLevel, String message, Throwable t, int count) {
     for (final def logMsg in list) {
-      if (logMsg.logLevel == logLevel && logMsg.message == message && logMsg.throwable == t && logMsg.count == count) {
+      if (logMsg.logLevel == logLevel && logMsg.message == message && logMsg.throwable == t && logMsg.count.get() == count) {
         return true
       }
     }

--- a/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableD1Test.java
+++ b/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableD1Test.java
@@ -464,7 +464,7 @@ class ConcurrentHashtableD1Test {
     assertNull(table.get("new"));
   }
 
-  private static final class StringEntry extends ConcurrentHashtable.D1.Entry<String> {
+  private static final class StringEntry extends ConcurrentHashtable.D1.Entry<String, StringEntry> {
     final int value;
 
     StringEntry(String key, int value) {
@@ -498,7 +498,8 @@ class ConcurrentHashtableD1Test {
     }
   }
 
-  private static final class CollidingEntry extends ConcurrentHashtable.D1.Entry<CollidingKey> {
+  private static final class CollidingEntry
+      extends ConcurrentHashtable.D1.Entry<CollidingKey, CollidingEntry> {
     CollidingEntry(CollidingKey key) {
       super(key);
     }

--- a/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableD1Test.java
+++ b/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableD1Test.java
@@ -80,7 +80,7 @@ class ConcurrentHashtableD1Test {
     table.tryGetOrCreateOrNull("b", k -> new StringEntry(k, 2));
     table.tryGetOrCreateOrNull("c", k -> new StringEntry(k, 3));
     Set<String> seen = new HashSet<>();
-    table.forEach(e -> seen.add(e.key));
+    table.forEach(e -> seen.add(e.key()));
     assertEquals(3, seen.size());
     assertTrue(seen.contains("a"));
     assertTrue(seen.contains("b"));
@@ -94,7 +94,7 @@ class ConcurrentHashtableD1Test {
     table.tryGetOrCreateOrNull("x", k -> new StringEntry(k, 10));
     table.tryGetOrCreateOrNull("y", k -> new StringEntry(k, 20));
     Set<String> seen = new HashSet<>();
-    table.forEach(seen, (ctx, e) -> ctx.add(e.key));
+    table.forEach(seen, (ctx, e) -> ctx.add(e.key()));
     assertEquals(2, seen.size());
     assertTrue(seen.contains("x"));
     assertTrue(seen.contains("y"));
@@ -258,7 +258,7 @@ class ConcurrentHashtableD1Test {
     assertTrue(removed);
     assertEquals(5, table.size());
     Set<String> seen = new HashSet<>();
-    table.forEach(e -> seen.add(e.key));
+    table.forEach(e -> seen.add(e.key()));
     assertEquals(5, seen.size());
     for (String key : seen) {
       assertNotNull(table.get(key));
@@ -301,7 +301,7 @@ class ConcurrentHashtableD1Test {
     int[] sum = {0};
     table.drain(
         e -> {
-          drained.add(e.key);
+          drained.add(e.key());
           sum[0] += e.value;
         });
 
@@ -323,7 +323,7 @@ class ConcurrentHashtableD1Test {
     table.tryGetOrCreateOrNull("b", k -> new StringEntry(k, 2));
 
     Set<String> drained = new HashSet<>();
-    table.drain(drained, (ctx, e) -> ctx.add(e.key));
+    table.drain(drained, (ctx, e) -> ctx.add(e.key()));
 
     assertEquals(new HashSet<>(Arrays.asList("a", "b")), drained);
     assertEquals(0, table.size());
@@ -421,7 +421,7 @@ class ConcurrentHashtableD1Test {
     Maybe<StringEntry> created =
         table.tryGetOrCreateOrEvict("new", k -> new StringEntry(k, 2), e -> true);
     assertTrue(created.isPresent());
-    assertEquals("new", created.getOrNull().key);
+    assertEquals("new", created.getOrNull().key());
     assertEquals(1, table.size());
     assertNull(table.get("old"));
     assertSame(created.getOrNull(), table.get("new"));
@@ -464,12 +464,21 @@ class ConcurrentHashtableD1Test {
     assertNull(table.get("new"));
   }
 
+  /** Entry holding a key plus one mutable {@code int} payload. */
   private static final class StringEntry extends ConcurrentHashtable.D1.Entry<String, StringEntry> {
-    final int value;
+    volatile int value;
 
     StringEntry(String key, int value) {
       super(key);
       this.value = value;
+    }
+  }
+
+  /** Entry with no payload, used for the bucket-chain/collision tests. */
+  private static final class CollidingEntry
+      extends ConcurrentHashtable.D1.Entry<CollidingKey, CollidingEntry> {
+    CollidingEntry(CollidingKey key) {
+      super(key);
     }
   }
 
@@ -495,13 +504,6 @@ class ConcurrentHashtableD1Test {
       }
       CollidingKey that = (CollidingKey) o;
       return fixedHash == that.fixedHash && label.equals(that.label);
-    }
-  }
-
-  private static final class CollidingEntry
-      extends ConcurrentHashtable.D1.Entry<CollidingKey, CollidingEntry> {
-    CollidingEntry(CollidingKey key) {
-      super(key);
     }
   }
 }

--- a/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableD1Test.java
+++ b/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableD1Test.java
@@ -465,7 +465,7 @@ class ConcurrentHashtableD1Test {
   }
 
   /** Entry holding a key plus one mutable {@code int} payload. */
-  private static final class StringEntry extends ConcurrentHashtable.D1.Entry<String, StringEntry> {
+  private static final class StringEntry extends ConcurrentHashtable.D1.Entry<String> {
     volatile int value;
 
     StringEntry(String key, int value) {
@@ -475,8 +475,7 @@ class ConcurrentHashtableD1Test {
   }
 
   /** Entry with no payload, used for the bucket-chain/collision tests. */
-  private static final class CollidingEntry
-      extends ConcurrentHashtable.D1.Entry<CollidingKey, CollidingEntry> {
+  private static final class CollidingEntry extends ConcurrentHashtable.D1.Entry<CollidingKey> {
     CollidingEntry(CollidingKey key) {
       super(key);
     }

--- a/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableD2Test.java
+++ b/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableD2Test.java
@@ -392,8 +392,7 @@ class ConcurrentHashtableD2Test {
   }
 
   /** Entry with no payload beyond its two key parts, used to exercise the D2 identity/API. */
-  private static final class PairEntry
-      extends ConcurrentHashtable.D2.Entry<String, Integer, PairEntry> {
+  private static final class PairEntry extends ConcurrentHashtable.D2.Entry<String, Integer> {
     PairEntry(String key1, Integer key2) {
       super(key1, key2);
     }

--- a/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableD2Test.java
+++ b/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableD2Test.java
@@ -45,8 +45,8 @@ class ConcurrentHashtableD2Test {
               return new PairEntry(k1, k2);
             });
     assertNotNull(created);
-    assertEquals("a", created.key1);
-    assertEquals(Integer.valueOf(1), created.key2);
+    assertEquals("a", created.key1());
+    assertEquals(Integer.valueOf(1), created.key2());
     assertEquals(1, table.size());
     assertEquals(1, createCount[0]);
     assertSame(created, table.get("a", 1));
@@ -78,7 +78,7 @@ class ConcurrentHashtableD2Test {
     table.tryGetOrCreateOrNull("a", 1, PairEntry::new);
     table.tryGetOrCreateOrNull("b", 2, PairEntry::new);
     Set<String> seen = new HashSet<>();
-    table.forEach(e -> seen.add(e.key1 + ":" + e.key2));
+    table.forEach(e -> seen.add(e.key1() + ":" + e.key2()));
     assertEquals(2, seen.size());
     assertTrue(seen.contains("a:1"));
     assertTrue(seen.contains("b:2"));
@@ -91,7 +91,7 @@ class ConcurrentHashtableD2Test {
     table.tryGetOrCreateOrNull("a", 1, PairEntry::new);
     table.tryGetOrCreateOrNull("b", 2, PairEntry::new);
     Set<String> seen = new HashSet<>();
-    table.forEach(seen, (ctx, e) -> ctx.add(e.key1 + ":" + e.key2));
+    table.forEach(seen, (ctx, e) -> ctx.add(e.key1() + ":" + e.key2()));
     assertEquals(2, seen.size());
     assertTrue(seen.contains("a:1"));
     assertTrue(seen.contains("b:2"));
@@ -246,11 +246,11 @@ class ConcurrentHashtableD2Test {
     for (int i = 0; i < 10; i++) {
       table.tryGetOrCreateOrNull("k", i, PairEntry::new);
     }
-    boolean removed = table.removeIf(e -> e.key2 % 2 == 0); // removes key2 0,2,4,6,8
+    boolean removed = table.removeIf(e -> e.key2() % 2 == 0); // removes key2 0,2,4,6,8
     assertTrue(removed);
     assertEquals(5, table.size());
     Set<String> seen = new HashSet<>();
-    table.forEach(e -> seen.add(e.key1 + ":" + e.key2));
+    table.forEach(e -> seen.add(e.key1() + ":" + e.key2()));
     assertEquals(5, seen.size());
   }
 
@@ -286,7 +286,7 @@ class ConcurrentHashtableD2Test {
     table.tryGetOrCreateOrNull("b", 1, PairEntry::new);
 
     Set<String> drained = new HashSet<>();
-    table.drain(e -> drained.add(e.key1 + ":" + e.key2));
+    table.drain(e -> drained.add(e.key1() + ":" + e.key2()));
 
     assertEquals(new HashSet<>(Arrays.asList("a:1", "a:2", "b:1")), drained);
     assertEquals(0, table.size());
@@ -304,7 +304,7 @@ class ConcurrentHashtableD2Test {
     table.tryGetOrCreateOrNull("b", 2, PairEntry::new);
 
     Set<String> drained = new HashSet<>();
-    table.drain(drained, (ctx, e) -> ctx.add(e.key1 + ":" + e.key2));
+    table.drain(drained, (ctx, e) -> ctx.add(e.key1() + ":" + e.key2()));
 
     assertEquals(new HashSet<>(Arrays.asList("a:1", "b:2")), drained);
     assertEquals(0, table.size());
@@ -348,7 +348,7 @@ class ConcurrentHashtableD2Test {
 
     Maybe<PairEntry> created = table.tryGetOrCreateOrEvict("new", 2, PairEntry::new, e -> true);
     assertTrue(created.isPresent());
-    assertEquals("new", created.getOrNull().key1);
+    assertEquals("new", created.getOrNull().key1());
     assertEquals(1, table.size());
     assertNull(table.get("old", 1));
     assertSame(created.getOrNull(), table.get("new", 2));
@@ -391,6 +391,7 @@ class ConcurrentHashtableD2Test {
     assertNull(table.get("new", 2));
   }
 
+  /** Entry with no payload beyond its two key parts, used to exercise the D2 identity/API. */
   private static final class PairEntry
       extends ConcurrentHashtable.D2.Entry<String, Integer, PairEntry> {
     PairEntry(String key1, Integer key2) {

--- a/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableD2Test.java
+++ b/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableD2Test.java
@@ -391,7 +391,8 @@ class ConcurrentHashtableD2Test {
     assertNull(table.get("new", 2));
   }
 
-  private static final class PairEntry extends ConcurrentHashtable.D2.Entry<String, Integer> {
+  private static final class PairEntry
+      extends ConcurrentHashtable.D2.Entry<String, Integer, PairEntry> {
     PairEntry(String key1, Integer key2) {
       super(key1, key2);
     }

--- a/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableReservationTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableReservationTest.java
@@ -35,7 +35,7 @@ class ConcurrentHashtableReservationTest {
     TestEntry first;
     try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
       assertTrue(r.isPresent());
-      first = r.tryGetOrInsertOrNull(TestEntry::new, 1);
+      first = r.tryGetOrInsertOrNull(1, TestEntry::new);
     }
     assertEquals(1, first.value);
     assertEquals(1, ConcurrentHashtable.estimateSize(state));
@@ -44,7 +44,7 @@ class ConcurrentHashtableReservationTest {
     // existing entry, not double-insert or leak the claimed slot.
     TestEntry second;
     try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
-      second = r.tryGetOrInsertOrNull(TestEntry::new, 1);
+      second = r.tryGetOrInsertOrNull(1, TestEntry::new);
     }
     assertSame(first, second);
     assertEquals(1, ConcurrentHashtable.estimateSize(state));
@@ -55,7 +55,7 @@ class ConcurrentHashtableReservationTest {
     ConcurrentHashtable.State<TestEntry> state =
         ConcurrentHashtable.createBounded(TestEntry.class, 1);
     try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
-      r.tryGetOrInsertOrNull(TestEntry::new, 1);
+      r.tryGetOrInsertOrNull(1, TestEntry::new);
     }
     assertTrue(ConcurrentHashtable.isFull(state));
 
@@ -65,11 +65,11 @@ class ConcurrentHashtableReservationTest {
       assertFalse(r.isPresent());
       result =
           r.tryGetOrInsertOrNull(
+              2,
               v -> {
                 factoryCalls.incrementAndGet();
                 return new TestEntry(v);
-              },
-              2);
+              });
     }
     assertNull(result);
     assertEquals(0, factoryCalls.get());
@@ -95,14 +95,14 @@ class ConcurrentHashtableReservationTest {
 
     Maybe<TestEntry> present;
     try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
-      present = r.tryGetOrInsert(TestEntry::new, 1);
+      present = r.tryGetOrInsert(1, TestEntry::new);
     }
     assertTrue(present.isPresent());
     assertEquals(1, present.getOrNull().value);
 
     Maybe<TestEntry> absent;
     try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
-      absent = r.tryGetOrInsert(TestEntry::new, 2);
+      absent = r.tryGetOrInsert(2, TestEntry::new);
     }
     assertFalse(absent.isPresent());
     assertNull(absent.getOrNull());
@@ -163,7 +163,7 @@ class ConcurrentHashtableReservationTest {
     ThreePartEntry three;
     try (ConcurrentHashtable.Reservation<ThreePartEntry> r =
         ConcurrentHashtable.tryReserve(state3)) {
-      three = r.tryGetOrInsertOrNull(ThreePartEntry::new, "x", "y", "z");
+      three = r.tryGetOrInsertOrNull("x", "y", "z", ThreePartEntry::new);
     }
     assertEquals("x", three.a);
     assertEquals("y", three.b);
@@ -174,7 +174,7 @@ class ConcurrentHashtableReservationTest {
     FourPartEntry four;
     try (ConcurrentHashtable.Reservation<FourPartEntry> r =
         ConcurrentHashtable.tryReserve(state4)) {
-      four = r.tryGetOrInsertOrNull(FourPartEntry::new, "w", "x", "y", "z");
+      four = r.tryGetOrInsertOrNull("w", "x", "y", "z", FourPartEntry::new);
     }
     assertEquals("w", four.a);
     assertEquals("x", four.b);

--- a/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableReservationTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableReservationTest.java
@@ -34,7 +34,7 @@ class ConcurrentHashtableReservationTest {
 
     TestEntry first;
     try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
-      assertTrue(r.isPresent());
+      assertTrue(r.isReserved());
       first = r.tryGetOrInsertOrNull(1, TestEntry::new);
     }
     assertEquals(1, first.value);
@@ -62,7 +62,7 @@ class ConcurrentHashtableReservationTest {
     AtomicInteger factoryCalls = new AtomicInteger();
     TestEntry result;
     try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
-      assertFalse(r.isPresent());
+      assertFalse(r.isReserved());
       result =
           r.tryGetOrInsertOrNull(
               2,
@@ -81,7 +81,7 @@ class ConcurrentHashtableReservationTest {
     ConcurrentHashtable.State<TestEntry> state =
         ConcurrentHashtable.createBounded(TestEntry.class, 1);
     try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
-      assertTrue(r.isPresent());
+      assertTrue(r.isReserved());
       // Deliberately not consuming the reservation.
     }
     assertEquals(0, ConcurrentHashtable.estimateSize(state));
@@ -113,7 +113,7 @@ class ConcurrentHashtableReservationTest {
     ConcurrentHashtable.State<TestEntry> state =
         ConcurrentHashtable.createBounded(TestEntry.class, 0);
     try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
-      assertFalse(r.isPresent());
+      assertFalse(r.isReserved());
     }
     assertEquals(0, ConcurrentHashtable.estimateSize(state));
   }

--- a/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableReservationTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableReservationTest.java
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
 
-/** Exercises {@link ConcurrentHashtable#reserve} and {@link ConcurrentHashtable.Reservation}. */
+/** Exercises {@link ConcurrentHashtable#tryReserve} and {@link ConcurrentHashtable.Reservation}. */
 class ConcurrentHashtableReservationTest {
 
   private static final class TestEntry extends ConcurrentHashtable.Entry<TestEntry> {
@@ -33,7 +33,7 @@ class ConcurrentHashtableReservationTest {
         ConcurrentHashtable.createBounded(TestEntry.class, 4);
 
     TestEntry first;
-    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.reserve(state)) {
+    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
       assertTrue(r.isPresent());
       first = r.tryGetOrInsertOrNull(TestEntry::new, 1);
     }
@@ -43,7 +43,7 @@ class ConcurrentHashtableReservationTest {
     // Reserving again for a key that already exists should discard the reservation and return the
     // existing entry, not double-insert or leak the claimed slot.
     TestEntry second;
-    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.reserve(state)) {
+    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
       second = r.tryGetOrInsertOrNull(TestEntry::new, 1);
     }
     assertSame(first, second);
@@ -54,14 +54,14 @@ class ConcurrentHashtableReservationTest {
   void reserveOnFullTableIsAbsentAndSkipsTheFactory() {
     ConcurrentHashtable.State<TestEntry> state =
         ConcurrentHashtable.createBounded(TestEntry.class, 1);
-    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.reserve(state)) {
+    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
       r.tryGetOrInsertOrNull(TestEntry::new, 1);
     }
     assertTrue(ConcurrentHashtable.isFull(state));
 
     AtomicInteger factoryCalls = new AtomicInteger();
     TestEntry result;
-    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.reserve(state)) {
+    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
       assertFalse(r.isPresent());
       result =
           r.tryGetOrInsertOrNull(
@@ -80,7 +80,7 @@ class ConcurrentHashtableReservationTest {
   void closeCancelsAnUnconsumedReservation() {
     ConcurrentHashtable.State<TestEntry> state =
         ConcurrentHashtable.createBounded(TestEntry.class, 1);
-    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.reserve(state)) {
+    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
       assertTrue(r.isPresent());
       // Deliberately not consuming the reservation.
     }
@@ -89,10 +89,30 @@ class ConcurrentHashtableReservationTest {
   }
 
   @Test
+  void tryGetOrInsertWrapsResultInMaybe() {
+    ConcurrentHashtable.State<TestEntry> state =
+        ConcurrentHashtable.createBounded(TestEntry.class, 1);
+
+    Maybe<TestEntry> present;
+    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
+      present = r.tryGetOrInsert(TestEntry::new, 1);
+    }
+    assertTrue(present.isPresent());
+    assertEquals(1, present.getOrNull().value);
+
+    Maybe<TestEntry> absent;
+    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
+      absent = r.tryGetOrInsert(TestEntry::new, 2);
+    }
+    assertFalse(absent.isPresent());
+    assertNull(absent.getOrNull());
+  }
+
+  @Test
   void closeOnAnAbsentReservationIsANoOp() {
     ConcurrentHashtable.State<TestEntry> state =
         ConcurrentHashtable.createBounded(TestEntry.class, 0);
-    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.reserve(state)) {
+    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.tryReserve(state)) {
       assertFalse(r.isPresent());
     }
     assertEquals(0, ConcurrentHashtable.estimateSize(state));
@@ -141,7 +161,8 @@ class ConcurrentHashtableReservationTest {
     ConcurrentHashtable.State<ThreePartEntry> state3 =
         ConcurrentHashtable.createBounded(ThreePartEntry.class, 2);
     ThreePartEntry three;
-    try (ConcurrentHashtable.Reservation<ThreePartEntry> r = ConcurrentHashtable.reserve(state3)) {
+    try (ConcurrentHashtable.Reservation<ThreePartEntry> r =
+        ConcurrentHashtable.tryReserve(state3)) {
       three = r.tryGetOrInsertOrNull(ThreePartEntry::new, "x", "y", "z");
     }
     assertEquals("x", three.a);
@@ -151,7 +172,8 @@ class ConcurrentHashtableReservationTest {
     ConcurrentHashtable.State<FourPartEntry> state4 =
         ConcurrentHashtable.createBounded(FourPartEntry.class, 2);
     FourPartEntry four;
-    try (ConcurrentHashtable.Reservation<FourPartEntry> r = ConcurrentHashtable.reserve(state4)) {
+    try (ConcurrentHashtable.Reservation<FourPartEntry> r =
+        ConcurrentHashtable.tryReserve(state4)) {
       four = r.tryGetOrInsertOrNull(FourPartEntry::new, "w", "x", "y", "z");
     }
     assertEquals("w", four.a);

--- a/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableReservationTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableReservationTest.java
@@ -1,0 +1,162 @@
+package datadog.trace.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+
+/** Exercises {@link ConcurrentHashtable#reserve} and {@link ConcurrentHashtable.Reservation}. */
+class ConcurrentHashtableReservationTest {
+
+  private static final class TestEntry extends ConcurrentHashtable.Entry<TestEntry> {
+    final int value;
+
+    TestEntry(int value) {
+      super(value);
+      this.value = value;
+    }
+
+    @Override
+    public boolean matches(@Nonnull TestEntry other) {
+      return value == other.value;
+    }
+  }
+
+  @Test
+  void tryGetOrInsertOrNullInsertsOnMissAndFindsOnHit() {
+    ConcurrentHashtable.State<TestEntry> state =
+        ConcurrentHashtable.createBounded(TestEntry.class, 4);
+
+    TestEntry first;
+    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.reserve(state)) {
+      assertTrue(r.isPresent());
+      first = r.tryGetOrInsertOrNull(TestEntry::new, 1);
+    }
+    assertEquals(1, first.value);
+    assertEquals(1, ConcurrentHashtable.estimateSize(state));
+
+    // Reserving again for a key that already exists should discard the reservation and return the
+    // existing entry, not double-insert or leak the claimed slot.
+    TestEntry second;
+    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.reserve(state)) {
+      second = r.tryGetOrInsertOrNull(TestEntry::new, 1);
+    }
+    assertSame(first, second);
+    assertEquals(1, ConcurrentHashtable.estimateSize(state));
+  }
+
+  @Test
+  void reserveOnFullTableIsAbsentAndSkipsTheFactory() {
+    ConcurrentHashtable.State<TestEntry> state =
+        ConcurrentHashtable.createBounded(TestEntry.class, 1);
+    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.reserve(state)) {
+      r.tryGetOrInsertOrNull(TestEntry::new, 1);
+    }
+    assertTrue(ConcurrentHashtable.isFull(state));
+
+    AtomicInteger factoryCalls = new AtomicInteger();
+    TestEntry result;
+    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.reserve(state)) {
+      assertFalse(r.isPresent());
+      result =
+          r.tryGetOrInsertOrNull(
+              v -> {
+                factoryCalls.incrementAndGet();
+                return new TestEntry(v);
+              },
+              2);
+    }
+    assertNull(result);
+    assertEquals(0, factoryCalls.get());
+    assertEquals(1, ConcurrentHashtable.estimateSize(state));
+  }
+
+  @Test
+  void closeCancelsAnUnconsumedReservation() {
+    ConcurrentHashtable.State<TestEntry> state =
+        ConcurrentHashtable.createBounded(TestEntry.class, 1);
+    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.reserve(state)) {
+      assertTrue(r.isPresent());
+      // Deliberately not consuming the reservation.
+    }
+    assertEquals(0, ConcurrentHashtable.estimateSize(state));
+    assertFalse(ConcurrentHashtable.isFull(state));
+  }
+
+  @Test
+  void closeOnAnAbsentReservationIsANoOp() {
+    ConcurrentHashtable.State<TestEntry> state =
+        ConcurrentHashtable.createBounded(TestEntry.class, 0);
+    try (ConcurrentHashtable.Reservation<TestEntry> r = ConcurrentHashtable.reserve(state)) {
+      assertFalse(r.isPresent());
+    }
+    assertEquals(0, ConcurrentHashtable.estimateSize(state));
+  }
+
+  private static final class ThreePartEntry extends ConcurrentHashtable.Entry<ThreePartEntry> {
+    final String a;
+    final String b;
+    final String c;
+
+    ThreePartEntry(String a, String b, String c) {
+      super(HashingUtils.hash(a, b, c));
+      this.a = a;
+      this.b = b;
+      this.c = c;
+    }
+
+    @Override
+    public boolean matches(@Nonnull ThreePartEntry other) {
+      return a.equals(other.a) && b.equals(other.b) && c.equals(other.c);
+    }
+  }
+
+  private static final class FourPartEntry extends ConcurrentHashtable.Entry<FourPartEntry> {
+    final String a;
+    final String b;
+    final String c;
+    final String d;
+
+    FourPartEntry(String a, String b, String c, String d) {
+      super(HashingUtils.hash(a, b, c, d));
+      this.a = a;
+      this.b = b;
+      this.c = c;
+      this.d = d;
+    }
+
+    @Override
+    public boolean matches(@Nonnull FourPartEntry other) {
+      return a.equals(other.a) && b.equals(other.b) && c.equals(other.c) && d.equals(other.d);
+    }
+  }
+
+  @Test
+  void tryGetOrInsertOrNullSupportsUpToFourComponents() {
+    ConcurrentHashtable.State<ThreePartEntry> state3 =
+        ConcurrentHashtable.createBounded(ThreePartEntry.class, 2);
+    ThreePartEntry three;
+    try (ConcurrentHashtable.Reservation<ThreePartEntry> r = ConcurrentHashtable.reserve(state3)) {
+      three = r.tryGetOrInsertOrNull(ThreePartEntry::new, "x", "y", "z");
+    }
+    assertEquals("x", three.a);
+    assertEquals("y", three.b);
+    assertEquals("z", three.c);
+
+    ConcurrentHashtable.State<FourPartEntry> state4 =
+        ConcurrentHashtable.createBounded(FourPartEntry.class, 2);
+    FourPartEntry four;
+    try (ConcurrentHashtable.Reservation<FourPartEntry> r = ConcurrentHashtable.reserve(state4)) {
+      four = r.tryGetOrInsertOrNull(FourPartEntry::new, "w", "x", "y", "z");
+    }
+    assertEquals("w", four.a);
+    assertEquals("x", four.b);
+    assertEquals("y", four.c);
+    assertEquals("z", four.d);
+  }
+}

--- a/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableSizeManagerTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableSizeManagerTest.java
@@ -420,12 +420,17 @@ class ConcurrentHashtableSizeManagerTest {
   }
 
   /** Entry with a caller-controlled {@code keyHash} so tests can place it in an exact bucket. */
-  private static final class TestEntry extends ConcurrentHashtable.Entry {
+  private static final class TestEntry extends ConcurrentHashtable.Entry<TestEntry> {
     final String label;
 
     TestEntry(long keyHash, String label) {
       super(keyHash);
       this.label = label;
+    }
+
+    @Override
+    public boolean matches(TestEntry other) {
+      return label.equals(other.label);
     }
   }
 }

--- a/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableSizeManagerTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableSizeManagerTest.java
@@ -40,7 +40,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void tryReserveOrEvictReservesDirectlyWhenUnderCapacity() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 2);
+        ConcurrentHashtable.createBounded(TestEntry.class, 2);
 
     boolean reserved = tryReserveOrEvict(state, e -> true);
     assertTrue(reserved);
@@ -51,7 +51,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void tryReserveOrEvictEvictsWhenFullAndSomethingMatches() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 1);
+        ConcurrentHashtable.createBounded(TestEntry.class, 1);
     TestEntry existing = insertAt(state, 0, "existing");
     assertTrue(state.sizeManager.tryReserve());
     assertTrue(state.sizeManager.isFull());
@@ -65,7 +65,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void tryReserveOrEvictFailsAndLeavesTableUntouchedWhenNothingEvictable() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 1);
+        ConcurrentHashtable.createBounded(TestEntry.class, 1);
     TestEntry existing = insertAt(state, 0, "existing");
     assertTrue(state.sizeManager.tryReserve());
 
@@ -78,7 +78,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void insertReservedSplicesWithoutTouchingTheCountAfterATryReserve() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 2);
+        ConcurrentHashtable.createBounded(TestEntry.class, 2);
     assertTrue(state.sizeManager.tryReserve());
     assertEquals(1, state.sizeManager.estimateSize());
 
@@ -95,7 +95,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void evictOneReturnsNullAndLeavesCountUnchangedWhenNothingMatches() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 4);
+        ConcurrentHashtable.createBounded(TestEntry.class, 4);
     insertAt(state, 0, "a");
     state.sizeManager.increment();
 
@@ -107,7 +107,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void evictOneUnlinksMatchAndDecrementsCount() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 4);
+        ConcurrentHashtable.createBounded(TestEntry.class, 4);
     TestEntry a = insertAt(state, 0, "a");
     TestEntry b = insertAt(state, 1, "b");
     state.sizeManager.increment();
@@ -130,7 +130,7 @@ class ConcurrentHashtableSizeManagerTest {
   void evictOneResumesFromLastEvictedBucketAndWrapsAround() {
     // Bucket-array length 4: keyHash i lands in bucket i.
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 4);
+        ConcurrentHashtable.createBounded(TestEntry.class, 4);
     TestEntry e0 = insertAt(state, 0, "e0");
     insertAt(state, 2, "e2");
     TestEntry e3 = insertAt(state, 3, "e3");
@@ -159,7 +159,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void evictAllRemovesEveryMatchAndReturnsCount() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 8);
+        ConcurrentHashtable.createBounded(TestEntry.class, 8);
     for (int i = 0; i < 6; i++) {
       insertAt(state, i, "e" + i);
       state.sizeManager.increment();
@@ -179,7 +179,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void evictAllResetsCursorSoSubsequentEvictOneScansFromBucketZero() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 4);
+        ConcurrentHashtable.createBounded(TestEntry.class, 4);
     insertAt(state, 2, "a");
     state.sizeManager.increment();
     // Advance the cursor away from 0 via a successful eviction at bucket 2.
@@ -203,7 +203,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void releaseGivesBackRemovedSlotsAndRestartsScan() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 4);
+        ConcurrentHashtable.createBounded(TestEntry.class, 4);
     insertAt(state, 2, "a");
     state.sizeManager.increment();
     evictOne(state, e -> true); // advances the cursor to 2, count back to 0
@@ -226,7 +226,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void stateCreateCappedBundlesBucketsAndSizeManager() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 3);
+        ConcurrentHashtable.createBounded(TestEntry.class, 3);
     assertEquals(0, state.sizeManager.estimateSize());
     assertEquals(3, state.sizeManager.capacity());
     assertTrue(state.buckets.length() >= 3);
@@ -235,7 +235,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void stateLevelTryReserveOrEvictAndEvictOneAndEvictAllDelegateToSizeManager() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 1);
+        ConcurrentHashtable.createBounded(TestEntry.class, 1);
     synchronized (ConcurrentHashtable.getWriteLockAt(state, 0)) {
       ConcurrentHashtable.insertHeadEntryAt(state, 0, new TestEntry(0, "a"));
     }
@@ -280,7 +280,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void clearCannotInterleaveBetweenReservationAndInsert() throws InterruptedException {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 1);
+        ConcurrentHashtable.createBounded(TestEntry.class, 1);
     insertAt(state, 0, "a");
     state.sizeManager.increment();
     assertTrue(ConcurrentHashtable.isFull(state));
@@ -318,7 +318,7 @@ class ConcurrentHashtableSizeManagerTest {
   @Test
   void reservationSurvivesAClearLandingBetweenReserveAndInsert() {
     ConcurrentHashtable.State<TestEntry> state =
-        ConcurrentHashtable.State.createBounded(TestEntry.class, 2);
+        ConcurrentHashtable.createBounded(TestEntry.class, 2);
     insertAt(state, 0, "a");
     state.sizeManager.increment();
 

--- a/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableStaticsTest.java
+++ b/internal-api/src/test/java/datadog/trace/util/ConcurrentHashtableStaticsTest.java
@@ -329,7 +329,7 @@ class ConcurrentHashtableStaticsTest {
   }
 
   /** Primitive-{@code int}-key entry: no boxing, keyHash is the key itself. */
-  private static final class IntEntry extends ConcurrentHashtable.Entry {
+  private static final class IntEntry extends ConcurrentHashtable.Entry<IntEntry> {
     final int key;
     final int value;
 
@@ -341,6 +341,11 @@ class ConcurrentHashtableStaticsTest {
 
     boolean matches(int key) {
       return this.key == key;
+    }
+
+    @Override
+    public boolean matches(IntEntry other) {
+      return matches(other.key);
     }
   }
 


### PR DESCRIPTION
# What Does This Do

Builds on #12453's cleanup of `ConcurrentHashtable` with a higher-level find-or-insert API, and ports `LogCollector` onto it as a worked example of the resulting ergonomics.

- `Entry<TEntry extends Entry<TEntry>>` (self-bounded, à la `Enum<E extends Enum<E>>`) forces every concrete entry to implement `matches(TEntry)`, replacing ad-hoc reuse of `equals()`/`hashCode()` with a comparison method scoped to what the hashtable actually needs.
- `ConcurrentHashtable.reserve(state)` returns an `AutoCloseable` `Reservation<TEntry>` that claims a slot lock-free, defers building the entry until the reservation actually succeeds, and auto-cancels an unclaimed slot on `close()` if nothing was inserted (e.g. a concurrent write already inserted the same logical entry).
- `Reservation#tryGetOrInsertOrNull` is overloaded from 1 to 4 key components (`Function` through a new `Function4`), so callers can pass a non-capturing constructor reference instead of allocating a capturing lambda per call.
- `SizeManager.cancelReservation()` is the new lock-free primitive backing `Reservation#close()` (symmetric with the existing `decrement()`).

`LogCollector` is ported onto this API illustratively — its hand-rolled `ConcurrentHashMap<RawLogMessage, AtomicInteger>` dedup logic collapses into a lock-free scan plus a single `try (Reservation<...> r = ConcurrentHashtable.reserve(...)) { r.tryGetOrInsertOrNull(RawLogMessage::new, ...) }`.

# Motivation

`ConcurrentHashtable` is a new toolbox-style primitive with no adopters yet. Porting `LogCollector` onto it dogfoods the API from inside Java LP before it's offered to other product areas, surfacing ergonomic gaps (like the reserve/insert dance) while the cost of changing the API is still low.

# Additional Notes

- `:internal-api:compileJava`, `:internal-api:compileTestJava`, `:internal-api:compileTestGroovy`, `:internal-api:compileJmhJava` all pass
- `:internal-api:test --tests "datadog.trace.util.ConcurrentHashtable*"` — all existing suites plus the new `ConcurrentHashtableReservationTest` pass
- `:internal-api:test --tests "datadog.trace.api.telemetry.LogCollectorTest"` passes against the ported implementation
- `./gradlew :internal-api:spotlessApply` — no formatting changes needed

# Contributor Checklist

- [x] Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- [ ] Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- [ ] Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion (n/a — no new top-level files/paths)
- [ ] Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors (n/a — no new config flags)
- [ ] Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

