### PR TITLE
Use ObjectStore to track context bound to arbitrary objects

### DIFF
--- a/components/context/build.gradle.kts
+++ b/components/context/build.gradle.kts
@@ -2,6 +2,10 @@ plugins {
   id("dd-trace-java.module.platform-component")
 }
 
+dependencies {
+  implementation(libs.instrument.java)
+}
+
 extra["excludedClassesInstructionCoverage"] =
   listOf("datadog.context.ContextProviders") // covered by forked test
 

--- a/components/context/src/main/java/datadog/context/ContextProviders.java
+++ b/components/context/src/main/java/datadog/context/ContextProviders.java
@@ -17,7 +17,7 @@ final class ContextProviders {
     static final ContextBinder INSTANCE =
         null != ContextProviders.customBinder
             ? ContextProviders.customBinder
-            : WeakMapContextBinder.INSTANCE;
+            : ObjectStoreContextBinder.INSTANCE;
   }
 
   static ContextManager manager() {

--- a/components/context/src/main/java/datadog/context/ObjectStoreContextBinder.java
+++ b/components/context/src/main/java/datadog/context/ObjectStoreContextBinder.java
@@ -1,22 +1,21 @@
 package datadog.context;
 
 import static datadog.context.Context.root;
-import static java.util.Collections.synchronizedMap;
 import static java.util.Objects.requireNonNull;
 
-import java.util.Map;
-import java.util.WeakHashMap;
+import datadog.instrument.fieldinject.ObjectStore;
 
-/** {@link ContextBinder} that uses a global weak map of carriers to contexts. */
-final class WeakMapContextBinder implements ContextBinder {
-  static final ContextBinder INSTANCE = new WeakMapContextBinder();
+/** {@link ContextBinder} that uses {@link ObjectStore} to track context carriers. */
+final class ObjectStoreContextBinder implements ContextBinder {
+  static final ContextBinder INSTANCE = new ObjectStoreContextBinder();
 
-  private static final Map<Object, Context> TRACKED = synchronizedMap(new WeakHashMap<>());
+  private static final ObjectStore<Object, Context> CONTEXT_STORE =
+      ObjectStore.of(Object.class, Context.class);
 
   @Override
   public Context from(Object carrier) {
     requireNonNull(carrier, "Context carrier cannot be null");
-    Context bound = TRACKED.get(carrier);
+    Context bound = CONTEXT_STORE.get(carrier);
     return null != bound ? bound : root();
   }
 
@@ -24,13 +23,13 @@ final class WeakMapContextBinder implements ContextBinder {
   public void attachTo(Object carrier, Context context) {
     requireNonNull(carrier, "Context carrier cannot be null");
     requireNonNull(context, "Context cannot be null. Use detachFrom() instead.");
-    TRACKED.put(carrier, context);
+    CONTEXT_STORE.put(carrier, context);
   }
 
   @Override
   public Context detachFrom(Object carrier) {
     requireNonNull(carrier, "Context key cannot be null");
-    Context previous = TRACKED.remove(carrier);
+    Context previous = CONTEXT_STORE.remove(carrier);
     return null != previous ? previous : root();
   }
 }

--- a/components/context/src/main/java/datadog/context/TestContextBinder.java
+++ b/components/context/src/main/java/datadog/context/TestContextBinder.java
@@ -31,7 +31,7 @@ final class TestContextBinder implements ContextBinder {
     ContextBinder delegate = ContextProviders.customBinder;
     if (delegate == TEST_INSTANCE) {
       // fall back to default context binder
-      return WeakMapContextBinder.INSTANCE;
+      return ObjectStoreContextBinder.INSTANCE;
     } else {
       return delegate;
     }


### PR DESCRIPTION
# Motivation

Replaces the placeholder synchronized WeakHashMap approach with `ObjectStore` from [dd-instrument-java](https://github.com/DataDog/dd-instrument-java):
```
┌───────────────────────────────────────────┬─────────────────────┬────────────────┬──────────┐
│                 Benchmark                 │     binderType      │ Score (ops/us) │  Error   │
├───────────────────────────────────────────┼─────────────────────┼────────────────┼──────────┤
│ handleRequest (attach + 2× read + detach) │ ObjectStore         │ 11.286         │ ± 1.148  │
├───────────────────────────────────────────┼─────────────────────┼────────────────┼──────────┤
│ handleRequest                             │ SynchronizedWeakMap │ 5.479          │ ± 0.642  │
├───────────────────────────────────────────┼─────────────────────┼────────────────┼──────────┤
│ readActiveRequest (read-only hot path)    │ ObjectStore         │ 1267.846       │ ± 17.647 │
├───────────────────────────────────────────┼─────────────────────┼────────────────┼──────────┤
│ readActiveRequest                         │ SynchronizedWeakMap │ 34.782         │ ± 1.208  │
└───────────────────────────────────────────┴─────────────────────┴────────────────┴──────────┘
```

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
