### PR TITLE
Prevent duplicate Kotlin coroutine continuation release

### DIFF
--- a/dd-java-agent/instrumentation/kotlin-coroutines-1.3/src/main/java/datadog/trace/instrumentation/kotlin/coroutines/DatadogThreadContextElement.java
+++ b/dd-java-agent/instrumentation/kotlin-coroutines-1.3/src/main/java/datadog/trace/instrumentation/kotlin/coroutines/DatadogThreadContextElement.java
@@ -2,6 +2,7 @@ package datadog.trace.instrumentation.kotlin.coroutines;
 
 import datadog.context.Context;
 import datadog.context.ContextContinuation;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import kotlin.coroutines.CoroutineContext;
@@ -11,6 +12,11 @@ import kotlinx.coroutines.ThreadContextElement;
 
 /** Manages the Datadog context for coroutines, switching contexts as coroutines switch threads. */
 public final class DatadogThreadContextElement implements ThreadContextElement<Context> {
+  private static final AtomicReferenceFieldUpdater<DatadogThreadContextElement, ContextContinuation>
+      CONTINUATION =
+          AtomicReferenceFieldUpdater.newUpdater(
+              DatadogThreadContextElement.class, ContextContinuation.class, "continuation");
+
   private static final CoroutineContext.Key<DatadogThreadContextElement> DATADOG_KEY =
       new CoroutineContext.Key<DatadogThreadContextElement>() {};
 
@@ -22,7 +28,7 @@ public final class DatadogThreadContextElement implements ThreadContextElement<C
   }
 
   private Context context;
-  private ContextContinuation continuation;
+  private volatile ContextContinuation continuation;
 
   @Nonnull
   @Override
@@ -42,9 +48,11 @@ public final class DatadogThreadContextElement implements ThreadContextElement<C
 
   public static void cancelDatadogContext(@Nonnull AbstractCoroutine<?> coroutine) {
     DatadogThreadContextElement datadog = coroutine.getContext().get(DATADOG_KEY);
-    if (datadog != null && datadog.continuation != null) {
+    ContextContinuation continuation =
+        datadog == null ? null : CONTINUATION.getAndSet(datadog, null);
+    if (continuation != null) {
       // release enclosing trace now the coroutine has completed
-      datadog.continuation.release();
+      continuation.release();
     }
   }
 


### PR DESCRIPTION
# What Does This Do

 Makes Kotlin coroutine continuation cleanup one-shot.

  Kotlin may invoke `AbstractCoroutine.onCompletionInternal` more than once for the same coroutine, sometimes from different dispatcher threads. Each invocation previously released the same Datadog continuation, violating its one-shot lifecycle.

  The continuation is now atomically taken and cleared. The first completion releases it; later completions safely do nothing.

  ```mermaid
  flowchart LR
    A[Continuation captured] --> B{Coroutine completion}

    B -->|First worker| C[Atomically take and clear]
    C -->|Continuation found| D[Release once]

    B -->|Later worker| E[Atomically take and clear]
    E -->|Already cleared| F[No-op]

    B -. Previous behavior .-> G[Release same continuation again]
    G -.-> H[Double finish]
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
