### PR TITLE
Add @ForegroundSafe / @BackgroundOnly marker annotations (AI perf review)

### DIFF
--- a/internal-api/src/main/java/datadog/trace/api/function/BackgroundOnly.java
+++ b/internal-api/src/main/java/datadog/trace/api/function/BackgroundOnly.java
@@ -1,0 +1,33 @@
+package datadog.trace.api.function;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks code that must be confined to a background thread the tracer owns and paces itself -- e.g.
+ * serialization, stats aggregation, or eviction -- and must never be reached from an application
+ * thread (the foreground; see {@link ForegroundSafe}), where its cost would become customer-visible
+ * latency instead.
+ *
+ * <p>This is a documentation-and-tooling marker; it changes no behavior. It exists to telegraph the
+ * constraint to readers and to give a future checker (see {@code APMLP-1645}) something to verify
+ * -- that no {@code @BackgroundOnly} code is reachable from a foreground call site. The discipline
+ * it names is <b>not yet enforced</b>; hold to it by hand until the checker lands.
+ *
+ * <p>The two markers are <b>not symmetric</b> -- see {@link ForegroundSafe} for why it, not this
+ * one, is the strictly stronger guarantee.
+ *
+ * <p><b>On a type</b> ({@link ElementType#TYPE}): every method of this type is background-only
+ * unless a method-level {@link ForegroundSafe} widens it.
+ *
+ * <p><b>On a method</b> ({@link ElementType#METHOD}): this method specifically is background-only,
+ * regardless of what the enclosing type declares -- a method-level marker always wins over the
+ * type-level one.
+ */
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface BackgroundOnly {}

--- a/internal-api/src/main/java/datadog/trace/api/function/ForegroundSafe.java
+++ b/internal-api/src/main/java/datadog/trace/api/function/ForegroundSafe.java
@@ -1,0 +1,36 @@
+package datadog.trace.api.function;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks code cheap enough to call from an application thread (the foreground) -- the request or
+ * transaction thread the instrumented application itself is running, where any added cost is
+ * customer-visible latency, as opposed to a background thread the tracer owns and paces itself (see
+ * {@link BackgroundOnly}).
+ *
+ * <p>This is a documentation-and-tooling marker; it changes no behavior. It exists to telegraph the
+ * guarantee to readers and to give a future checker (see {@code APMLP-1645}) something to verify --
+ * that no {@link BackgroundOnly} code is reachable from a foreground call site. The discipline it
+ * names is <b>not yet enforced</b>; hold to it by hand until the checker lands.
+ *
+ * <p>The two markers are <b>not symmetric</b>. {@code @ForegroundSafe} is the strictly stronger
+ * guarantee: code cheap enough for the foreground is automatically fine to call from a background
+ * thread too, so a {@code @ForegroundSafe} type or method may be called from either. {@link
+ * BackgroundOnly} code carries no such guarantee and must never be reached from a foreground call
+ * site.
+ *
+ * <p><b>On a type</b> ({@link ElementType#TYPE}): every method of this type is foreground-safe
+ * unless a method-level {@link BackgroundOnly} narrows it.
+ *
+ * <p><b>On a method</b> ({@link ElementType#METHOD}): this method specifically is foreground-safe,
+ * regardless of what the enclosing type declares -- a method-level marker always wins over the
+ * type-level one.
+ */
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface ForegroundSafe {}


### PR DESCRIPTION
# What Does This Do

- Adds two documentation-and-tooling marker annotations, `@ForegroundSafe` and `@BackgroundOnly` (`datadog.trace.api.function`), that declare whether code is cheap enough to run on application (foreground) threads or must be confined to a background thread.
- `@ForegroundSafe` is the strictly stronger guarantee — safe from either thread context; `@BackgroundOnly` must never be reached from a foreground call site.
- Both apply to types and methods, with method-level taking precedence over type-level.
- Pure declaration: `SOURCE` retention, no runtime behavior change. No annotation of real call sites and no checker yet — those are tracked separately (APMLP-1544, APMLP-1546).

# Motivation

Implements APMLP-1543, laying groundwork for annotation-checking support in the `/perf-review` skill (APMLP-1513).

# Additional Notes

- `techdebt` review: no issues (pure marker annotations, no duplication/dead code).
- `perf-review` review: no findings (SOURCE-retention, zero runtime footprint).
- `./gradlew spotlessCheck` / `:internal-api:spotbugsMain` still pending.

# Contributor Checklist

- [x] Format the title according to the contribution guidelines
- [ ] Assign the `type:` and (`comp:` or `inst:`) labels in addition to any other useful labels
- [x] Avoid using `close`, `fix`, or any linking keywords when referencing an issue
- [ ] Update the CODEOWNERS file on source file addition, migration, or deletion (n/a — no new module/ownership boundary)
- [ ] Update public documentation with any new configuration flags or behaviors (n/a — internal-only marker annotations)
- [ ] Once approved, use merge queue to merge the PR

Jira ticket: [APMLP-1543]

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[APMLP-1543]: https://datadoghq.atlassian.net/browse/APMLP-1543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ