### PR TITLE
Prevent OkHttp TaskRunner from retaining request contexts

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExcludeFilter.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/bootstrap/instrumentation/java/concurrent/ExcludeFilter.java
@@ -99,6 +99,8 @@ public class ExcludeFilter {
     SKIP_TYPE_PREFIXES
         .get(ExcludeType.EXECUTOR)
         .add("io.netty.util.concurrent.SingleThreadEventExecutor.");
+    // OkHttp's TaskRunner Runnable is a long-lived worker loop, not a single submitted task.
+    SKIP_TYPE_PREFIXES.get(ExcludeType.RUNNABLE).add("okhttp3.internal.concurrent.TaskRunner$");
     // Don't wrap Runnables belonging to NioEventLoop(s) as they want to propagate CloseException
     // outside of the event loop on close() and wrapping them in FutureTask interferes with that
     SKIP_TYPE_PREFIXES.get(ExcludeType.RUNNABLE).add("com.aerospike.client.async.NioEventLoop");

--- a/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/ExcludeFilterTest.groovy
+++ b/dd-java-agent/agent-bootstrap/src/test/groovy/datadog/trace/bootstrap/ExcludeFilterTest.groovy
@@ -46,6 +46,12 @@ class ExcludeFilterTest extends DDSpecification {
     type << ExcludeFilter.ExcludeType.values()
   }
 
+  def "exclude OkHttp TaskRunner worker from Runnable propagation"() {
+    expect:
+    ExcludeFilter.exclude(RUNNABLE, 'okhttp3.internal.concurrent.TaskRunner$runnable$1')
+    !ExcludeFilter.exclude(EXECUTOR, 'okhttp3.internal.concurrent.TaskRunner$runnable$1')
+  }
+
   static class One {}
 
   static class Another {}


### PR DESCRIPTION
# What does this PR do?

Excludes OkHttp's internal `TaskRunner` worker loop from generic `Runnable` context propagation.

`TaskRunner$runnable$1` is a long-lived scheduler loop, not a single request task. Capturing the submitting request context on it keeps that trace open until the runner becomes idle, causing delayed or missing traces.

Individual OkHttp tasks already handle their own request context, so the scheduler itself should not inherit one.

```mermaid
flowchart LR
    A[Test worker<br/>okhttp.request active]
    B[OkHttp TaskRunner<br/>long-lived scheduler]
    C[Individual HTTP task]
    D[Request completes]

    A -->|🔴 previous: capture context| B
    B -->|scope retained until idle| R[🔴 Scope left open]

    A -->|🟢 request handoff| C
    C --> D
    D -->|close request scope| G[🟢 Trace is written]

    A -. TaskRunner excluded .-> B
```

# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
