### PR TITLE
Prevent Pekko stream lifecycle context retention

### DIFF
--- a/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
+++ b/dd-java-agent/instrumentation/java/java-concurrent/java-concurrent-1.8/src/main/java/datadog/trace/instrumentation/java/concurrent/AsyncPropagatingDisableInstrumentation.java
@@ -64,6 +64,8 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
       extendsClass(named("java.net.http.HttpClient"));
   private static final String LETTUCE_HANDSHAKE_HANDLER =
       "io.lettuce.core.protocol.RedisHandshakeHandler";
+  private static final String PEKKO_HTTP_STREAM_STAGE =
+      "org.apache.pekko.http.impl.util.StreamUtils$$anon$4$$anon$5";
 
   @Override
   public boolean onlyMatchKnownTypes() {
@@ -101,6 +103,7 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
       "io.reactivex.rxjava3.internal.schedulers.AbstractDirectTask",
       "jdk.internal.net.http.HttpClientImpl",
       LETTUCE_HANDSHAKE_HANDLER,
+      PEKKO_HTTP_STREAM_STAGE,
       "io.netty.util.concurrent.GlobalEventExecutor",
       "io.grpc.netty.shaded.io.netty.util.concurrent.GlobalEventExecutor",
       "com.linecorp.armeria.client.HttpClientFactory",
@@ -213,6 +216,8 @@ public final class AsyncPropagatingDisableInstrumentation extends InstrumenterMo
     transformer.applyAdvice(namedOneOf("sendAsync").and(isDeclaredBy(JAVA_HTTP_CLIENT)), advice);
     transformer.applyAdvice(
         named("channelRegistered").and(isDeclaredBy(named(LETTUCE_HANDSHAKE_HANDLER))), advice);
+    transformer.applyAdvice(
+        named("preStart").and(isDeclaredBy(named(PEKKO_HTTP_STREAM_STAGE))), advice);
     // armeria runs its own codec/pipeline, so the active request span captured during connection
     // pool creation and channel connect will have no consumers.
     transformer.applyAdvice(


### PR DESCRIPTION
# What Does This Do
  
Pekko HTTP registers a shutdown callback from StreamUtils.preStart(). When this happens during a request, Scala’s callback instrumentation captures the active context and retains it until the stream shuts down.

  This change temporarily disables async propagation only while that callback is registered. It uses the existing context-tracking instrumentation, without creating a no-op span or affecting the active request
  context.
```mermaid
  flowchart LR
      A[Active request context] --> B[StreamUtils.preStart]
      B -->|async propagation disabled| C[Register shutdown callback]
      C --> D[Restore async propagation]
      A -. not captured .-> C
```

  ## Why?

  The shutdown callback belongs to the stream lifecycle, not to the request that happened to initialize it. Propagating the request context there creates a continuation that can remain unresolved until server
  shutdown.

  The matcher is limited to the exact Pekko stream-stage type and its preStart() method.

  ## Akka

  Akka has similar code, but its equivalent IAST scenario does not retain a continuation. Tests passed with Akka HTTP 10.1, 10.2, and the latest supported dependencies, so no speculative Akka suppression was added.
# Motivation

# Additional Notes

# Contributor Checklist

- Format the title according to [the contribution guidelines](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#title-format)
- Assign the `type:` and (`comp:` or `inst:`) labels in addition to [any other useful labels](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#labels)
- Avoid using `close`, `fix`, or [any linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue  
  Use `solves` instead, and assign the PR [milestone](https://github.com/DataDog/dd-trace-java/milestones) to the issue
- Update the [CODEOWNERS](https://github.com/DataDog/dd-trace-java/blob/master/.github/CODEOWNERS) file on source file addition, migration, or deletion
- Update [public documentation](https://docs.datadoghq.com/tracing/trace_collection/library_config/java/) with any new configuration flags or behaviors
- Once approved, [use merge queue](https://github.com/DataDog/dd-trace-java/blob/master/CONTRIBUTING.md#merge-queue) to merge the PR

Jira ticket: [PROJ-IDENT]

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.

# Linking a JIRA ticket:
Please link your JIRA ticket by adding its identifier between brackets (ex [PROJ-IDENT]) in the PR description, not the title.
This requirement only applies to Datadog employees.
-->
