### PR TITLE
Prevent smoke-test teardown race

### DIFF
--- a/dd-smoke-tests/src/main/java/datadog/smoketest/OutputThreads.java
+++ b/dd-smoke-tests/src/main/java/datadog/smoketest/OutputThreads.java
@@ -23,17 +23,25 @@ public class OutputThreads implements Closeable {
   private static final int MAX_LINE_SIZE = 1024 * 1024;
   private static final int DEFAULT_TIMEOUT_MILLIS = 10_000;
 
-  final ThreadGroup tg = new ThreadGroup("smoke-output");
+  final ThreadGroup tg;
   final List<String> testLogMessages = new ArrayList<>();
+
+  public OutputThreads() {
+    this(new ThreadGroup("smoke-output"));
+  }
+
+  OutputThreads(ThreadGroup tg) {
+    this.tg = tg;
+  }
 
   public void close() {
     tg.interrupt();
     Thread[] threads = new Thread[tg.activeCount()];
-    tg.enumerate(threads);
+    int threadCount = tg.enumerate(threads);
 
-    for (Thread thread : threads) {
+    for (int i = 0; i < threadCount; i++) {
       try {
-        thread.join(THREAD_JOIN_TIMEOUT_MILLIS);
+        threads[i].join(THREAD_JOIN_TIMEOUT_MILLIS);
       } catch (InterruptedException e) {
         // ignore
       }

--- a/dd-smoke-tests/src/main/java/datadog/smoketest/OutputThreads.java
+++ b/dd-smoke-tests/src/main/java/datadog/smoketest/OutputThreads.java
@@ -1,5 +1,6 @@
 package datadog.smoketest;
 
+import datadog.trace.api.internal.VisibleForTesting;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -30,6 +31,7 @@ public class OutputThreads implements Closeable {
     this(new ThreadGroup("smoke-output"));
   }
 
+  @VisibleForTesting
   OutputThreads(ThreadGroup tg) {
     this.tg = tg;
   }

--- a/dd-smoke-tests/src/test/java/datadog/smoketest/OutputThreadsTest.java
+++ b/dd-smoke-tests/src/test/java/datadog/smoketest/OutputThreadsTest.java
@@ -1,0 +1,26 @@
+package datadog.smoketest;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+
+class OutputThreadsTest {
+
+  @Test
+  void closeOnlyJoinsEnumeratedThreads() {
+    ThreadGroup shrinkingThreadGroup =
+        new ThreadGroup("shrinking-smoke-output") {
+          @Override
+          public int activeCount() {
+            return 1;
+          }
+
+          @Override
+          public int enumerate(Thread[] threads) {
+            return 0;
+          }
+        };
+
+    assertDoesNotThrow(() -> new OutputThreads(shrinkingThreadGroup).close());
+  }
+}


### PR DESCRIPTION
# What Does This Do

Use the number of threads actually returned by `ThreadGroup.enumerate()` when joining smoke-test output readers during teardown.

Add a deterministic regression test that models an output thread disappearing between `activeCount()` and `enumerate()`.

# Motivation

`ThreadGroup.activeCount()` is only an estimate. The teardown code sized an array from that estimate, ignored the smaller count returned by `enumerate()`, and attempted to join every array entry. This could dereference an unused null entry after an output reader exited.

# Additional Notes

The failure was flaky because teardown first interrupts the output-reader thread. If that thread exited after `activeCount()` reported it but before `enumerate()` populated the array, the array retained a null tail entry:

```text
java.lang.NullPointerException
    at datadog.smoketest.OutputThreads.close(OutputThreads.java:36)
    at datadog.smoketest.AbstractSmokeApp.afterAll(AbstractSmokeApp.java:265)
```

Whether the reader exited inside that narrow window depended on JVM thread scheduling, so the same test could pass on retry. Joining only indexes below the count returned by `enumerate()` follows the API contract and removes the race.

Validation:

- `./gradlew :dd-smoke-tests:test -PtestJvm=11 --tests datadog.smoketest.ErrorLogSmokeTest --tests datadog.smoketest.OutputThreadsTest` — 2 passed
- `./gradlew :dd-smoke-tests:test -PtestJvm=11` — 60 passed
- `./gradlew :dd-smoke-tests:spotlessJavaCheck` — passed

No public API or user-facing behavior changes.

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: N/A