### PR TITLE
Fix NullPointerException when publishing an SNS batch without a topic ARN

### DIFF
--- a/dd-java-agent/instrumentation/aws-java/aws-java-sns-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sns/SnsInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sns-1.0/src/main/java/datadog/trace/instrumentation/aws/v1/sns/SnsInterceptor.java
@@ -90,6 +90,9 @@ public class SnsInterceptor extends RequestHandler2 {
       PublishBatchRequest pmbRequest = (PublishBatchRequest) request;
       // Extract the topic name from the ARN for DSM
       String topicName = pmbRequest.getTopicArn();
+      if (null == topicName) {
+        return request; // no topic to attribute the batch to, leave it untouched
+      }
       topicName = topicName.substring(topicName.lastIndexOf(':') + 1);
 
       final ByteBuffer bytebuffer = this.getMessageAttributeValueToInject(request, topicName);

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sns-1.0/src/test/groovy/SnsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sns-1.0/src/test/groovy/SnsClientTest.groovy
@@ -1,9 +1,12 @@
+import com.amazonaws.AmazonClientException
 import com.amazonaws.auth.AWSStaticCredentialsProvider
 import com.amazonaws.auth.BasicAWSCredentials
 import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.services.sns.AmazonSNSClient
 import com.amazonaws.services.sns.AmazonSNSClientBuilder
 import com.amazonaws.services.sns.model.MessageAttributeValue
+import com.amazonaws.services.sns.model.PublishBatchRequest
+import com.amazonaws.services.sns.model.PublishBatchRequestEntry
 import com.amazonaws.services.sns.model.PublishRequest
 import datadog.trace.agent.test.naming.VersionedNamingTestBase
 import datadog.trace.agent.test.utils.TraceUtils
@@ -234,6 +237,15 @@ abstract class SnsClientTest extends VersionedNamingTestBase {
 
     then:
     noExceptionThrown()
+  }
+
+  def "SNS batch without topic ARN doesn't leak exception"() {
+    when:
+    snsClient.publishBatch(new PublishBatchRequest()
+      .withPublishBatchRequestEntries(new PublishBatchRequestEntry().withId("1").withMessage('sometext')))
+
+    then:
+    thrown(AmazonClientException)
   }
 }
 

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sns-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sns/SnsInterceptor.java
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sns-2.0/src/main/java/datadog/trace/instrumentation/aws/v2/sns/SnsInterceptor.java
@@ -81,6 +81,9 @@ public class SnsInterceptor implements ExecutionInterceptor {
       PublishBatchRequest request = (PublishBatchRequest) context.request();
       // Get topic name for DSM
       String snsTopicArn = request.topicArn();
+      if (null == snsTopicArn) {
+        return request; // no topic to attribute the batch to, leave it untouched
+      }
       String snsTopicName = snsTopicArn.substring(snsTopicArn.lastIndexOf(':') + 1);
       ArrayList<PublishBatchRequestEntry> entries = new ArrayList<>();
       SdkBytes value = this.getMessageAttributeValueToInject(executionAttributes, snsTopicName);

--- a/dd-java-agent/instrumentation/aws-java/aws-java-sns-2.0/src/test/groovy/SnsClientTest.groovy
+++ b/dd-java-agent/instrumentation/aws-java/aws-java-sns-2.0/src/test/groovy/SnsClientTest.groovy
@@ -13,6 +13,8 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sns.SnsClient
+import software.amazon.awssdk.core.exception.SdkException
+import software.amazon.awssdk.services.sns.model.PublishBatchRequestEntry
 import software.amazon.awssdk.services.sns.model.PublishResponse
 import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName
@@ -182,6 +184,16 @@ abstract class SnsClientTest extends VersionedNamingTestBase {
 
     then:
     noExceptionThrown()
+  }
+
+  def "SNS batch without topic ARN doesn't leak exception"() {
+    when:
+    snsClient.publishBatch {
+      it.publishBatchRequestEntries(PublishBatchRequestEntry.builder().id("1").message("sometext").build())
+    }
+
+    then:
+    thrown(SdkException)
   }
 
   def "test propagation styles"() {


### PR DESCRIPTION
`SnsInterceptor` reads the topic ARN to derive the topic name for DSM. The single-publish path already handles a missing ARN (a publish to a phone number has neither `topicArn` nor `targetArn`), but the batch path dereferences it straight away:

```java
String snsTopicArn = request.topicArn();
String snsTopicName = snsTopicArn.substring(snsTopicArn.lastIndexOf(':') + 1);
```

`PublishBatchRequest` builds fine without a topic ARN, and the interceptor runs before marshalling, so a request that AWS would have rejected with a validation error instead fails with an NPE thrown from the agent. Neither SDK wraps exceptions from `modifyRequest`/`beforeMarshalling`, so it surfaces to the caller as-is.

Without the change, the new test fails like this:

```
Expected exception of type 'software.amazon.awssdk.core.exception.SdkException',
but got 'java.lang.NullPointerException'
Caused by: java.lang.NullPointerException: Cannot invoke "String.lastIndexOf(int)"
  because "snsTopicArn" is null
	at datadog.trace.instrumentation.aws.v2.sns.SnsInterceptor.modifyRequest
```

Both the v1 and v2 interceptors have it, so both are fixed the same way the single-publish path already does: skip the injection and leave the request alone.

I checked the other ARN parsing in the aws-java modules while I was here. `AwsSdkClientDecorator` guards it in v1 (`if (null != topicArn)`) and uses `Optional.map` in v2, so the two batch branches were the only unguarded ones.

Tests mirror the existing `SNS message to phone number doesn't leak exception` case. `aws-java-sns-1.0` and `aws-java-sns-2.0` test tasks pass, `spotlessApply` is clean.

Could a maintainer add `inst: aws` and `type: bug`? I can't set labels on this repo.
