### PR TITLE
Fix metrics-api JaCoCo coverage gate

### DIFF
--- a/products/metrics/metrics-api/build.gradle.kts
+++ b/products/metrics/metrics-api/build.gradle.kts
@@ -7,4 +7,17 @@ description = "Metrics API"
 
 dependencies {
   implementation(libs.slf4j)
+
+  testImplementation(libs.bundles.junit5)
+  testImplementation(libs.bundles.mockito)
 }
+
+extra["excludedClassesCoverage"] = listOf(
+  "datadog.metrics.api.Monitoring",
+  "datadog.metrics.api.NoOpCounter",
+  "datadog.metrics.api.NoOpHistogram",
+  "datadog.metrics.api.NoOpHistogramsFactory",
+  "datadog.metrics.api.NoOpMonitoring",
+  "datadog.metrics.api.NoOpRecording",
+  "datadog.metrics.api.statsd.NoOpStatsDClient",
+)

--- a/products/metrics/metrics-api/src/test/java/datadog/metrics/api/HistogramsTest.java
+++ b/products/metrics/metrics-api/src/test/java/datadog/metrics/api/HistogramsTest.java
@@ -1,0 +1,63 @@
+package datadog.metrics.api;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class HistogramsTest {
+
+  @AfterEach
+  void resetFactory() {
+    Histograms.factory = Histograms.NO_OP;
+  }
+
+  @Test
+  void constructorIsUsable() {
+    assertNotNull(new Histograms());
+  }
+
+  @Test
+  void registerIgnoresNull() {
+    Histograms.Factory before = Histograms.factory;
+    Histograms.register(null);
+    assertSame(before, Histograms.factory);
+  }
+
+  @Test
+  void registerReplacesFactory() {
+    Histograms.Factory factory = mock(Histograms.Factory.class);
+    Histograms.register(factory);
+    assertSame(factory, Histograms.factory);
+  }
+
+  @Test
+  void staticFactoryMethodsDelegateToRegisteredFactory() {
+    Histograms.Factory factory = mock(Histograms.Factory.class);
+    Histogram histogram = mock(Histogram.class);
+    Histogram logHistogram = mock(Histogram.class);
+    Histogram histogramWithBins = mock(Histogram.class);
+    HistogramWithSum histogramWithSum = mock(HistogramWithSum.class);
+    HistogramWithSum histogramWithSumFromBoundaries = mock(HistogramWithSum.class);
+
+    when(factory.newHistogram()).thenReturn(histogram);
+    when(factory.newLogHistogram()).thenReturn(logHistogram);
+    when(factory.newHistogram(0.01, 10)).thenReturn(histogramWithBins);
+    when(factory.newHistogramWithSum(0.01, 10)).thenReturn(histogramWithSum);
+    List<Double> boundaries = Arrays.asList(1.0, 2.0);
+    when(factory.newHistogramWithSum(boundaries)).thenReturn(histogramWithSumFromBoundaries);
+
+    Histograms.register(factory);
+
+    assertSame(histogram, Histogram.newHistogram());
+    assertSame(logHistogram, Histogram.newLogHistogram());
+    assertSame(histogramWithBins, Histogram.newHistogram(0.01, 10));
+    assertSame(histogramWithSum, Histogram.newHistogramWithSum(0.01, 10));
+    assertSame(histogramWithSumFromBoundaries, Histogram.newHistogramWithSum(boundaries));
+  }
+}

--- a/products/metrics/metrics-api/src/test/java/datadog/metrics/api/RecordingTest.java
+++ b/products/metrics/metrics-api/src/test/java/datadog/metrics/api/RecordingTest.java
@@ -1,0 +1,37 @@
+package datadog.metrics.api;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class RecordingTest {
+
+  @Test
+  void closeDelegatesToStop() {
+    StoppableRecording recording = new StoppableRecording();
+
+    recording.close();
+
+    assertTrue(recording.stopped);
+  }
+
+  private static final class StoppableRecording extends Recording {
+    boolean stopped;
+
+    @Override
+    public Recording start() {
+      return this;
+    }
+
+    @Override
+    public void reset() {}
+
+    @Override
+    public void stop() {
+      stopped = true;
+    }
+
+    @Override
+    public void flush() {}
+  }
+}

--- a/products/metrics/metrics-api/src/test/java/datadog/metrics/api/statsd/StatsDClientManagerTest.java
+++ b/products/metrics/metrics-api/src/test/java/datadog/metrics/api/statsd/StatsDClientManagerTest.java
@@ -1,0 +1,40 @@
+package datadog.metrics.api.statsd;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+class StatsDClientManagerTest {
+
+  @Test
+  void defaultFiveArgOverloadDelegatesWithAggregationEnabled() {
+    StatsDClient client = StatsDClient.NO_OP;
+    RecordingStatsDClientManager manager = new RecordingStatsDClientManager(client);
+
+    StatsDClient result = manager.statsDClient("host", 8125, null, "ns", new String[] {"tag"});
+
+    assertSame(client, result);
+    assertSame(Boolean.TRUE, manager.lastUseAggregation);
+  }
+
+  private static final class RecordingStatsDClientManager implements StatsDClientManager {
+    private final StatsDClient client;
+    private Boolean lastUseAggregation;
+
+    RecordingStatsDClientManager(StatsDClient client) {
+      this.client = client;
+    }
+
+    @Override
+    public StatsDClient statsDClient(
+        String host,
+        Integer port,
+        String namedPipe,
+        String namespace,
+        String[] constantTags,
+        boolean useAggregation) {
+      this.lastUseAggregation = useAggregation;
+      return client;
+    }
+  }
+}

--- a/products/metrics/metrics-api/src/test/java/datadog/metrics/api/statsd/StatsDClientTest.java
+++ b/products/metrics/metrics-api/src/test/java/datadog/metrics/api/statsd/StatsDClientTest.java
@@ -1,0 +1,61 @@
+package datadog.metrics.api.statsd;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+class StatsDClientTest {
+
+  @Test
+  void noOpConstantIsUsable() {
+    assertNotNull(StatsDClient.NO_OP);
+  }
+
+  @Test
+  void defaultRecordEventIsNoOp() {
+    StatsDClient client = new MinimalStatsDClient();
+
+    client.recordEvent("type", "source", "eventName", "message", "tag");
+  }
+
+  private static final class MinimalStatsDClient implements StatsDClient {
+    @Override
+    public void incrementCounter(String metricName, String... tags) {}
+
+    @Override
+    public void count(String metricName, long delta, String... tags) {}
+
+    @Override
+    public void gauge(String metricName, long value, String... tags) {}
+
+    @Override
+    public void gauge(String metricName, double value, String... tags) {}
+
+    @Override
+    public void histogram(String metricName, long value, String... tags) {}
+
+    @Override
+    public void histogram(String metricName, double value, String... tags) {}
+
+    @Override
+    public void distribution(String metricName, long value, String... tags) {}
+
+    @Override
+    public void distribution(String metricName, double value, String... tags) {}
+
+    @Override
+    public void serviceCheck(
+        String serviceCheckName, String status, String message, String... tags) {}
+
+    @Override
+    public void error(Exception error) {}
+
+    @Override
+    public int getErrorCount() {
+      return 0;
+    }
+
+    @Override
+    public void close() {}
+  }
+}


### PR DESCRIPTION
# What Does This Do

- `products/metrics/metrics-api` never opted into the `excludedClassesCoverage` convention used by sibling modules, so the repo-wide 0.9 minimum instruction/branch coverage rule failed for every `NoOp*` class as soon as CI ran this module's full `check` task (module-scoped CI hadn't run a full `check` here in a while).
- Excludes the true no-op classes (`NoOpCounter`, `NoOpHistogram`, `NoOpHistogramsFactory`, `NoOpMonitoring`, `NoOpRecording`, `NoOpStatsDClient`) and the pure-interface `Monitoring`.
- Adds the module's first `src/test` tree with real unit tests for the classes that have actual untested logic: `Histograms` (registration + static factory dispatch), `StatsDClientManager` (default 5-arg overload delegating to the 6-arg one), `Recording` (`close()` delegates to `stop()`), and a small `StatsDClient` test to clear its default `recordEvent` method.

# Motivation

Unrelated to any in-flight feature work — this is a pre-existing coverage gap surfaced while working on #12351, which switched `metrics-api`'s `build.gradle.kts` to the `dd-trace-java.module.internal-api` plugin and newly exposed the module to this gate. Kept as its own PR rather than folded into #12351, since the two are independent and shouldn't be reviewed together.

# Additional Notes

- Test plan:
  - [x] `./gradlew :products:metrics:metrics-api:test`
  - [x] `./gradlew :products:metrics:metrics-api:jacocoTestCoverageVerification`
  - [x] `./gradlew :products:metrics:metrics-api:check`

# Contributor Checklist

- [x] Format the title according to the contribution guidelines
- [x] Assign the `type:` and (`comp:` or `inst:`) labels in addition to any other useful labels
- [x] Avoid using `close`, `fix`, or any linking keywords when referencing an issue
- [ ] Update the CODEOWNERS file on source file addition, migration, or deletion (n/a — no new top-level source areas)
- [ ] Update public documentation with any new configuration flags or behaviors (n/a — no config/behavior change)
- [ ] Once approved, use merge queue to merge the PR

Jira ticket: none — pre-existing gap found incidentally, not tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
